### PR TITLE
Unified N-source SelectBuilder + auto-alias joins + subqueries

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Skunk gives you correct encoders/decoders and the `sql""` macro, but queries sti
 
 ## Modules
 
-- `skunk-sharp-core` — the DSL, table/view descriptions, WHERE / ORDER BY / GROUP BY / HAVING / LIMIT / OFFSET, SELECT / INSERT / UPDATE / DELETE, two-table INNER/LEFT JOINs, row locking, `ON CONFLICT`, `RETURNING`, aggregates, and the schema validator.
+- `skunk-sharp-core` — the DSL: table/view descriptions, WHERE / ORDER BY / GROUP BY / HAVING / LIMIT / OFFSET, SELECT / INSERT / UPDATE / DELETE, N-way INNER / LEFT / CROSS JOINs with auto-alias, row locking, `ON CONFLICT`, `RETURNING`, aggregates, subqueries (scalar / `IN` / `EXISTS`, correlated or uncorrelated), and the schema validator.
 - `skunk-sharp-iron` — optional [Iron](https://iltotore.github.io/iron/) refinement support (e.g. `String :| MaxLength[256]` maps to `varchar(256)`).
 
 ## Quick tour
@@ -109,18 +109,53 @@ users.delete.where(u => u.id === id).returningAll.compile.unique(session)
 
 ### JOINs
 
+Auto-alias — the alias defaults to the table's name, so `.alias("u")` is optional:
+
 ```scala
-users.alias("u")
-  .innerJoin(posts.alias("p")).on(r => r.u.id ==== r.p.user_id)
-  .select(r => (r.u.email, r.p.title))
-  .where(r => r.p.created_at > cutoff)
+users
+  .innerJoin(posts).on(r => r.users.id ==== r.posts.user_id)
+  .select(r => (r.users.email, r.posts.title))
+  .where(r => r.posts.created_at > cutoff)
   .compile.run(session)
 
 // LEFT JOIN flips right-side nullability at the type level.
+users
+  .leftJoin(posts).on(r => r.users.id ==== r.posts.user_id)
+  .select(r => (r.users.email, Pg.count(r.posts.id).as("n")))
+  .groupBy(r => r.users.email)
+  .compile.run(session)
+
+// CROSS JOIN — no `.on(...)` required. Same for chaining N sources.
+users.crossJoin(posts).select(r => (r.users.email, r.posts.title)).compile.run(session)
+
+// Chained after a single-source WHERE, and 3+ source joins:
+users.select.where(u => u.age >= 18)
+  .innerJoin(posts).on(r => r.users.id ==== r.posts.user_id)
+  .leftJoin(tags).on(r => r.posts.id ==== r.tags.post_id)
+  .select(r => (r.users.email, r.posts.title, r.tags.name))
+  .compile.run(session)
+
+// Explicit aliases still work when the same table appears twice.
+users.alias("u1").innerJoin(users.alias("u2")).on(r => r.u1.id ==== r.u2.id)
+```
+
+### Subqueries
+
+`TypedExpr`-unified: scalar subqueries, `IN`, and `EXISTS` all take a builder — no inner `.compile` needed, correlation is automatic through lexical scope.
+
+```scala
+// Scalar subquery in projection (correlated — inner WHERE closes over outer `u.id`)
+users.alias("u").select(u =>
+  (u.email, posts.select(_ => Pg.countAll).where(p => p.user_id ==== u.id).asExpr)
+).compile.run(session)
+
+// IN subquery
+users.select.where(u => u.id.in(posts.select(p => p.user_id))).compile.run(session)
+
+// EXISTS — `Pg.exists` returns a TypedExpr[Boolean] usable directly in WHERE
 users.alias("u")
-  .leftJoin(posts.alias("p")).on(r => r.u.id ==== r.p.user_id)
-  .select(r => (r.u.email, Pg.count(r.p.id).as("n")))
-  .groupBy(r => r.u.email)
+  .select(u => u.email)
+  .where(u => u.age >= 18 && Pg.exists(posts.select(_ => lit(1)).where(p => p.user_id ==== u.id)))
   .compile.run(session)
 ```
 
@@ -182,11 +217,12 @@ Planned companion modules: `skunk-sharp-json` (based on skunk-circe, for `json`/
 
 See [CLAUDE.md](CLAUDE.md) for the design notes.
 
-- Implicit join aliases defaulting to the table name (requires singleton `Name` on `Table`/`View`).
-- Unified N-source SELECT (more than two tables in one JOIN chain).
-- Subqueries (scalar + `IN` / `EXISTS`) and window functions (`OVER (…)`).
+- Window functions (`OVER (…)`).
+- CTEs (`WITH …`).
+- `UNION` / `INTERSECT` / `EXCEPT`.
+- `FULL` / `RIGHT JOIN` (trivial additions to the existing join kinds).
 - Compile-time `GROUP BY` coverage check.
-- Companion modules for JSON, ltree, arrays, full-text search.
+- Companion modules for JSON (`skunk-sharp-json`, based on skunk-circe), ltree, arrays, full-text search, and PostGIS.
 - Move more of the SQL assembly into macros so only user-supplied parameters flow at runtime.
 - Laika + mdoc docs site.
 

--- a/modules/core/src/main/scala/skunk/sharp/PgFunction.scala
+++ b/modules/core/src/main/scala/skunk/sharp/PgFunction.scala
@@ -169,6 +169,23 @@ object Pg {
   def boolOr(expr: TypedExpr[Boolean]): TypedExpr[Boolean] =
     TypedExpr(TypedExpr.raw("bool_or(") |+| expr.render |+| TypedExpr.raw(")"), skunk.codec.all.bool)
 
+  // -------- Subquery predicates --------
+
+  /**
+   * `EXISTS (<subquery>)`. The subquery's row type doesn't matter — only existence does. Accepts any
+   * [[skunk.sharp.dsl.AsSubquery]]-compatible value (compiled or un-compiled builder).
+   */
+  def exists[Q, T](sub: Q)(using ev: skunk.sharp.dsl.AsSubquery[Q, T]): TypedExpr[Boolean] = {
+    val cq = ev.toCompiled(sub)
+    TypedExpr(TypedExpr.raw("EXISTS (") |+| cq.af |+| TypedExpr.raw(")"), skunk.codec.all.bool)
+  }
+
+  /** `NOT EXISTS (<subquery>)`. */
+  def notExists[Q, T](sub: Q)(using ev: skunk.sharp.dsl.AsSubquery[Q, T]): TypedExpr[Boolean] = {
+    val cq = ev.toCompiled(sub)
+    TypedExpr(TypedExpr.raw("NOT EXISTS (") |+| cq.af |+| TypedExpr.raw(")"), skunk.codec.all.bool)
+  }
+
 }
 
 /**

--- a/modules/core/src/main/scala/skunk/sharp/Table.scala
+++ b/modules/core/src/main/scala/skunk/sharp/Table.scala
@@ -100,6 +100,7 @@ object Table {
 
   /** Continuation for [[of]]. Kept public because the builder / test code refers to it by path. */
   final class OfCont[T <: Product] {
+
     inline def apply[Name <: String & Singleton](tableName: Name)(using
       m: Mirror.ProductOf[T]
     ): Table[ColumnsFromMirror[m.MirroredElemLabels, m.MirroredElemTypes], Name] = {
@@ -110,6 +111,7 @@ object Table {
         cols.asInstanceOf[ColumnsFromMirror[m.MirroredElemLabels, m.MirroredElemTypes]]
       )
     }
+
   }
 
   /** Type-level: flip the `Default` phantom on the column named `N`. */

--- a/modules/core/src/main/scala/skunk/sharp/View.scala
+++ b/modules/core/src/main/scala/skunk/sharp/View.scala
@@ -57,6 +57,7 @@ object View {
   inline def of[T <: Product]: OfCont[T] = new OfCont[T]
 
   final class OfCont[T <: Product] {
+
     inline def apply[Name <: String & Singleton](viewName: Name)(using
       m: Mirror.ProductOf[T]
     ): View[ColumnsFromMirror[m.MirroredElemLabels, m.MirroredElemTypes], Name] = {
@@ -67,6 +68,7 @@ object View {
         cols.asInstanceOf[ColumnsFromMirror[m.MirroredElemLabels, m.MirroredElemTypes]]
       )
     }
+
   }
 
 }

--- a/modules/core/src/main/scala/skunk/sharp/dsl/Compiled.scala
+++ b/modules/core/src/main/scala/skunk/sharp/dsl/Compiled.scala
@@ -60,3 +60,56 @@ extension (c: CompiledCommand) {
     session.execute(c.af.fragment.command)(c.af.argument)
 
 }
+
+/**
+ * Subquery support — typeclass-based. A subquery is anything that can be turned into a [[CompiledQuery]]`[T]`:
+ *
+ *   - a fully `.compile`d query (identity instance),
+ *   - a [[ProjectedSelect]]`[Ss, T]` with an explicit projection (compiled on demand),
+ *   - a [[SelectBuilder]]`[Ss]` anchored at a single source whose whole-row is `T` (compiled on demand).
+ *
+ * This way users don't have to call `.compile` on inner queries — they pass the builder directly to `.asExpr`,
+ * `col.in(...)`, or `Pg.exists(...)` and the outer compilation handles the inner too.
+ *
+ * Correlated subqueries: build the inner query inside an outer `.select` / `.where` lambda; outer
+ * [[skunk.sharp.TypedColumn]]s are in lexical scope, their `render` emits alias-qualified SQL
+ * (`"u"."id"`) that correlates at SQL-evaluation time.
+ */
+sealed trait AsSubquery[Q, T] {
+  def toCompiled(q: Q): CompiledQuery[T]
+}
+
+object AsSubquery {
+
+  given identity[T]: AsSubquery[CompiledQuery[T], T] = new AsSubquery[CompiledQuery[T], T] {
+    def toCompiled(q: CompiledQuery[T]): CompiledQuery[T] = q
+  }
+
+  given fromProjected[Ss <: Tuple, T]: AsSubquery[ProjectedSelect[Ss, T], T] =
+    new AsSubquery[ProjectedSelect[Ss, T], T] {
+      def toCompiled(q: ProjectedSelect[Ss, T]): CompiledQuery[T] = q.compile
+    }
+
+  /** Whole-row SelectBuilder → subquery of NamedRow. Relies on the same IsSingleSource evidence `.compile` uses. */
+  given fromSelectBuilder[Ss <: Tuple, C <: Tuple](using
+    ev: IsSingleSource.Aux[Ss, C]
+  ): AsSubquery[SelectBuilder[Ss], skunk.sharp.NamedRowOf[C]] =
+    new AsSubquery[SelectBuilder[Ss], skunk.sharp.NamedRowOf[C]] {
+      def toCompiled(b: SelectBuilder[Ss]): CompiledQuery[skunk.sharp.NamedRowOf[C]] = b.compile(using ev)
+    }
+
+}
+
+/**
+ * Lift a subquery-like thing into the [[skunk.sharp.TypedExpr]] vocabulary so it slots in wherever an expression is
+ * expected — SELECT projection, WHERE RHS, UPDATE SET, `col.in(q)`, `Pg.exists(q)`, etc.
+ */
+extension [Q](q: Q) {
+  def asExpr[T](using ev: AsSubquery[Q, T]): skunk.sharp.TypedExpr[T] = {
+    val cq = ev.toCompiled(q)
+    skunk.sharp.TypedExpr(
+      skunk.sharp.TypedExpr.raw("(") |+| cq.af |+| skunk.sharp.TypedExpr.raw(")"),
+      cq.codec
+    )
+  }
+}

--- a/modules/core/src/main/scala/skunk/sharp/dsl/Compiled.scala
+++ b/modules/core/src/main/scala/skunk/sharp/dsl/Compiled.scala
@@ -72,8 +72,8 @@ extension (c: CompiledCommand) {
  * `col.in(...)`, or `Pg.exists(...)` and the outer compilation handles the inner too.
  *
  * Correlated subqueries: build the inner query inside an outer `.select` / `.where` lambda; outer
- * [[skunk.sharp.TypedColumn]]s are in lexical scope, their `render` emits alias-qualified SQL
- * (`"u"."id"`) that correlates at SQL-evaluation time.
+ * [[skunk.sharp.TypedColumn]]s are in lexical scope, their `render` emits alias-qualified SQL (`"u"."id"`) that
+ * correlates at SQL-evaluation time.
  */
 sealed trait AsSubquery[Q, T] {
   def toCompiled(q: Q): CompiledQuery[T]
@@ -105,6 +105,7 @@ object AsSubquery {
  * expected — SELECT projection, WHERE RHS, UPDATE SET, `col.in(q)`, `Pg.exists(q)`, etc.
  */
 extension [Q](q: Q) {
+
   def asExpr[T](using ev: AsSubquery[Q, T]): skunk.sharp.TypedExpr[T] = {
     val cq = ev.toCompiled(q)
     skunk.sharp.TypedExpr(
@@ -112,4 +113,5 @@ extension [Q](q: Q) {
       cq.codec
     )
   }
+
 }

--- a/modules/core/src/main/scala/skunk/sharp/dsl/Delete.scala
+++ b/modules/core/src/main/scala/skunk/sharp/dsl/Delete.scala
@@ -3,7 +3,7 @@ package skunk.sharp.dsl
 import skunk.{AppliedFragment, Codec}
 import skunk.sharp.*
 import skunk.sharp.internal.tupleCodec
-import skunk.sharp.where.{Where, &&}
+import skunk.sharp.where.{&&, Where}
 
 /**
  * DELETE builder — compile-time staged so you can't accidentally run a `DELETE FROM …` with no WHERE.

--- a/modules/core/src/main/scala/skunk/sharp/dsl/Delete.scala
+++ b/modules/core/src/main/scala/skunk/sharp/dsl/Delete.scala
@@ -3,7 +3,7 @@ package skunk.sharp.dsl
 import skunk.{AppliedFragment, Codec}
 import skunk.sharp.*
 import skunk.sharp.internal.tupleCodec
-import skunk.sharp.where.Where
+import skunk.sharp.where.{Where, &&}
 
 /**
  * DELETE builder — compile-time staged so you can't accidentally run a `DELETE FROM …` with no WHERE.

--- a/modules/core/src/main/scala/skunk/sharp/dsl/Join.scala
+++ b/modules/core/src/main/scala/skunk/sharp/dsl/Join.scala
@@ -8,31 +8,28 @@ import skunk.sharp.where.Where
 import scala.NamedTuple
 
 /**
- * Two-table SQL joins (v1). Kept as a sibling of [[SelectBuilder]] while the unified "one builder for 1..N sources"
- * story is being designed. All join-specific methods are shaped identically to the single-source builder (`.where`,
- * `.orderBy`, `.limit`, `.offset`, `.select`) so users see one API surface.
+ * N-table SQL joins. `.innerJoin` / `.leftJoin` / `.crossJoin` chain off any relation (or
+ * [[AliasedRelation]]); each join appends a [[SourceEntry]] to a `Sources <: Tuple` carried at the type level.
+ * The lambda passed to `.where` / `.select` / `.orderBy` / `.groupBy` / `.having` receives a `JoinedView[Sources]` —
+ * a Scala 3 named tuple keyed by alias — so columns are reached as `r.<alias>.<column>`.
  *
  * {{{
- *   users.alias("u").innerJoin(posts.alias("p")).on(r => r.u.id ==== r.p.user_id)
- *     .select(r => (mail = r.u.email, title = r.p.title))
- *     .where(r => r.p.published === true)
- *     .orderBy(r => r.p.created_at.desc)
+ *   users
+ *     .innerJoin(posts).on(r => r.users.id ==== r.posts.user_id)
+ *     .leftJoin(tags).on(r => r.posts.id ==== r.tags.post_id)
+ *     .select(r => (r.users.email, r.posts.title, r.tags.name))
+ *     .where(r => r.users.age >= 18)
  *     .compile
  * }}}
  *
- *   - `.alias("u")` wraps any [[Relation]] in an [[AliasedRelation]] carrying the alias at the type level.
- *   - `.innerJoin` / `.leftJoin` on an aliased relation take another aliased relation and return [[IncompleteJoin2]]
- *     (must call `.on(…)` before you can execute or project — compile error otherwise).
- *   - `.on(r => pred)` finalises the join predicate, returning [[Join2]] which exposes `.where`, `.orderBy`, `.limit`,
- *     `.offset`, and `.select(f)` / `.apply(f)` for projection.
- *   - The `r` view is a named tuple keyed by alias: `r.<alias>.<column>`.
- *   - `LEFT JOIN` flips the right-hand-side columns' nullability for `.where` / `.select` — value types become
- *     `Option[T]` and codecs get `.opt` at runtime. The `.on` predicate still sees the declared (non-nullable) types
- *     because Postgres evaluates `ON` before padding unmatched rows with `NULL`s.
+ * LEFT JOIN flips the right-side columns' nullability for `.where` / `.select` — value types become `Option[T]` and
+ * codecs get `.opt` at runtime. The `.on` predicate still sees the declared (non-nullable) types, because Postgres
+ * evaluates `ON` before NULL-padding unmatched rows.
  *
- * **Roadmap:** unify into `SelectBuilder[Sources <: Tuple]` so single-table and join cases share one class. Requires a
- * match type that reduces the view to `ColumnsView[Cols]` for 1 source and a named-tuple-of-views for N sources.
+ * `Select.from(a, b, ...)` (alias: `a.crossJoin(b)`) renders as `CROSS JOIN`, no `.on(...)` required.
  */
+
+// ---- AliasedRelation + .alias extension --------------------------------------------------------
 
 /** A relation paired with its SQL alias (`"u"`, `"p"`, `"sub"`, …). Constructed via the `.alias("u")` extension. */
 final class AliasedRelation[R <: Relation[Cols], Cols <: Tuple, Alias <: String & Singleton] private[sharp] (
@@ -51,15 +48,18 @@ extension [R <: Relation[Cols], Cols <: Tuple](r: R) {
 
 }
 
+// ---- JoinKind + NullableCols -------------------------------------------------------------------
+
 /** Kind of join — drives the rendered keyword and whether the right-side cols are nullabilified. */
 enum JoinKind(val sql: String) {
   case Inner extends JoinKind("INNER JOIN")
   case Left  extends JoinKind("LEFT JOIN")
+  case Cross extends JoinKind("CROSS JOIN")
 }
 
 /**
  * Type-level "make every column nullable" — wraps each value type in `Option` and flips the Null phantom to `true`.
- * Used for the RIGHT side of a LEFT JOIN, where all columns may be `NULL` when there's no matching row.
+ * Used for sources attached via LEFT JOIN, where all their columns may be `NULL` when no match is found.
  */
 type NullableCols[Cols <: Tuple] <: Tuple = Cols match {
   case Column[t, n, nu, d] *: tail => Column[Option[t], n, true, d] *: NullableCols[tail]
@@ -88,307 +88,7 @@ private[sharp] def nullabilifyCols(cols: Tuple): Tuple = {
   Tuple.fromArray(wrapped.toArray[Any])
 }
 
-/**
- * Named-tuple view for a two-table join, keyed by alias. Lambdas receive `r` where `r.<leftAlias>` and `r.<rightAlias>`
- * are the per-relation [[ColumnsView]]s.
- */
-type JoinedView2[AL <: String & Singleton, CL <: Tuple, AR <: String & Singleton, CR <: Tuple] =
-  NamedTuple.NamedTuple[(AL, AR), (ColumnsView[CL], ColumnsView[CR])]
-
-/**
- * Incomplete two-table join — the shape after `.innerJoin(other)` / `.leftJoin(other)`, before `.on(predicate)`.
- * Deliberately exposes only `.on` so compiling without a predicate is a compile error.
- */
-final class IncompleteJoin2[
-  RL <: Relation[CL],
-  CL <: Tuple,
-  AL <: String & Singleton,
-  RR <: Relation[CR0],
-  CR0 <: Tuple,
-  AR <: String & Singleton,
-  CR <: Tuple // effective right-side Cols after nullability flipping
-] private[sharp] (
-  left: AliasedRelation[RL, CL, AL],
-  right: AliasedRelation[RR, CR0, AR],
-  rightColsEffective: CR,
-  kind: JoinKind
-) {
-
-  /**
-   * Finalise the join predicate. The view here uses the right relation's **original** columns (non-nullabilified) —
-   * Postgres evaluates `ON` before padding unmatched rows with `NULL`s, so on both sides the declared types apply.
-   * Subsequent `.where` / `.select` clauses see the LEFT-JOIN-nullabilified shape.
-   */
-  def on(f: JoinedView2[AL, CL, AR, CR0] => Where): Join2[RL, CL, AL, RR, CR0, AR, CR] = {
-    val onView = joinedView2[AL, CL, AR, CR0](
-      left.alias,
-      left.relation.columns.asInstanceOf[CL],
-      right.alias,
-      right.relation.columns
-    )
-    val pred = f(onView)
-    new Join2[RL, CL, AL, RR, CR0, AR, CR](left, right, rightColsEffective, kind, pred)
-  }
-
-}
-
-/**
- * Fully-specified two-table join. Supports `.where` / `.orderBy` / `.limit` / `.offset`, and projection via `.apply`.
- */
-final class Join2[
-  RL <: Relation[CL],
-  CL <: Tuple,
-  AL <: String & Singleton,
-  RR <: Relation[CR0],
-  CR0 <: Tuple,
-  AR <: String & Singleton,
-  CR <: Tuple
-] private[sharp] (
-  private[sharp] val left: AliasedRelation[RL, CL, AL],
-  private[sharp] val right: AliasedRelation[RR, CR0, AR],
-  private[sharp] val rightColsEffective: CR,
-  private[sharp] val kind: JoinKind,
-  private[sharp] val onPred: Where,
-  private[sharp] val whereOpt: Option[Where] = None,
-  private[sharp] val orderBys: List[OrderBy] = Nil,
-  private[sharp] val limitOpt: Option[Int] = None,
-  private[sharp] val offsetOpt: Option[Int] = None
-) {
-
-  private def copy(
-    whereOpt: Option[Where] = whereOpt,
-    orderBys: List[OrderBy] = orderBys,
-    limitOpt: Option[Int] = limitOpt,
-    offsetOpt: Option[Int] = offsetOpt
-  ): Join2[RL, CL, AL, RR, CR0, AR, CR] =
-    new Join2[RL, CL, AL, RR, CR0, AR, CR](
-      left,
-      right,
-      rightColsEffective,
-      kind,
-      onPred,
-      whereOpt,
-      orderBys,
-      limitOpt,
-      offsetOpt
-    )
-
-  private def view: JoinedView2[AL, CL, AR, CR] =
-    joinedView2[AL, CL, AR, CR](
-      left.alias,
-      left.relation.columns.asInstanceOf[CL],
-      right.alias,
-      rightColsEffective
-    )
-
-  def where(f: JoinedView2[AL, CL, AR, CR] => Where): Join2[RL, CL, AL, RR, CR0, AR, CR] = {
-    val next = whereOpt match {
-      case Some(existing) => existing && f(view)
-      case None           => f(view)
-    }
-    copy(whereOpt = Some(next))
-  }
-
-  def orderBy(f: JoinedView2[AL, CL, AR, CR] => OrderBy | Tuple): Join2[RL, CL, AL, RR, CR0, AR, CR] = {
-    val fresh = f(view) match {
-      case ob: OrderBy => List(ob)
-      case t: Tuple    => t.toList.asInstanceOf[List[OrderBy]]
-    }
-    copy(orderBys = orderBys ++ fresh)
-  }
-
-  def limit(n: Int): Join2[RL, CL, AL, RR, CR0, AR, CR]  = copy(limitOpt = Some(n))
-  def offset(n: Int): Join2[RL, CL, AL, RR, CR0, AR, CR] = copy(offsetOpt = Some(n))
-
-  /**
-   * Projection — pick the columns / expressions to return. Same shape as [[SelectBuilder.apply]] on a single relation:
-   * single `TypedExpr[T]` → row is `T`; tuple → row is the tuple of output types.
-   */
-  transparent inline def select[X](inline f: JoinedView2[AL, CL, AR, CR] => X)
-    : ProjectedJoin2[RL, CL, AL, RR, CR0, AR, CR, ProjResult[X]] = {
-    val v = view
-    f(v) match {
-      case expr: TypedExpr[?] =>
-        new ProjectedJoin2[RL, CL, AL, RR, CR0, AR, CR, ProjResult[X]](
-          left,
-          right,
-          rightColsEffective,
-          kind,
-          onPred,
-          whereOpt,
-          groupBys = Nil,
-          havingOpt = None,
-          orderBys,
-          limitOpt,
-          offsetOpt,
-          List(expr),
-          expr.codec.asInstanceOf[Codec[ProjResult[X]]]
-        )
-      case tup: NonEmptyTuple =>
-        val exprs = tup.toList.asInstanceOf[List[TypedExpr[?]]]
-        val codec = tupleCodec(exprs.map(_.codec)).asInstanceOf[Codec[ProjResult[X]]]
-        new ProjectedJoin2[RL, CL, AL, RR, CR0, AR, CR, ProjResult[X]](
-          left,
-          right,
-          rightColsEffective,
-          kind,
-          onPred,
-          whereOpt,
-          groupBys = Nil,
-          havingOpt = None,
-          orderBys,
-          limitOpt,
-          offsetOpt,
-          exprs,
-          codec
-        )
-    }
-  }
-
-  transparent inline def apply[X](inline f: JoinedView2[AL, CL, AR, CR] => X)
-    : ProjectedJoin2[RL, CL, AL, RR, CR0, AR, CR, ProjResult[X]] = select[X](f)
-
-}
-
-/** Projected join — a [[Join2]] plus a chosen projection. Terminal: compile to a [[CompiledQuery]]. */
-final class ProjectedJoin2[
-  RL <: Relation[CL],
-  CL <: Tuple,
-  AL <: String & Singleton,
-  RR <: Relation[CR0],
-  CR0 <: Tuple,
-  AR <: String & Singleton,
-  CR <: Tuple,
-  Row
-](
-  left: AliasedRelation[RL, CL, AL],
-  right: AliasedRelation[RR, CR0, AR],
-  rightColsEffective: CR,
-  kind: JoinKind,
-  onPred: Where,
-  whereOpt: Option[Where],
-  groupBys: List[TypedExpr[?]] = Nil,
-  havingOpt: Option[Where] = None,
-  orderBys: List[OrderBy],
-  limitOpt: Option[Int],
-  offsetOpt: Option[Int],
-  projections: List[TypedExpr[?]],
-  codec: Codec[Row]
-) {
-
-  private def view: JoinedView2[AL, CL, AR, CR] =
-    joinedView2[AL, CL, AR, CR](
-      left.alias,
-      left.relation.columns.asInstanceOf[CL],
-      right.alias,
-      rightColsEffective
-    )
-
-  private def copy(
-    whereOpt: Option[Where] = whereOpt,
-    groupBys: List[TypedExpr[?]] = groupBys,
-    havingOpt: Option[Where] = havingOpt,
-    orderBys: List[OrderBy] = orderBys,
-    limitOpt: Option[Int] = limitOpt,
-    offsetOpt: Option[Int] = offsetOpt
-  ): ProjectedJoin2[RL, CL, AL, RR, CR0, AR, CR, Row] =
-    new ProjectedJoin2[RL, CL, AL, RR, CR0, AR, CR, Row](
-      left,
-      right,
-      rightColsEffective,
-      kind,
-      onPred,
-      whereOpt,
-      groupBys,
-      havingOpt,
-      orderBys,
-      limitOpt,
-      offsetOpt,
-      projections,
-      codec
-    )
-
-  def where(f: JoinedView2[AL, CL, AR, CR] => Where): ProjectedJoin2[RL, CL, AL, RR, CR0, AR, CR, Row] = {
-    val next = whereOpt match {
-      case Some(existing) => existing && f(view)
-      case None           => f(view)
-    }
-    copy(whereOpt = Some(next))
-  }
-
-  def orderBy(f: JoinedView2[AL, CL, AR, CR] => OrderBy | Tuple): ProjectedJoin2[RL, CL, AL, RR, CR0, AR, CR, Row] = {
-    val fresh = f(view) match {
-      case ob: OrderBy => List(ob)
-      case t: Tuple    => t.toList.asInstanceOf[List[OrderBy]]
-    }
-    copy(orderBys = orderBys ++ fresh)
-  }
-
-  /** `GROUP BY …`. Same semantics as [[SelectBuilder.groupBy]] — coverage is not type-checked. */
-  def groupBy(
-    f: JoinedView2[AL, CL, AR, CR] => TypedExpr[?] | Tuple
-  ): ProjectedJoin2[RL, CL, AL, RR, CR0, AR, CR, Row] = {
-    val fresh = f(view) match {
-      case e: TypedExpr[?] => List(e)
-      case t: Tuple        => t.toList.asInstanceOf[List[TypedExpr[?]]]
-    }
-    copy(groupBys = groupBys ++ fresh)
-  }
-
-  /** `HAVING <predicate>`. Chains with AND. */
-  def having(f: JoinedView2[AL, CL, AR, CR] => Where): ProjectedJoin2[RL, CL, AL, RR, CR0, AR, CR, Row] = {
-    val next = havingOpt match {
-      case Some(existing) => existing && f(view)
-      case None           => f(view)
-    }
-    copy(havingOpt = Some(next))
-  }
-
-  def limit(n: Int): ProjectedJoin2[RL, CL, AL, RR, CR0, AR, CR, Row]  = copy(limitOpt = Some(n))
-  def offset(n: Int): ProjectedJoin2[RL, CL, AL, RR, CR0, AR, CR, Row] = copy(offsetOpt = Some(n))
-
-  def compile: CompiledQuery[Row] = {
-    val projList  = TypedExpr.joined(projections.map(_.render), ", ")
-    val fromL     = TypedExpr.raw(aliasedFrom(left))
-    val fromR     = TypedExpr.raw(aliasedFrom(right))
-    val joinSql   = TypedExpr.raw(s" ${kind.sql} ") |+| fromR |+| TypedExpr.raw(" ON ") |+| onPred.render
-    val header    = TypedExpr.raw("SELECT ") |+| projList |+| TypedExpr.raw(" FROM ") |+| fromL |+| joinSql
-    val withWhere = whereOpt.fold(header)(w => header |+| TypedExpr.raw(" WHERE ") |+| w.render)
-    val withGroup =
-      if (groupBys.isEmpty) withWhere
-      else withWhere |+| TypedExpr.raw(" GROUP BY ") |+| TypedExpr.joined(groupBys.map(_.render), ", ")
-    val withHaving = havingOpt.fold(withGroup)(h => withGroup |+| TypedExpr.raw(" HAVING ") |+| h.render)
-    val withOrder  =
-      if (orderBys.isEmpty) withHaving
-      else withHaving |+| TypedExpr.raw(" ORDER BY " + orderBys.map(_.sql).mkString(", "))
-    val withLimit  = limitOpt.fold(withOrder)(n => withOrder |+| TypedExpr.raw(s" LIMIT $n"))
-    val withOffset = offsetOpt.fold(withLimit)(n => withLimit |+| TypedExpr.raw(s" OFFSET $n"))
-    CompiledQuery(withOffset, codec)
-  }
-
-}
-
-/**
- * Render `"schema"."name" AS "alias"`, eliding the `AS` clause when the alias equals the relation's unqualified name
- * (the auto-alias case) — `"public"."posts"` already implies `"posts"` as the default alias.
- */
-private[sharp] def aliasedFrom(ar: AliasedRelation[?, ?, ?]): String =
-  if (ar.alias == ar.relation.name) ar.relation.qualifiedName
-  else s"""${ar.relation.qualifiedName} AS "${ar.alias}""""
-
-/** Build the named-tuple view of two aliased relations. Columns render with their alias prefix. */
-private[sharp] def joinedView2[
-  AL <: String & Singleton,
-  CL <: Tuple,
-  AR <: String & Singleton,
-  CR <: Tuple
-](aliasL: AL, colsL: CL, aliasR: AR, colsR: CR): JoinedView2[AL, CL, AR, CR] = {
-  val vL = ColumnsView.qualified(colsL, aliasL)
-  val vR = ColumnsView.qualified(colsR, aliasR)
-  (vL, vR).asInstanceOf[JoinedView2[AL, CL, AR, CR]]
-}
-
-// ---- .innerJoin / .leftJoin ----
+// ---- AsAliased typeclass -----------------------------------------------------------------------
 
 /**
  * Evidence that `T` is, or can be implicitly wrapped as, an [[AliasedRelation]]. Three sources:
@@ -396,8 +96,9 @@ private[sharp] def joinedView2[
  *   - A [[Table]] `Table[Cols, Name]` — auto-aliased to the table's name.
  *   - A [[View]] `View[Cols, Name]` — auto-aliased to the view's name.
  *
- * Lets `users.innerJoin(posts)` work without explicit `.alias(...)`: the alias defaults to the relation's name, pulled
- * from the `Name` type parameter so it's usable as a NamedTuple label in the join's lambda view (`r.users.id`).
+ * Lets `users.innerJoin(posts)` work without explicit `.alias(...)`: the alias defaults to the relation's name,
+ * pulled from the `Name` type parameter so it's usable as a NamedTuple label in the join's lambda view
+ * (`r.users.id`).
  */
 sealed trait AsAliased[T] {
   type R <: Relation[Cols]
@@ -414,7 +115,6 @@ object AsAliased {
     type Alias = Alias_
   }
 
-  /** An already-aliased relation passes through unchanged. */
   given fromAliased[RR <: Relation[CC], CC <: Tuple, A <: String & Singleton]
     : AsAliased.Aux[AliasedRelation[RR, CC, A], RR, CC, A] = new AsAliased[AliasedRelation[RR, CC, A]] {
     type R = RR
@@ -423,7 +123,6 @@ object AsAliased {
     def apply(a: AliasedRelation[RR, CC, A]): AliasedRelation[RR, CC, A] = a
   }
 
-  /** A bare `Table` is auto-aliased to its own name. */
   given fromTable[CC <: Tuple, N <: String & Singleton]: AsAliased.Aux[Table[CC, N], Table[CC, N], CC, N] =
     new AsAliased[Table[CC, N]] {
       type R = Table[CC, N]
@@ -433,7 +132,6 @@ object AsAliased {
         new AliasedRelation[Table[CC, N], CC, N](t, t.name)
     }
 
-  /** A bare `View` is auto-aliased to its own name. */
   given fromView[CC <: Tuple, N <: String & Singleton]: AsAliased.Aux[View[CC, N], View[CC, N], CC, N] =
     new AsAliased[View[CC, N]] {
       type R = View[CC, N]
@@ -445,37 +143,414 @@ object AsAliased {
 
 }
 
+// ---- SourceEntry + match types over Sources ----------------------------------------------------
+
 /**
- * `.innerJoin` / `.leftJoin` on any relation-like value — bare `Table` / `View` (auto-aliased to its own name) or an
- * already-aliased `AliasedRelation`.
+ * A single source in an N-source join. Carries both the declared column tuple (`Cols0`) and the effective one
+ * (`Cols`, = `NullableCols[Cols0]` when attached via LEFT JOIN). The lambda passed to `.where` / `.select` sees
+ * `Cols`; the `.on` lambda for the just-added source sees `Cols0`.
  */
-extension [L](left: L)(using aL: AsAliased[L]) {
+final class SourceEntry[
+  R     <: Relation[Cols0],
+  Cols0 <: Tuple,
+  Cols  <: Tuple,
+  Alias <: String & Singleton
+] private[sharp] (
+  val relation: R,
+  val alias: Alias,
+  val originalCols: Cols0,
+  val effectiveCols: Cols,
+  val kind: JoinKind,           // for the base source this is `Inner` (cosmetic — not rendered for index 0)
+  val onPredOpt: Option[Where]  // `None` for the base source and CROSS joins; `Some` for INNER/LEFT
+)
+
+/**
+ * Aliases tuple: one alias literal per committed source. Pattern-matches `SourceEntry[?, ?, ?, a]` directly in the
+ * `*:` arm — going through a separate `AliasOf` helper breaks reduction when `Ss` is constructed through multiple
+ * steps because the inner match type stays abstract.
+ */
+type AliasesOf[Ss <: Tuple] <: Tuple = Ss match {
+  case EmptyTuple                   => EmptyTuple
+  case SourceEntry[?, ?, ?, a] *: t => a *: AliasesOf[t]
+}
+
+/** Views tuple: `ColumnsView[EffectiveCols]` per committed source. */
+type EffectiveViewsOf[Ss <: Tuple] <: Tuple = Ss match {
+  case EmptyTuple                   => EmptyTuple
+  case SourceEntry[?, ?, c, ?] *: t => ColumnsView[c] *: EffectiveViewsOf[t]
+}
+
+/** The view the `.where` / `.select` / `.orderBy` / `.groupBy` / `.having` lambdas receive. */
+type JoinedView[Ss <: Tuple] =
+  NamedTuple.NamedTuple[AliasesOf[Ss], EffectiveViewsOf[Ss]]
+
+/** Aliases tuple for the `.on`-time view — committed aliases + pending alias (appended). */
+type OnAliases[Ss <: Tuple, AR <: String & Singleton] <: Tuple = Ss match {
+  case EmptyTuple                   => AR *: EmptyTuple
+  case SourceEntry[?, ?, ?, a] *: t => a *: OnAliases[t, AR]
+}
+
+/** Views tuple for the `.on`-time view — committed effective views + pending original view (appended). */
+type OnViews[Ss <: Tuple, CR0 <: Tuple] <: Tuple = Ss match {
+  case EmptyTuple                   => ColumnsView[CR0] *: EmptyTuple
+  case SourceEntry[?, ?, c, ?] *: t => ColumnsView[c] *: OnViews[t, CR0]
+}
+
+/**
+ * The view the `.on` lambda receives: committed sources use their effective cols; the pending source uses its
+ * *original* cols because Postgres evaluates `ON` before NULL-padding.
+ */
+type OnView[Ss <: Tuple, PendingCols <: Tuple, PendingAlias <: String & Singleton] =
+  NamedTuple.NamedTuple[OnAliases[Ss, PendingAlias], OnViews[Ss, PendingCols]]
+
+// ---- View builders (runtime) -------------------------------------------------------------------
+
+private[sharp] def buildJoinedView[Ss <: Tuple](sources: Ss): JoinedView[Ss] = {
+  val views = sources.toList.asInstanceOf[List[SourceEntry[?, ?, ?, ?]]].map { s =>
+    ColumnsView.qualified(s.effectiveCols, s.alias)
+  }
+  Tuple.fromArray(views.toArray[Any]).asInstanceOf[JoinedView[Ss]]
+}
+
+private[sharp] def buildOnView[Ss <: Tuple, CR0 <: Tuple, AR <: String & Singleton](
+  sources: Ss,
+  pendingOriginalCols: CR0,
+  pendingAlias: AR
+): OnView[Ss, CR0, AR] = {
+  val committedViews = sources.toList.asInstanceOf[List[SourceEntry[?, ?, ?, ?]]].map { s =>
+    ColumnsView.qualified(s.effectiveCols, s.alias)
+  }
+  val pendingView = ColumnsView.qualified(pendingOriginalCols, pendingAlias)
+  Tuple.fromArray((committedViews :+ pendingView).toArray[Any]).asInstanceOf[OnView[Ss, CR0, AR]]
+}
+
+// ---- IncompleteJoin ----------------------------------------------------------------------------
+
+/**
+ * Transitional state after `.innerJoin(x)` or `.leftJoin(x)`, before `.on(predicate)`. Only `.on` is exposed —
+ * calling `.compile` / `.select` here is a compile error because the method isn't here.
+ */
+final class IncompleteJoin[
+  Ss    <: Tuple,
+  RR    <: Relation[CR0],
+  CR0   <: Tuple,
+  CR    <: Tuple,            // = CR0 for INNER, NullableCols[CR0] for LEFT
+  AR    <: String & Singleton
+] private[sharp] (
+  sources: Ss,
+  pendingRelation: RR,
+  pendingAlias: AR,
+  pendingOriginalCols: CR0,
+  pendingEffectiveCols: CR,
+  kind: JoinKind
+) {
+
+  /**
+   * Finalise the join predicate. The view sees every committed source's effective cols plus the pending source's
+   * *original* cols — `ON` is evaluated before `NULL`-padding happens.
+   */
+  def on(
+    f: OnView[Ss, CR0, AR] => Where
+  ): JoinBuilder[Tuple.Append[Ss, SourceEntry[RR, CR0, CR, AR]]] = {
+    val pred  = f(buildOnView[Ss, CR0, AR](sources, pendingOriginalCols, pendingAlias))
+    val entry = new SourceEntry[RR, CR0, CR, AR](
+      pendingRelation,
+      pendingAlias,
+      pendingOriginalCols,
+      pendingEffectiveCols,
+      kind,
+      Some(pred)
+    )
+    val nextSources = (sources :* entry).asInstanceOf[Tuple.Append[Ss, SourceEntry[RR, CR0, CR, AR]]]
+    new JoinBuilder[Tuple.Append[Ss, SourceEntry[RR, CR0, CR, AR]]](nextSources)
+  }
+
+}
+
+// ---- JoinBuilder -------------------------------------------------------------------------------
+
+/**
+ * The main N-source builder. State: sources committed, no projection yet. Attach more sources with `.innerJoin`,
+ * `.leftJoin`, `.crossJoin`; narrow with `.where`; order with `.orderBy`; project with `.select` (→ [[ProjectedJoin]]).
+ */
+final class JoinBuilder[Ss <: Tuple] private[sharp] (
+  private[sharp] val sources: Ss,
+  private[sharp] val whereOpt: Option[Where] = None,
+  private[sharp] val orderBys: List[OrderBy] = Nil,
+  private[sharp] val limitOpt: Option[Int] = None,
+  private[sharp] val offsetOpt: Option[Int] = None
+) {
+
+  private def copy(
+    whereOpt: Option[Where] = whereOpt,
+    orderBys: List[OrderBy] = orderBys,
+    limitOpt: Option[Int] = limitOpt,
+    offsetOpt: Option[Int] = offsetOpt
+  ): JoinBuilder[Ss] =
+    new JoinBuilder[Ss](sources, whereOpt, orderBys, limitOpt, offsetOpt)
+
+  private def view: JoinedView[Ss] = buildJoinedView(sources)
+
+  /** Attach another source via INNER JOIN. Transitions to [[IncompleteJoin]] — call `.on(...)` to finalise. */
+  def innerJoin[T, RR <: Relation[CR], CR <: Tuple, AR <: String & Singleton](
+    next: T
+  )(using a: AsAliased.Aux[T, RR, CR, AR]): IncompleteJoin[Ss, RR, CR, CR, AR] = {
+    val ar   = a(next)
+    val cols = ar.relation.columns.asInstanceOf[CR]
+    new IncompleteJoin[Ss, RR, CR, CR, AR](sources, ar.relation, ar.alias, cols, cols, JoinKind.Inner)
+  }
+
+  /** Attach another source via LEFT JOIN. Right-side cols become nullable for subsequent `.where` / `.select`. */
+  def leftJoin[T, RR <: Relation[CR], CR <: Tuple, AR <: String & Singleton](
+    next: T
+  )(using a: AsAliased.Aux[T, RR, CR, AR]): IncompleteJoin[Ss, RR, CR, NullableCols[CR], AR] = {
+    val ar           = a(next)
+    val origCols     = ar.relation.columns.asInstanceOf[CR]
+    val effectiveCls = nullabilifyCols(origCols).asInstanceOf[NullableCols[CR]]
+    new IncompleteJoin[Ss, RR, CR, NullableCols[CR], AR](
+      sources,
+      ar.relation,
+      ar.alias,
+      origCols,
+      effectiveCls,
+      JoinKind.Left
+    )
+  }
+
+  /**
+   * Attach another source via CROSS JOIN — no `.on(...)` required. Renders as `CROSS JOIN`; equivalent to comma-FROM
+   * in SQL, but more readable.
+   */
+  def crossJoin[T, RR <: Relation[CR], CR <: Tuple, AR <: String & Singleton](
+    next: T
+  )(using a: AsAliased.Aux[T, RR, CR, AR]): JoinBuilder[Tuple.Append[Ss, SourceEntry[RR, CR, CR, AR]]] = {
+    val ar    = a(next)
+    val cols  = ar.relation.columns.asInstanceOf[CR]
+    val entry = new SourceEntry[RR, CR, CR, AR](ar.relation, ar.alias, cols, cols, JoinKind.Cross, None)
+    val next2 = (sources :* entry).asInstanceOf[Tuple.Append[Ss, SourceEntry[RR, CR, CR, AR]]]
+    new JoinBuilder[Tuple.Append[Ss, SourceEntry[RR, CR, CR, AR]]](next2)
+  }
+
+  def where(f: JoinedView[Ss] => Where): JoinBuilder[Ss] = {
+    val next = whereOpt.fold(f(view))(_ && f(view))
+    copy(whereOpt = Some(next))
+  }
+
+  def orderBy(f: JoinedView[Ss] => OrderBy | Tuple): JoinBuilder[Ss] = {
+    val fresh = f(view) match {
+      case ob: OrderBy => List(ob)
+      case t: Tuple    => t.toList.asInstanceOf[List[OrderBy]]
+    }
+    copy(orderBys = orderBys ++ fresh)
+  }
+
+  def limit(n: Int): JoinBuilder[Ss]  = copy(limitOpt = Some(n))
+  def offset(n: Int): JoinBuilder[Ss] = copy(offsetOpt = Some(n))
+
+  /**
+   * Projection — pick the columns / expressions to return. Single `TypedExpr[T]` → row is `T`; tuple (named or
+   * positional) → row is the projection's value tuple.
+   */
+  transparent inline def select[X](inline f: JoinedView[Ss] => X): ProjectedJoin[Ss, ProjResult[X]] = {
+    val v = view
+    f(v) match {
+      case expr: TypedExpr[?] =>
+        new ProjectedJoin[Ss, ProjResult[X]](
+          sources,
+          whereOpt,
+          groupBys = Nil,
+          havingOpt = None,
+          orderBys,
+          limitOpt,
+          offsetOpt,
+          List(expr),
+          expr.codec.asInstanceOf[Codec[ProjResult[X]]]
+        )
+      case tup: NonEmptyTuple =>
+        val exprs = tup.toList.asInstanceOf[List[TypedExpr[?]]]
+        val codec = tupleCodec(exprs.map(_.codec)).asInstanceOf[Codec[ProjResult[X]]]
+        new ProjectedJoin[Ss, ProjResult[X]](
+          sources,
+          whereOpt,
+          groupBys = Nil,
+          havingOpt = None,
+          orderBys,
+          limitOpt,
+          offsetOpt,
+          exprs,
+          codec
+        )
+    }
+  }
+
+  transparent inline def apply[X](inline f: JoinedView[Ss] => X): ProjectedJoin[Ss, ProjResult[X]] = select[X](f)
+
+}
+
+// ---- ProjectedJoin -----------------------------------------------------------------------------
+
+/** Projected N-source join — post-`.select`. Terminal: `.compile` returns a [[CompiledQuery]]. */
+final class ProjectedJoin[Ss <: Tuple, Row] (
+  private[sharp] val sources: Ss,
+  private[sharp] val whereOpt: Option[Where],
+  private[sharp] val groupBys: List[TypedExpr[?]] = Nil,
+  private[sharp] val havingOpt: Option[Where] = None,
+  private[sharp] val orderBys: List[OrderBy],
+  private[sharp] val limitOpt: Option[Int],
+  private[sharp] val offsetOpt: Option[Int],
+  private[sharp] val projections: List[TypedExpr[?]],
+  private[sharp] val codec: Codec[Row]
+) {
+
+  private def view: JoinedView[Ss] = buildJoinedView(sources)
+
+  private def copy(
+    whereOpt: Option[Where] = whereOpt,
+    groupBys: List[TypedExpr[?]] = groupBys,
+    havingOpt: Option[Where] = havingOpt,
+    orderBys: List[OrderBy] = orderBys,
+    limitOpt: Option[Int] = limitOpt,
+    offsetOpt: Option[Int] = offsetOpt
+  ): ProjectedJoin[Ss, Row] =
+    new ProjectedJoin[Ss, Row](sources, whereOpt, groupBys, havingOpt, orderBys, limitOpt, offsetOpt, projections, codec)
+
+  def where(f: JoinedView[Ss] => Where): ProjectedJoin[Ss, Row] = {
+    val next = whereOpt.fold(f(view))(_ && f(view))
+    copy(whereOpt = Some(next))
+  }
+
+  def orderBy(f: JoinedView[Ss] => OrderBy | Tuple): ProjectedJoin[Ss, Row] = {
+    val fresh = f(view) match {
+      case ob: OrderBy => List(ob)
+      case t: Tuple    => t.toList.asInstanceOf[List[OrderBy]]
+    }
+    copy(orderBys = orderBys ++ fresh)
+  }
+
+  /** `GROUP BY …`. Coverage is not type-checked (Postgres will raise at runtime on misalignment). */
+  def groupBy(f: JoinedView[Ss] => TypedExpr[?] | Tuple): ProjectedJoin[Ss, Row] = {
+    val fresh = f(view) match {
+      case e: TypedExpr[?] => List(e)
+      case t: Tuple        => t.toList.asInstanceOf[List[TypedExpr[?]]]
+    }
+    copy(groupBys = groupBys ++ fresh)
+  }
+
+  /** `HAVING <predicate>`. Chains with AND. */
+  def having(f: JoinedView[Ss] => Where): ProjectedJoin[Ss, Row] = {
+    val next = havingOpt.fold(f(view))(_ && f(view))
+    copy(havingOpt = Some(next))
+  }
+
+  def limit(n: Int): ProjectedJoin[Ss, Row]  = copy(limitOpt = Some(n))
+  def offset(n: Int): ProjectedJoin[Ss, Row] = copy(offsetOpt = Some(n))
+
+  def compile: CompiledQuery[Row] = {
+    val entries = sources.toList.asInstanceOf[List[SourceEntry[?, ?, ?, ?]]]
+    require(entries.nonEmpty, "JoinBuilder needs at least one source")
+
+    val projList = TypedExpr.joined(projections.map(_.render), ", ")
+    val head     = entries.head
+    val headFrag = TypedExpr.raw("SELECT ") |+| projList |+| TypedExpr.raw(s" FROM ${aliasedFromEntry(head)}")
+
+    val withJoins = entries.tail.foldLeft(headFrag) { (acc, s) =>
+      val fromFrag = TypedExpr.raw(s" ${s.kind.sql} ${aliasedFromEntry(s)}")
+      s.onPredOpt.fold(acc |+| fromFrag)(p => acc |+| fromFrag |+| TypedExpr.raw(" ON ") |+| p.render)
+    }
+    val withWhere = whereOpt.fold(withJoins)(w => withJoins |+| TypedExpr.raw(" WHERE ") |+| w.render)
+    val withGroup =
+      if (groupBys.isEmpty) withWhere
+      else withWhere |+| TypedExpr.raw(" GROUP BY ") |+| TypedExpr.joined(groupBys.map(_.render), ", ")
+    val withHaving = havingOpt.fold(withGroup)(h => withGroup |+| TypedExpr.raw(" HAVING ") |+| h.render)
+    val withOrder  =
+      if (orderBys.isEmpty) withHaving
+      else withHaving |+| TypedExpr.raw(" ORDER BY " + orderBys.map(_.sql).mkString(", "))
+    val withLimit  = limitOpt.fold(withOrder)(n => withOrder |+| TypedExpr.raw(s" LIMIT $n"))
+    val withOffset = offsetOpt.fold(withLimit)(n => withLimit |+| TypedExpr.raw(s" OFFSET $n"))
+    CompiledQuery(withOffset, codec)
+  }
+
+}
+
+// ---- FROM helpers ------------------------------------------------------------------------------
+
+/**
+ * Render `"schema"."name" AS "alias"`, eliding the `AS` clause when the alias equals the relation's unqualified name
+ * (the auto-alias case) — `"public"."posts"` already implies `"posts"` as the default alias.
+ */
+private[sharp] def aliasedFrom(ar: AliasedRelation[?, ?, ?]): String =
+  if (ar.alias == ar.relation.name) ar.relation.qualifiedName
+  else s"""${ar.relation.qualifiedName} AS "${ar.alias}""""
+
+private[sharp] def aliasedFromEntry(s: SourceEntry[?, ?, ?, ?]): String =
+  if (s.alias == s.relation.name) s.relation.qualifiedName
+  else s"""${s.relation.qualifiedName} AS "${s.alias}""""
+
+// ---- Join entry points -------------------------------------------------------------------------
+
+/**
+ * `.innerJoin` / `.leftJoin` / `.crossJoin` on any relation-like value — bare `Table` / `View` (auto-aliased to its
+ * own name) or an already-aliased `AliasedRelation`. The first chained call transitions from a bare relation to a
+ * single-source [[JoinBuilder]], from which further sources can be attached.
+ */
+extension [L, RL <: Relation[CL], CL <: Tuple, AL <: String & Singleton](left: L)(using
+  aL: AsAliased.Aux[L, RL, CL, AL]
+) {
 
   /** `INNER JOIN` — right-side columns keep their declared types. */
-  def innerJoin[R](right: R)(using aR: AsAliased[R])
-    : IncompleteJoin2[aL.R, aL.Cols, aL.Alias, aR.R, aR.Cols, aR.Alias, aR.Cols] = {
-    val al = aL(left)
-    val ar = aR(right)
-    new IncompleteJoin2[aL.R, aL.Cols, aL.Alias, aR.R, aR.Cols, aR.Alias, aR.Cols](
-      al,
-      ar,
-      ar.relation.columns,
+  def innerJoin[R, RR <: Relation[CR], CR <: Tuple, AR <: String & Singleton](right: R)(using
+    aR: AsAliased.Aux[R, RR, CR, AR]
+  ): IncompleteJoin[SourceEntry[RL, CL, CL, AL] *: EmptyTuple, RR, CR, CR, AR] = {
+    val baseEntry = makeBaseEntry[L, RL, CL, AL](aL, left)
+    val ar        = aR(right)
+    val rCols     = ar.relation.columns.asInstanceOf[CR]
+    new IncompleteJoin[SourceEntry[RL, CL, CL, AL] *: EmptyTuple, RR, CR, CR, AR](
+      baseEntry *: EmptyTuple,
+      ar.relation,
+      ar.alias,
+      rCols,
+      rCols,
       JoinKind.Inner
     )
   }
 
   /** `LEFT JOIN` — right-side column value types are wrapped in `Option`; `.opt` on the codecs at runtime. */
-  def leftJoin[R](right: R)(using aR: AsAliased[R])
-    : IncompleteJoin2[aL.R, aL.Cols, aL.Alias, aR.R, aR.Cols, aR.Alias, NullableCols[aR.Cols]] = {
-    val al        = aL(left)
-    val ar        = aR(right)
-    val nullified = nullabilifyCols(ar.relation.columns).asInstanceOf[NullableCols[aR.Cols]]
-    new IncompleteJoin2[aL.R, aL.Cols, aL.Alias, aR.R, aR.Cols, aR.Alias, NullableCols[aR.Cols]](
-      al,
-      ar,
-      nullified,
+  def leftJoin[R, RR <: Relation[CR], CR <: Tuple, AR <: String & Singleton](right: R)(using
+    aR: AsAliased.Aux[R, RR, CR, AR]
+  ): IncompleteJoin[SourceEntry[RL, CL, CL, AL] *: EmptyTuple, RR, CR, NullableCols[CR], AR] = {
+    val baseEntry    = makeBaseEntry[L, RL, CL, AL](aL, left)
+    val ar           = aR(right)
+    val origCols     = ar.relation.columns.asInstanceOf[CR]
+    val effectiveCls = nullabilifyCols(origCols).asInstanceOf[NullableCols[CR]]
+    new IncompleteJoin[SourceEntry[RL, CL, CL, AL] *: EmptyTuple, RR, CR, NullableCols[CR], AR](
+      baseEntry *: EmptyTuple,
+      ar.relation,
+      ar.alias,
+      origCols,
+      effectiveCls,
       JoinKind.Left
     )
   }
 
+  /** `CROSS JOIN` — no predicate required; transitions straight to a two-source [[JoinBuilder]]. */
+  def crossJoin[R, RR <: Relation[CR], CR <: Tuple, AR <: String & Singleton](right: R)(using
+    aR: AsAliased.Aux[R, RR, CR, AR]
+  ): JoinBuilder[(SourceEntry[RL, CL, CL, AL], SourceEntry[RR, CR, CR, AR])] = {
+    val baseEntry = makeBaseEntry[L, RL, CL, AL](aL, left)
+    val ar        = aR(right)
+    val rCols     = ar.relation.columns.asInstanceOf[CR]
+    val rEntry    = new SourceEntry[RR, CR, CR, AR](ar.relation, ar.alias, rCols, rCols, JoinKind.Cross, None)
+    new JoinBuilder[(SourceEntry[RL, CL, CL, AL], SourceEntry[RR, CR, CR, AR])]((baseEntry, rEntry))
+  }
+
 }
+
+private[sharp] def makeBaseEntry[L, RL <: Relation[CL], CL <: Tuple, AL <: String & Singleton](
+  aL: AsAliased.Aux[L, RL, CL, AL],
+  left: L
+): SourceEntry[RL, CL, CL, AL] = {
+  val al   = aL(left)
+  val cols = al.relation.columns.asInstanceOf[CL]
+  new SourceEntry[RL, CL, CL, AL](al.relation, al.alias, cols, cols, JoinKind.Inner, None)
+}
+

--- a/modules/core/src/main/scala/skunk/sharp/dsl/Join.scala
+++ b/modules/core/src/main/scala/skunk/sharp/dsl/Join.scala
@@ -2,7 +2,6 @@ package skunk.sharp.dsl
 
 import skunk.Codec
 import skunk.sharp.*
-import skunk.sharp.internal.tupleCodec
 import skunk.sharp.where.Where
 
 import scala.NamedTuple
@@ -247,11 +246,12 @@ final class IncompleteJoin[
 
   /**
    * Finalise the join predicate. The view sees every committed source's effective cols plus the pending source's
-   * *original* cols — `ON` is evaluated before `NULL`-padding happens.
+   * *original* cols — `ON` is evaluated before `NULL`-padding happens. Transitions to [[SelectBuilder]] with the
+   * pending source appended to `Ss`.
    */
   def on(
     f: OnView[Ss, CR0, AR] => Where
-  ): JoinBuilder[Tuple.Append[Ss, SourceEntry[RR, CR0, CR, AR]]] = {
+  ): SelectBuilder[Tuple.Append[Ss, SourceEntry[RR, CR0, CR, AR]]] = {
     val pred  = f(buildOnView[Ss, CR0, AR](sources, pendingOriginalCols, pendingAlias))
     val entry = new SourceEntry[RR, CR0, CR, AR](
       pendingRelation,
@@ -262,212 +262,7 @@ final class IncompleteJoin[
       Some(pred)
     )
     val nextSources = (sources :* entry).asInstanceOf[Tuple.Append[Ss, SourceEntry[RR, CR0, CR, AR]]]
-    new JoinBuilder[Tuple.Append[Ss, SourceEntry[RR, CR0, CR, AR]]](nextSources)
-  }
-
-}
-
-// ---- JoinBuilder -------------------------------------------------------------------------------
-
-/**
- * The main N-source builder. State: sources committed, no projection yet. Attach more sources with `.innerJoin`,
- * `.leftJoin`, `.crossJoin`; narrow with `.where`; order with `.orderBy`; project with `.select` (→ [[ProjectedJoin]]).
- */
-final class JoinBuilder[Ss <: Tuple] private[sharp] (
-  private[sharp] val sources: Ss,
-  private[sharp] val whereOpt: Option[Where] = None,
-  private[sharp] val orderBys: List[OrderBy] = Nil,
-  private[sharp] val limitOpt: Option[Int] = None,
-  private[sharp] val offsetOpt: Option[Int] = None
-) {
-
-  private def copy(
-    whereOpt: Option[Where] = whereOpt,
-    orderBys: List[OrderBy] = orderBys,
-    limitOpt: Option[Int] = limitOpt,
-    offsetOpt: Option[Int] = offsetOpt
-  ): JoinBuilder[Ss] =
-    new JoinBuilder[Ss](sources, whereOpt, orderBys, limitOpt, offsetOpt)
-
-  private def view: JoinedView[Ss] = buildJoinedView(sources)
-
-  /** Attach another source via INNER JOIN. Transitions to [[IncompleteJoin]] — call `.on(...)` to finalise. */
-  def innerJoin[T, RR <: Relation[CR], CR <: Tuple, AR <: String & Singleton](
-    next: T
-  )(using a: AsAliased.Aux[T, RR, CR, AR]): IncompleteJoin[Ss, RR, CR, CR, AR] = {
-    val ar   = a(next)
-    val cols = ar.relation.columns.asInstanceOf[CR]
-    new IncompleteJoin[Ss, RR, CR, CR, AR](sources, ar.relation, ar.alias, cols, cols, JoinKind.Inner)
-  }
-
-  /** Attach another source via LEFT JOIN. Right-side cols become nullable for subsequent `.where` / `.select`. */
-  def leftJoin[T, RR <: Relation[CR], CR <: Tuple, AR <: String & Singleton](
-    next: T
-  )(using a: AsAliased.Aux[T, RR, CR, AR]): IncompleteJoin[Ss, RR, CR, NullableCols[CR], AR] = {
-    val ar           = a(next)
-    val origCols     = ar.relation.columns.asInstanceOf[CR]
-    val effectiveCls = nullabilifyCols(origCols).asInstanceOf[NullableCols[CR]]
-    new IncompleteJoin[Ss, RR, CR, NullableCols[CR], AR](
-      sources,
-      ar.relation,
-      ar.alias,
-      origCols,
-      effectiveCls,
-      JoinKind.Left
-    )
-  }
-
-  /**
-   * Attach another source via CROSS JOIN — no `.on(...)` required. Renders as `CROSS JOIN`; equivalent to comma-FROM
-   * in SQL, but more readable.
-   */
-  def crossJoin[T, RR <: Relation[CR], CR <: Tuple, AR <: String & Singleton](
-    next: T
-  )(using a: AsAliased.Aux[T, RR, CR, AR]): JoinBuilder[Tuple.Append[Ss, SourceEntry[RR, CR, CR, AR]]] = {
-    val ar    = a(next)
-    val cols  = ar.relation.columns.asInstanceOf[CR]
-    val entry = new SourceEntry[RR, CR, CR, AR](ar.relation, ar.alias, cols, cols, JoinKind.Cross, None)
-    val next2 = (sources :* entry).asInstanceOf[Tuple.Append[Ss, SourceEntry[RR, CR, CR, AR]]]
-    new JoinBuilder[Tuple.Append[Ss, SourceEntry[RR, CR, CR, AR]]](next2)
-  }
-
-  def where(f: JoinedView[Ss] => Where): JoinBuilder[Ss] = {
-    val next = whereOpt.fold(f(view))(_ && f(view))
-    copy(whereOpt = Some(next))
-  }
-
-  def orderBy(f: JoinedView[Ss] => OrderBy | Tuple): JoinBuilder[Ss] = {
-    val fresh = f(view) match {
-      case ob: OrderBy => List(ob)
-      case t: Tuple    => t.toList.asInstanceOf[List[OrderBy]]
-    }
-    copy(orderBys = orderBys ++ fresh)
-  }
-
-  def limit(n: Int): JoinBuilder[Ss]  = copy(limitOpt = Some(n))
-  def offset(n: Int): JoinBuilder[Ss] = copy(offsetOpt = Some(n))
-
-  /**
-   * Projection — pick the columns / expressions to return. Single `TypedExpr[T]` → row is `T`; tuple (named or
-   * positional) → row is the projection's value tuple.
-   */
-  transparent inline def select[X](inline f: JoinedView[Ss] => X): ProjectedJoin[Ss, ProjResult[X]] = {
-    val v = view
-    f(v) match {
-      case expr: TypedExpr[?] =>
-        new ProjectedJoin[Ss, ProjResult[X]](
-          sources,
-          whereOpt,
-          groupBys = Nil,
-          havingOpt = None,
-          orderBys,
-          limitOpt,
-          offsetOpt,
-          List(expr),
-          expr.codec.asInstanceOf[Codec[ProjResult[X]]]
-        )
-      case tup: NonEmptyTuple =>
-        val exprs = tup.toList.asInstanceOf[List[TypedExpr[?]]]
-        val codec = tupleCodec(exprs.map(_.codec)).asInstanceOf[Codec[ProjResult[X]]]
-        new ProjectedJoin[Ss, ProjResult[X]](
-          sources,
-          whereOpt,
-          groupBys = Nil,
-          havingOpt = None,
-          orderBys,
-          limitOpt,
-          offsetOpt,
-          exprs,
-          codec
-        )
-    }
-  }
-
-  transparent inline def apply[X](inline f: JoinedView[Ss] => X): ProjectedJoin[Ss, ProjResult[X]] = select[X](f)
-
-}
-
-// ---- ProjectedJoin -----------------------------------------------------------------------------
-
-/** Projected N-source join — post-`.select`. Terminal: `.compile` returns a [[CompiledQuery]]. */
-final class ProjectedJoin[Ss <: Tuple, Row] (
-  private[sharp] val sources: Ss,
-  private[sharp] val whereOpt: Option[Where],
-  private[sharp] val groupBys: List[TypedExpr[?]] = Nil,
-  private[sharp] val havingOpt: Option[Where] = None,
-  private[sharp] val orderBys: List[OrderBy],
-  private[sharp] val limitOpt: Option[Int],
-  private[sharp] val offsetOpt: Option[Int],
-  private[sharp] val projections: List[TypedExpr[?]],
-  private[sharp] val codec: Codec[Row]
-) {
-
-  private def view: JoinedView[Ss] = buildJoinedView(sources)
-
-  private def copy(
-    whereOpt: Option[Where] = whereOpt,
-    groupBys: List[TypedExpr[?]] = groupBys,
-    havingOpt: Option[Where] = havingOpt,
-    orderBys: List[OrderBy] = orderBys,
-    limitOpt: Option[Int] = limitOpt,
-    offsetOpt: Option[Int] = offsetOpt
-  ): ProjectedJoin[Ss, Row] =
-    new ProjectedJoin[Ss, Row](sources, whereOpt, groupBys, havingOpt, orderBys, limitOpt, offsetOpt, projections, codec)
-
-  def where(f: JoinedView[Ss] => Where): ProjectedJoin[Ss, Row] = {
-    val next = whereOpt.fold(f(view))(_ && f(view))
-    copy(whereOpt = Some(next))
-  }
-
-  def orderBy(f: JoinedView[Ss] => OrderBy | Tuple): ProjectedJoin[Ss, Row] = {
-    val fresh = f(view) match {
-      case ob: OrderBy => List(ob)
-      case t: Tuple    => t.toList.asInstanceOf[List[OrderBy]]
-    }
-    copy(orderBys = orderBys ++ fresh)
-  }
-
-  /** `GROUP BY …`. Coverage is not type-checked (Postgres will raise at runtime on misalignment). */
-  def groupBy(f: JoinedView[Ss] => TypedExpr[?] | Tuple): ProjectedJoin[Ss, Row] = {
-    val fresh = f(view) match {
-      case e: TypedExpr[?] => List(e)
-      case t: Tuple        => t.toList.asInstanceOf[List[TypedExpr[?]]]
-    }
-    copy(groupBys = groupBys ++ fresh)
-  }
-
-  /** `HAVING <predicate>`. Chains with AND. */
-  def having(f: JoinedView[Ss] => Where): ProjectedJoin[Ss, Row] = {
-    val next = havingOpt.fold(f(view))(_ && f(view))
-    copy(havingOpt = Some(next))
-  }
-
-  def limit(n: Int): ProjectedJoin[Ss, Row]  = copy(limitOpt = Some(n))
-  def offset(n: Int): ProjectedJoin[Ss, Row] = copy(offsetOpt = Some(n))
-
-  def compile: CompiledQuery[Row] = {
-    val entries = sources.toList.asInstanceOf[List[SourceEntry[?, ?, ?, ?]]]
-    require(entries.nonEmpty, "JoinBuilder needs at least one source")
-
-    val projList = TypedExpr.joined(projections.map(_.render), ", ")
-    val head     = entries.head
-    val headFrag = TypedExpr.raw("SELECT ") |+| projList |+| TypedExpr.raw(s" FROM ${aliasedFromEntry(head)}")
-
-    val withJoins = entries.tail.foldLeft(headFrag) { (acc, s) =>
-      val fromFrag = TypedExpr.raw(s" ${s.kind.sql} ${aliasedFromEntry(s)}")
-      s.onPredOpt.fold(acc |+| fromFrag)(p => acc |+| fromFrag |+| TypedExpr.raw(" ON ") |+| p.render)
-    }
-    val withWhere = whereOpt.fold(withJoins)(w => withJoins |+| TypedExpr.raw(" WHERE ") |+| w.render)
-    val withGroup =
-      if (groupBys.isEmpty) withWhere
-      else withWhere |+| TypedExpr.raw(" GROUP BY ") |+| TypedExpr.joined(groupBys.map(_.render), ", ")
-    val withHaving = havingOpt.fold(withGroup)(h => withGroup |+| TypedExpr.raw(" HAVING ") |+| h.render)
-    val withOrder  =
-      if (orderBys.isEmpty) withHaving
-      else withHaving |+| TypedExpr.raw(" ORDER BY " + orderBys.map(_.sql).mkString(", "))
-    val withLimit  = limitOpt.fold(withOrder)(n => withOrder |+| TypedExpr.raw(s" LIMIT $n"))
-    val withOffset = offsetOpt.fold(withLimit)(n => withLimit |+| TypedExpr.raw(s" OFFSET $n"))
-    CompiledQuery(withOffset, codec)
+    new SelectBuilder[Tuple.Append[Ss, SourceEntry[RR, CR0, CR, AR]]](nextSources)
   }
 
 }
@@ -532,15 +327,15 @@ extension [L, RL <: Relation[CL], CL <: Tuple, AL <: String & Singleton](left: L
     )
   }
 
-  /** `CROSS JOIN` — no predicate required; transitions straight to a two-source [[JoinBuilder]]. */
+  /** `CROSS JOIN` — no predicate required; transitions straight to a two-source [[SelectBuilder]]. */
   def crossJoin[R, RR <: Relation[CR], CR <: Tuple, AR <: String & Singleton](right: R)(using
     aR: AsAliased.Aux[R, RR, CR, AR]
-  ): JoinBuilder[(SourceEntry[RL, CL, CL, AL], SourceEntry[RR, CR, CR, AR])] = {
+  ): SelectBuilder[(SourceEntry[RL, CL, CL, AL], SourceEntry[RR, CR, CR, AR])] = {
     val baseEntry = makeBaseEntry[L, RL, CL, AL](aL, left)
     val ar        = aR(right)
     val rCols     = ar.relation.columns.asInstanceOf[CR]
     val rEntry    = new SourceEntry[RR, CR, CR, AR](ar.relation, ar.alias, rCols, rCols, JoinKind.Cross, None)
-    new JoinBuilder[(SourceEntry[RL, CL, CL, AL], SourceEntry[RR, CR, CR, AR])]((baseEntry, rEntry))
+    new SelectBuilder[(SourceEntry[RL, CL, CL, AL], SourceEntry[RR, CR, CR, AR])]((baseEntry, rEntry))
   }
 
 }

--- a/modules/core/src/main/scala/skunk/sharp/dsl/Join.scala
+++ b/modules/core/src/main/scala/skunk/sharp/dsl/Join.scala
@@ -7,10 +7,10 @@ import skunk.sharp.where.Where
 import scala.NamedTuple
 
 /**
- * N-table SQL joins. `.innerJoin` / `.leftJoin` / `.crossJoin` chain off any relation (or
- * [[AliasedRelation]]); each join appends a [[SourceEntry]] to a `Sources <: Tuple` carried at the type level.
- * The lambda passed to `.where` / `.select` / `.orderBy` / `.groupBy` / `.having` receives a `JoinedView[Sources]` —
- * a Scala 3 named tuple keyed by alias — so columns are reached as `r.<alias>.<column>`.
+ * N-table SQL joins. `.innerJoin` / `.leftJoin` / `.crossJoin` chain off any relation (or [[AliasedRelation]]); each
+ * join appends a [[SourceEntry]] to a `Sources <: Tuple` carried at the type level. The lambda passed to `.where` /
+ * `.select` / `.orderBy` / `.groupBy` / `.having` receives a `JoinedView[Sources]` — a Scala 3 named tuple keyed by
+ * alias — so columns are reached as `r.<alias>.<column>`.
  *
  * {{{
  *   users
@@ -95,9 +95,8 @@ private[sharp] def nullabilifyCols(cols: Tuple): Tuple = {
  *   - A [[Table]] `Table[Cols, Name]` — auto-aliased to the table's name.
  *   - A [[View]] `View[Cols, Name]` — auto-aliased to the view's name.
  *
- * Lets `users.innerJoin(posts)` work without explicit `.alias(...)`: the alias defaults to the relation's name,
- * pulled from the `Name` type parameter so it's usable as a NamedTuple label in the join's lambda view
- * (`r.users.id`).
+ * Lets `users.innerJoin(posts)` work without explicit `.alias(...)`: the alias defaults to the relation's name, pulled
+ * from the `Name` type parameter so it's usable as a NamedTuple label in the join's lambda view (`r.users.id`).
  */
 sealed trait AsAliased[T] {
   type R <: Relation[Cols]
@@ -109,23 +108,23 @@ sealed trait AsAliased[T] {
 object AsAliased {
 
   type Aux[T, R_ <: Relation[Cols_], Cols_ <: Tuple, Alias_ <: String & Singleton] = AsAliased[T] {
-    type R = R_
-    type Cols = Cols_
+    type R     = R_
+    type Cols  = Cols_
     type Alias = Alias_
   }
 
   given fromAliased[RR <: Relation[CC], CC <: Tuple, A <: String & Singleton]
     : AsAliased.Aux[AliasedRelation[RR, CC, A], RR, CC, A] = new AsAliased[AliasedRelation[RR, CC, A]] {
-    type R = RR
-    type Cols = CC
+    type R     = RR
+    type Cols  = CC
     type Alias = A
     def apply(a: AliasedRelation[RR, CC, A]): AliasedRelation[RR, CC, A] = a
   }
 
   given fromTable[CC <: Tuple, N <: String & Singleton]: AsAliased.Aux[Table[CC, N], Table[CC, N], CC, N] =
     new AsAliased[Table[CC, N]] {
-      type R = Table[CC, N]
-      type Cols = CC
+      type R     = Table[CC, N]
+      type Cols  = CC
       type Alias = N
       def apply(t: Table[CC, N]): AliasedRelation[Table[CC, N], CC, N] =
         new AliasedRelation[Table[CC, N], CC, N](t, t.name)
@@ -133,8 +132,8 @@ object AsAliased {
 
   given fromView[CC <: Tuple, N <: String & Singleton]: AsAliased.Aux[View[CC, N], View[CC, N], CC, N] =
     new AsAliased[View[CC, N]] {
-      type R = View[CC, N]
-      type Cols = CC
+      type R     = View[CC, N]
+      type Cols  = CC
       type Alias = N
       def apply(v: View[CC, N]): AliasedRelation[View[CC, N], CC, N] =
         new AliasedRelation[View[CC, N], CC, N](v, v.name)
@@ -145,28 +144,28 @@ object AsAliased {
 // ---- SourceEntry + match types over Sources ----------------------------------------------------
 
 /**
- * A single source in an N-source join. Carries both the declared column tuple (`Cols0`) and the effective one
- * (`Cols`, = `NullableCols[Cols0]` when attached via LEFT JOIN). The lambda passed to `.where` / `.select` sees
- * `Cols`; the `.on` lambda for the just-added source sees `Cols0`.
+ * A single source in an N-source join. Carries both the declared column tuple (`Cols0`) and the effective one (`Cols`, =
+ * `NullableCols[Cols0]` when attached via LEFT JOIN). The lambda passed to `.where` / `.select` sees `Cols`; the `.on`
+ * lambda for the just-added source sees `Cols0`.
  */
 final class SourceEntry[
-  R     <: Relation[Cols0],
+  R <: Relation[Cols0],
   Cols0 <: Tuple,
-  Cols  <: Tuple,
+  Cols <: Tuple,
   Alias <: String & Singleton
 ] private[sharp] (
   val relation: R,
   val alias: Alias,
   val originalCols: Cols0,
   val effectiveCols: Cols,
-  val kind: JoinKind,           // for the base source this is `Inner` (cosmetic — not rendered for index 0)
-  val onPredOpt: Option[Where]  // `None` for the base source and CROSS joins; `Some` for INNER/LEFT
+  val kind: JoinKind,          // for the base source this is `Inner` (cosmetic — not rendered for index 0)
+  val onPredOpt: Option[Where] // `None` for the base source and CROSS joins; `Some` for INNER/LEFT
 )
 
 /**
- * Aliases tuple: one alias literal per committed source. Pattern-matches `SourceEntry[?, ?, ?, a]` directly in the
- * `*:` arm — going through a separate `AliasOf` helper breaks reduction when `Ss` is constructed through multiple
- * steps because the inner match type stays abstract.
+ * Aliases tuple: one alias literal per committed source. Pattern-matches `SourceEntry[?, ?, ?, a]` directly in the `*:`
+ * arm — going through a separate `AliasOf` helper breaks reduction when `Ss` is constructed through multiple steps
+ * because the inner match type stays abstract.
  */
 type AliasesOf[Ss <: Tuple] <: Tuple = Ss match {
   case EmptyTuple                   => EmptyTuple
@@ -226,15 +225,15 @@ private[sharp] def buildOnView[Ss <: Tuple, CR0 <: Tuple, AR <: String & Singlet
 // ---- IncompleteJoin ----------------------------------------------------------------------------
 
 /**
- * Transitional state after `.innerJoin(x)` or `.leftJoin(x)`, before `.on(predicate)`. Only `.on` is exposed —
- * calling `.compile` / `.select` here is a compile error because the method isn't here.
+ * Transitional state after `.innerJoin(x)` or `.leftJoin(x)`, before `.on(predicate)`. Only `.on` is exposed — calling
+ * `.compile` / `.select` here is a compile error because the method isn't here.
  */
 final class IncompleteJoin[
-  Ss    <: Tuple,
-  RR    <: Relation[CR0],
-  CR0   <: Tuple,
-  CR    <: Tuple,            // = CR0 for INNER, NullableCols[CR0] for LEFT
-  AR    <: String & Singleton
+  Ss <: Tuple,
+  RR <: Relation[CR0],
+  CR0 <: Tuple,
+  CR <: Tuple, // = CR0 for INNER, NullableCols[CR0] for LEFT
+  AR <: String & Singleton
 ] private[sharp] (
   sources: Ss,
   pendingRelation: RR,
@@ -284,8 +283,8 @@ private[sharp] def aliasedFromEntry(s: SourceEntry[?, ?, ?, ?]): String =
 // ---- Join entry points -------------------------------------------------------------------------
 
 /**
- * `.innerJoin` / `.leftJoin` / `.crossJoin` on any relation-like value — bare `Table` / `View` (auto-aliased to its
- * own name) or an already-aliased `AliasedRelation`. The first chained call transitions from a bare relation to a
+ * `.innerJoin` / `.leftJoin` / `.crossJoin` on any relation-like value — bare `Table` / `View` (auto-aliased to its own
+ * name) or an already-aliased `AliasedRelation`. The first chained call transitions from a bare relation to a
  * single-source [[JoinBuilder]], from which further sources can be attached.
  */
 extension [L, RL <: Relation[CL], CL <: Tuple, AL <: String & Singleton](left: L)(using
@@ -348,4 +347,3 @@ private[sharp] def makeBaseEntry[L, RL <: Relation[CL], CL <: Tuple, AL <: Strin
   val cols = al.relation.columns.asInstanceOf[CL]
   new SourceEntry[RL, CL, CL, AL](al.relation, al.alias, cols, cols, JoinKind.Inner, None)
 }
-

--- a/modules/core/src/main/scala/skunk/sharp/dsl/Select.scala
+++ b/modules/core/src/main/scala/skunk/sharp/dsl/Select.scala
@@ -3,7 +3,7 @@ package skunk.sharp.dsl
 import skunk.Codec
 import skunk.sharp.*
 import skunk.sharp.internal.{rowCodec, tupleCodec}
-import skunk.sharp.where.Where
+import skunk.sharp.where.{Where, &&}
 
 /**
  * Unified SELECT builder — one class for single-source, JOINed, or CROSS-joined queries. Every lambda-taking method
@@ -446,10 +446,16 @@ type SelectView[Ss <: Tuple] = Ss match {
 
 private[sharp] def buildSelectView[Ss <: Tuple](sources: Ss): SelectView[Ss] =
   sources.toList.asInstanceOf[List[SourceEntry[?, ?, ?, ?]]] match {
-    // Single source: bare column names in WHERE/ORDER BY (matches the pre-unification SelectBuilder behaviour and
-    // avoids redundant qualifiers when there's only one source to qualify against).
-    case single :: Nil => ColumnsView(single.effectiveCols).asInstanceOf[SelectView[Ss]]
-    case _             => buildJoinedView[Ss](sources).asInstanceOf[SelectView[Ss]]
+    // Single source: columns render *bare* when the alias is the default (equal to the relation's name) — avoids
+    // redundant qualifiers and matches the pre-unification SelectBuilder SQL. When the caller gave an explicit
+    // `.alias(...)`, we qualify — it's how correlation inside subqueries works (outer `u.id` must render as
+    // `"u"."id"` for Postgres to resolve to the outer source).
+    case single :: Nil =>
+      if (single.alias == single.relation.name)
+        ColumnsView(single.effectiveCols).asInstanceOf[SelectView[Ss]]
+      else
+        ColumnsView.qualified(single.effectiveCols, single.alias).asInstanceOf[SelectView[Ss]]
+    case _ => buildJoinedView[Ss](sources).asInstanceOf[SelectView[Ss]]
   }
 
 // ---- Evidence typeclasses ----------------------------------------------------------------------

--- a/modules/core/src/main/scala/skunk/sharp/dsl/Select.scala
+++ b/modules/core/src/main/scala/skunk/sharp/dsl/Select.scala
@@ -6,49 +6,28 @@ import skunk.sharp.internal.{rowCodec, tupleCodec}
 import skunk.sharp.where.Where
 
 /**
- * SELECT builder — anchored at a single relation.
+ * Unified SELECT builder — one class for single-source, JOINed, or CROSS-joined queries. Every lambda-taking method
+ * receives a [[SelectView]], which the match type reduces to:
  *
- *   - Default projection: the whole row as a Scala 3 named tuple (`NamedRowOf[Cols]`).
- *   - `.apply(cols => …)` — **function-based** projection. See trade-offs below.
- *   - `.cols(tupleOfNames)` — **name-based** projection. See trade-offs below.
- *   - `.where(cols => …)`, `.orderBy(cols => c.x.desc)`, `.limit(n)`, `.offset(n)`.
- *   - `.run(session)` materialises the query as a skunk `AppliedFragment` and executes it.
+ *   - `ColumnsView[Cols]` when there's exactly one source — user writes `u.email`, same as before.
+ *   - `JoinedView[Ss]` (a Scala 3 named tuple keyed by alias) when there are 2+ sources — user writes `r.users.email`.
  *
- * ==Function-based vs name-based projection==
- *
- * ''TODO: carry these trade-offs into the docs module when Laika+mdoc land.''
- *
- *   - `.apply(cols => …)` (function form):
- *     - Expressions are first class — `Pg.lower(cols.email)`, arithmetic, user functions, column-to-column composition
- *       all compose naturally.
- *     - IDE autocomplete on `cols.` surfaces every column; refactoring rename-column updates references.
- *     - Scope is clear: the lambda binds `cols`, making it obvious which columns are visible.
- *     - Slightly more ceremony for simple projections (`cols =>` at the head).
- *   - `.cols(("id", "email"))` (name form):
- *     - Terse for straight "select these named columns" queries.
- *     - Unknown column names produce a compile error that lists the available columns.
- *     - No expression support — pure column references only.
- *     - Not refactor-safe: renaming a column won't update string literals (the compile-time check catches drift, but
- *       you still have to change every call site by hand).
- *     - Reads closer to SQL for one-off projections.
- *
- * For FROM-less queries (`SELECT now()`), use the top-level [[skunk.sharp.dsl.Select]] entry point instead. Multi-table
- * joins are roadmap (v0.1+).
+ * Row-level locking (`FOR UPDATE`, `FOR SHARE`, …) is gated on `IsSingleTable[Ss]` evidence — only a single-source
+ * query over a [[Table]] can lock; anything else is a compile error.
  */
-final class SelectBuilder[R <: Relation[Cols], Cols <: Tuple] private[sharp] (
-  private[sharp] val relation: R,
-  private[sharp] val distinct: Boolean,
-  private[sharp] val whereOpt: Option[Where],
-  private[sharp] val groupBys: List[TypedExpr[?]],
-  private[sharp] val havingOpt: Option[Where],
-  private[sharp] val orderBys: List[OrderBy],
-  private[sharp] val limitOpt: Option[Int],
-  private[sharp] val offsetOpt: Option[Int],
-  private[sharp] val lockingOpt: Option[Locking]
+final class SelectBuilder[Ss <: Tuple] private[sharp] (
+  private[sharp] val sources: Ss,
+  private[sharp] val distinct: Boolean = false,
+  private[sharp] val whereOpt: Option[Where] = None,
+  private[sharp] val groupBys: List[TypedExpr[?]] = Nil,
+  private[sharp] val havingOpt: Option[Where] = None,
+  private[sharp] val orderBys: List[OrderBy] = Nil,
+  private[sharp] val limitOpt: Option[Int] = None,
+  private[sharp] val offsetOpt: Option[Int] = None,
+  private[sharp] val lockingOpt: Option[Locking] = None
 ) {
 
   private def copy(
-    relation: R = relation,
     distinct: Boolean = distinct,
     whereOpt: Option[Where] = whereOpt,
     groupBys: List[TypedExpr[?]] = groupBys,
@@ -57,9 +36,104 @@ final class SelectBuilder[R <: Relation[Cols], Cols <: Tuple] private[sharp] (
     limitOpt: Option[Int] = limitOpt,
     offsetOpt: Option[Int] = offsetOpt,
     lockingOpt: Option[Locking] = lockingOpt
-  ): SelectBuilder[R, Cols] =
-    new SelectBuilder[R, Cols](
-      relation,
+  ): SelectBuilder[Ss] =
+    new SelectBuilder[Ss](sources, distinct, whereOpt, groupBys, havingOpt, orderBys, limitOpt, offsetOpt, lockingOpt)
+
+  private def view: SelectView[Ss] = buildSelectView[Ss](sources)
+
+  def where(f: SelectView[Ss] => Where): SelectBuilder[Ss] = {
+    val next = whereOpt.fold(f(view))(_ && f(view))
+    copy(whereOpt = Some(next))
+  }
+
+  def orderBy(f: SelectView[Ss] => OrderBy | Tuple): SelectBuilder[Ss] = {
+    val fresh = f(view) match {
+      case ob: OrderBy => List(ob)
+      case t: Tuple    => t.toList.asInstanceOf[List[OrderBy]]
+    }
+    copy(orderBys = orderBys ++ fresh)
+  }
+
+  /** `GROUP BY …`. Coverage is not type-checked (Postgres raises runtime on misalignment). */
+  def groupBy(f: SelectView[Ss] => TypedExpr[?] | Tuple): SelectBuilder[Ss] = {
+    val fresh = f(view) match {
+      case e: TypedExpr[?] => List(e)
+      case t: Tuple        => t.toList.asInstanceOf[List[TypedExpr[?]]]
+    }
+    copy(groupBys = groupBys ++ fresh)
+  }
+
+  /** `HAVING <predicate>`. Chains with AND. */
+  def having(f: SelectView[Ss] => Where): SelectBuilder[Ss] = {
+    val next = havingOpt.fold(f(view))(_ && f(view))
+    copy(havingOpt = Some(next))
+  }
+
+  def limit(n: Int): SelectBuilder[Ss]  = copy(limitOpt = Some(n))
+  def offset(n: Int): SelectBuilder[Ss] = copy(offsetOpt = Some(n))
+
+  /** `SELECT DISTINCT …`. */
+  def distinctRows: SelectBuilder[Ss] = copy(distinct = true)
+
+  // ---- Row-level locking (single-source Table only) ---------------------------------------------
+
+  /** `FOR UPDATE` — exclusive row lock. Requires single-source Table; anything else is a compile error. */
+  def forUpdate(using ev: IsSingleTable[Ss]): SelectBuilder[Ss] =
+    copy(lockingOpt = Some(Locking(LockMode.ForUpdate)))
+
+  def forNoKeyUpdate(using ev: IsSingleTable[Ss]): SelectBuilder[Ss] =
+    copy(lockingOpt = Some(Locking(LockMode.ForNoKeyUpdate)))
+
+  def forShare(using ev: IsSingleTable[Ss]): SelectBuilder[Ss] =
+    copy(lockingOpt = Some(Locking(LockMode.ForShare)))
+
+  def forKeyShare(using ev: IsSingleTable[Ss]): SelectBuilder[Ss] =
+    copy(lockingOpt = Some(Locking(LockMode.ForKeyShare)))
+
+  def skipLocked(using ev: IsSingleTable[Ss]): SelectBuilder[Ss] =
+    copy(lockingOpt = lockingOpt.map(_.copy(waitPolicy = WaitPolicy.SkipLocked)))
+
+  def noWait(using ev: IsSingleTable[Ss]): SelectBuilder[Ss] =
+    copy(lockingOpt = lockingOpt.map(_.copy(waitPolicy = WaitPolicy.NoWait)))
+
+  // ---- Attach more sources (upgrade single-source → multi-source) -------------------------------
+
+  /** Attach another source via INNER JOIN. Transitions to [[IncompleteJoin]] — call `.on(...)` to finalise. */
+  def innerJoin[T, RR <: Relation[CR], CR <: Tuple, AR <: String & Singleton](
+    next: T
+  )(using a: AsAliased.Aux[T, RR, CR, AR]): IncompleteJoin[Ss, RR, CR, CR, AR] = {
+    val ar   = a(next)
+    val cols = ar.relation.columns.asInstanceOf[CR]
+    new IncompleteJoin[Ss, RR, CR, CR, AR](sources, ar.relation, ar.alias, cols, cols, JoinKind.Inner)
+  }
+
+  /** Attach another source via LEFT JOIN. Right-side cols become nullable for subsequent `.where` / `.select`. */
+  def leftJoin[T, RR <: Relation[CR], CR <: Tuple, AR <: String & Singleton](
+    next: T
+  )(using a: AsAliased.Aux[T, RR, CR, AR]): IncompleteJoin[Ss, RR, CR, NullableCols[CR], AR] = {
+    val ar           = a(next)
+    val origCols     = ar.relation.columns.asInstanceOf[CR]
+    val effectiveCls = nullabilifyCols(origCols).asInstanceOf[NullableCols[CR]]
+    new IncompleteJoin[Ss, RR, CR, NullableCols[CR], AR](
+      sources,
+      ar.relation,
+      ar.alias,
+      origCols,
+      effectiveCls,
+      JoinKind.Left
+    )
+  }
+
+  /** Attach another source via CROSS JOIN. No `.on(...)` required. */
+  def crossJoin[T, RR <: Relation[CR], CR <: Tuple, AR <: String & Singleton](
+    next: T
+  )(using a: AsAliased.Aux[T, RR, CR, AR]): SelectBuilder[Tuple.Append[Ss, SourceEntry[RR, CR, CR, AR]]] = {
+    val ar    = a(next)
+    val cols  = ar.relation.columns.asInstanceOf[CR]
+    val entry = new SourceEntry[RR, CR, CR, AR](ar.relation, ar.alias, cols, cols, JoinKind.Cross, None)
+    val next2 = (sources :* entry).asInstanceOf[Tuple.Append[Ss, SourceEntry[RR, CR, CR, AR]]]
+    new SelectBuilder[Tuple.Append[Ss, SourceEntry[RR, CR, CR, AR]]](
+      next2,
       distinct,
       whereOpt,
       groupBys,
@@ -69,101 +143,20 @@ final class SelectBuilder[R <: Relation[Cols], Cols <: Tuple] private[sharp] (
       offsetOpt,
       lockingOpt
     )
-
-  def where(f: ColumnsView[Cols] => Where): SelectBuilder[R, Cols] = {
-    val view = ColumnsView(relation.columns)
-    val next = whereOpt match {
-      case Some(existing) => existing && f(view)
-      case None           => f(view)
-    }
-    copy(whereOpt = Some(next))
   }
 
-  def orderBy(f: ColumnsView[Cols] => OrderBy | Tuple): SelectBuilder[R, Cols] = {
-    val view  = ColumnsView(relation.columns)
-    val fresh = f(view) match {
-      case ob: OrderBy => List(ob)
-      case t: Tuple    => t.toList.asInstanceOf[List[OrderBy]]
-    }
-    copy(orderBys = orderBys ++ fresh)
-  }
+  // ---- Projection -------------------------------------------------------------------------------
 
   /**
-   * `GROUP BY expr1, expr2, …`. Pass a single expression or a tuple. Does **not** validate at compile time that every
-   * bare column in the SELECT is covered — Postgres raises that as a loud runtime error. Aggregates in `Pg.count`,
-   * `Pg.sum`, etc. do not need to appear here.
+   * Projection — pick the columns / expressions to return. Single `TypedExpr[T]` → row is `T`; tuple (named or
+   * positional) → row is the tuple of expression output types.
    */
-  def groupBy(f: ColumnsView[Cols] => TypedExpr[?] | Tuple): SelectBuilder[R, Cols] = {
-    val view  = ColumnsView(relation.columns)
-    val fresh = f(view) match {
-      case e: TypedExpr[?] => List(e)
-      case t: Tuple        => t.toList.asInstanceOf[List[TypedExpr[?]]]
-    }
-    copy(groupBys = groupBys ++ fresh)
-  }
-
-  /** `HAVING <predicate>`. Chains with AND if called multiple times. Typically references aggregates. */
-  def having(f: ColumnsView[Cols] => Where): SelectBuilder[R, Cols] = {
-    val view = ColumnsView(relation.columns)
-    val next = havingOpt match {
-      case Some(existing) => existing && f(view)
-      case None           => f(view)
-    }
-    copy(havingOpt = Some(next))
-  }
-
-  def limit(n: Int): SelectBuilder[R, Cols]  = copy(limitOpt = Some(n))
-  def offset(n: Int): SelectBuilder[R, Cols] = copy(offsetOpt = Some(n))
-
-  /** Apply `SELECT DISTINCT …`. */
-  def distinctRows: SelectBuilder[R, Cols] = copy(distinct = true)
-
-  // ---- Postgres row-level locking (SELECT … FOR UPDATE etc.) ----
-  // Gated on `R <:< Table[Cols, ?]` — `SELECT … FOR UPDATE` against a view is a Postgres error.
-
-  /**
-   * `FOR UPDATE` — exclusive row lock. Use `.noWait` / `.skipLocked` on the resulting builder to tweak the wait policy.
-   * Only available when the underlying relation is a [[Table]]: views reject at compile time.
-   */
-  def forUpdate(using ev: R <:< Table[Cols, ?]): SelectBuilder[R, Cols] =
-    copy(lockingOpt = Some(Locking(LockMode.ForUpdate)))
-
-  /** `FOR NO KEY UPDATE` — exclusive but weaker; allows foreign-key checks to proceed. */
-  def forNoKeyUpdate(using ev: R <:< Table[Cols, ?]): SelectBuilder[R, Cols] =
-    copy(lockingOpt = Some(Locking(LockMode.ForNoKeyUpdate)))
-
-  /** `FOR SHARE` — shared row lock. */
-  def forShare(using ev: R <:< Table[Cols, ?]): SelectBuilder[R, Cols] =
-    copy(lockingOpt = Some(Locking(LockMode.ForShare)))
-
-  /** `FOR KEY SHARE` — weakest shared lock, blocks only DELETE and some UPDATEs. */
-  def forKeyShare(using ev: R <:< Table[Cols, ?]): SelectBuilder[R, Cols] =
-    copy(lockingOpt = Some(Locking(LockMode.ForKeyShare)))
-
-  /** Append ` SKIP LOCKED` — skip rows that are already locked (useful for queue-style consumers). */
-  def skipLocked(using ev: R <:< Table[Cols, ?]): SelectBuilder[R, Cols] =
-    copy(lockingOpt = lockingOpt.map(_.copy(waitPolicy = WaitPolicy.SkipLocked)))
-
-  /** Append ` NOWAIT` — fail immediately if any target row is already locked. */
-  def noWait(using ev: R <:< Table[Cols, ?]): SelectBuilder[R, Cols] =
-    copy(lockingOpt = lockingOpt.map(_.copy(waitPolicy = WaitPolicy.NoWait)))
-
-  /**
-   * Projection. Accepts either a single `TypedExpr[T]` (row shape is `T`) or a non-empty tuple of `TypedExpr`s (row
-   * shape is a tuple of the expressions' output types).
-   *
-   * {{{
-   *   select.from(users)(u => u.email)                // ProjectedSelect[String]
-   *   select.from(users)(u => Pg.lower(u.email))      // ProjectedSelect[String]
-   *   select.from(users)(u => (u.email, u.age))       // ProjectedSelect[(String, Int)]
-   * }}}
-   */
-  transparent inline def apply[X](inline f: ColumnsView[Cols] => X): ProjectedSelect[R, Cols, ProjResult[X]] = {
-    val view = ColumnsView(relation.columns)
-    f(view) match {
+  transparent inline def select[X](inline f: SelectView[Ss] => X): ProjectedSelect[Ss, ProjResult[X]] = {
+    val v = view
+    f(v) match {
       case expr: TypedExpr[?] =>
-        new ProjectedSelect[R, Cols, ProjResult[X]](
-          relation,
+        new ProjectedSelect[Ss, ProjResult[X]](
+          sources,
           distinct,
           List(expr),
           expr.codec.asInstanceOf[Codec[ProjResult[X]]],
@@ -178,8 +171,8 @@ final class SelectBuilder[R <: Relation[Cols], Cols <: Tuple] private[sharp] (
       case tup: NonEmptyTuple =>
         val exprs = tup.toList.asInstanceOf[List[TypedExpr[?]]]
         val codec = tupleCodec(exprs.map(_.codec)).asInstanceOf[Codec[ProjResult[X]]]
-        new ProjectedSelect[R, Cols, ProjResult[X]](
-          relation,
+        new ProjectedSelect[Ss, ProjResult[X]](
+          sources,
           distinct,
           exprs,
           codec,
@@ -194,60 +187,48 @@ final class SelectBuilder[R <: Relation[Cols], Cols <: Tuple] private[sharp] (
     }
   }
 
-  // `.cols(("id", "email"))` name-based projection lives on the roadmap (v0.1+). Passing a regular tuple literal
-  // widens its elements to `String`, so the singleton information needed to look up `ColumnType[Cols, "id"]` is lost
-  // at the call site. Options to revisit: (a) a quoted macro that reads the literal string values at compile time;
-  // (b) an explicit type parameter — `.cols[("id","email")](("id","email"))`; (c) wait for twiddles-backed tuple
-  // ergonomics. Until then, use the function form: `select.from(users)(u => (u.id, u.email))`.
+  transparent inline def apply[X](inline f: SelectView[Ss] => X): ProjectedSelect[Ss, ProjResult[X]] = select[X](f)
 
   /**
-   * Compile the default whole-row SELECT into a [[CompiledQuery]]. Use the extensions in [[Compiled]] to execute it.
+   * Whole-row `.compile` — only available on single-source builders. Multi-source builders must project first via
+   * `.select(f)`.
    */
-  def compile: CompiledQuery[NamedRowOf[Cols]] = {
-    val cols        = relation.columns.toList.asInstanceOf[List[Column[?, ?, ?, ?]]]
-    val projections = cols.map(c => s""""${c.name}"""").mkString(", ")
-    val keyword     = if (distinct) "SELECT DISTINCT " else "SELECT "
-    val sqlHeader   =
-      if (relation.hasFromClause) s"$keyword$projections FROM ${relation.qualifiedName}"
-      else s"$keyword$projections"
-    val header    = TypedExpr.raw(sqlHeader)
-    val withWhere = whereOpt.fold(header)(w => header |+| TypedExpr.raw(" WHERE ") |+| w.render)
-    val withGroup =
-      if (groupBys.isEmpty) withWhere
-      else withWhere |+| TypedExpr.raw(" GROUP BY ") |+| TypedExpr.joined(groupBys.map(_.render), ", ")
-    val withHaving = havingOpt.fold(withGroup)(h => withGroup |+| TypedExpr.raw(" HAVING ") |+| h.render)
-    val withOrder  =
-      if (orderBys.isEmpty) withHaving
-      else withHaving |+| TypedExpr.raw(" ORDER BY " + orderBys.map(_.sql).mkString(", "))
-    val withLimit   = limitOpt.fold(withOrder)(n => withOrder |+| TypedExpr.raw(s" LIMIT $n"))
-    val withOffset  = offsetOpt.fold(withLimit)(n => withLimit |+| TypedExpr.raw(s" OFFSET $n"))
-    val withLocking = lockingOpt.fold(withOffset)(l => withOffset |+| TypedExpr.raw(" " + l.sql))
-    CompiledQuery(withLocking, rowCodec(relation.columns).asInstanceOf[Codec[NamedRowOf[Cols]]])
+  def compile(using ev: IsSingleSource[Ss]): CompiledQuery[NamedRowOf[ev.Cols]] = {
+    val entries = sources.toList.asInstanceOf[List[SourceEntry[?, ?, ?, ?]]]
+    val head    = entries.head
+    val cols    = head.effectiveCols.toList.asInstanceOf[List[Column[?, ?, ?, ?]]]
+    val projStr = cols.map(c => s""""${c.name}"""").mkString(", ")
+    val keyword = if (distinct) "SELECT DISTINCT " else "SELECT "
+    val header =
+      if (head.relation.hasFromClause)
+        TypedExpr.raw(s"$keyword$projStr FROM ${aliasedFromEntry(head)}")
+      else
+        TypedExpr.raw(s"$keyword$projStr")
+    val withClauses = renderClauses(header, whereOpt, groupBys, havingOpt, orderBys, limitOpt, offsetOpt, lockingOpt)
+    CompiledQuery(withClauses, rowCodec(head.effectiveCols).asInstanceOf[Codec[NamedRowOf[ev.Cols]]])
   }
 
 }
 
 /**
- * A SELECT with an explicit projection list — rows have shape `Row` instead of the relation's default named tuple. The
- * relation type parameter `R` is carried through so locking methods (`.forUpdate`, `.forShare`, …) remain gated to
- * `Table` (rejected at compile time on a `View`).
+ * A SELECT with an explicit projection list — rows have shape `Row` instead of the relation's default named tuple.
+ * Shared between single-source and multi-source queries; the `Ss` parameter carries the full shape.
  */
-final class ProjectedSelect[R <: Relation[Cols], Cols <: Tuple, Row](
-  relation: R,
-  distinct: Boolean,
-  projections: List[TypedExpr[?]],
-  codec: Codec[Row],
-  whereOpt: Option[Where],
-  groupBys: List[TypedExpr[?]],
-  havingOpt: Option[Where],
-  orderBys: List[OrderBy],
-  limitOpt: Option[Int],
-  offsetOpt: Option[Int],
-  lockingOpt: Option[Locking] = None
+final class ProjectedSelect[Ss <: Tuple, Row](
+  private[sharp] val sources: Ss,
+  private[sharp] val distinct: Boolean,
+  private[sharp] val projections: List[TypedExpr[?]],
+  private[sharp] val codec: Codec[Row],
+  private[sharp] val whereOpt: Option[Where],
+  private[sharp] val groupBys: List[TypedExpr[?]],
+  private[sharp] val havingOpt: Option[Where],
+  private[sharp] val orderBys: List[OrderBy],
+  private[sharp] val limitOpt: Option[Int],
+  private[sharp] val offsetOpt: Option[Int],
+  private[sharp] val lockingOpt: Option[Locking] = None
 ) {
 
   private def copy(
-    relation: R = relation,
     distinct: Boolean = distinct,
     projections: List[TypedExpr[?]] = projections,
     codec: Codec[Row] = codec,
@@ -258,9 +239,9 @@ final class ProjectedSelect[R <: Relation[Cols], Cols <: Tuple, Row](
     limitOpt: Option[Int] = limitOpt,
     offsetOpt: Option[Int] = offsetOpt,
     lockingOpt: Option[Locking] = lockingOpt
-  ): ProjectedSelect[R, Cols, Row] =
-    new ProjectedSelect[R, Cols, Row](
-      relation,
+  ): ProjectedSelect[Ss, Row] =
+    new ProjectedSelect[Ss, Row](
+      sources,
       distinct,
       projections,
       codec,
@@ -273,22 +254,14 @@ final class ProjectedSelect[R <: Relation[Cols], Cols <: Tuple, Row](
       lockingOpt
     )
 
-  /**
-   * `WHERE <predicate>`. Chains with AND if called multiple times. Works equally before or after projecting via
-   * [[SelectBuilder.apply]] — users can write `users.select(f).where(p)` in natural SQL order.
-   */
-  def where(f: ColumnsView[Cols] => Where): ProjectedSelect[R, Cols, Row] = {
-    val view = ColumnsView(relation.columns)
-    val next = whereOpt match {
-      case Some(existing) => existing && f(view)
-      case None           => f(view)
-    }
+  private def view: SelectView[Ss] = buildSelectView[Ss](sources)
+
+  def where(f: SelectView[Ss] => Where): ProjectedSelect[Ss, Row] = {
+    val next = whereOpt.fold(f(view))(_ && f(view))
     copy(whereOpt = Some(next))
   }
 
-  /** `ORDER BY …`. Accepts a single `OrderBy` or a tuple. */
-  def orderBy(f: ColumnsView[Cols] => OrderBy | Tuple): ProjectedSelect[R, Cols, Row] = {
-    val view  = ColumnsView(relation.columns)
+  def orderBy(f: SelectView[Ss] => OrderBy | Tuple): ProjectedSelect[Ss, Row] = {
     val fresh = f(view) match {
       case ob: OrderBy => List(ob)
       case t: Tuple    => t.toList.asInstanceOf[List[OrderBy]]
@@ -296,15 +269,7 @@ final class ProjectedSelect[R <: Relation[Cols], Cols <: Tuple, Row](
     copy(orderBys = orderBys ++ fresh)
   }
 
-  def limit(n: Int): ProjectedSelect[R, Cols, Row]  = copy(limitOpt = Some(n))
-  def offset(n: Int): ProjectedSelect[R, Cols, Row] = copy(offsetOpt = Some(n))
-
-  /** `SELECT DISTINCT …`. */
-  def distinctRows: ProjectedSelect[R, Cols, Row] = copy(distinct = true)
-
-  /** `GROUP BY expr1, expr2, …`. See [[SelectBuilder.groupBy]] for details. */
-  def groupBy(f: ColumnsView[Cols] => TypedExpr[?] | Tuple): ProjectedSelect[R, Cols, Row] = {
-    val view  = ColumnsView(relation.columns)
+  def groupBy(f: SelectView[Ss] => TypedExpr[?] | Tuple): ProjectedSelect[Ss, Row] = {
     val fresh = f(view) match {
       case e: TypedExpr[?] => List(e)
       case t: Tuple        => t.toList.asInstanceOf[List[TypedExpr[?]]]
@@ -312,51 +277,41 @@ final class ProjectedSelect[R <: Relation[Cols], Cols <: Tuple, Row](
     copy(groupBys = groupBys ++ fresh)
   }
 
-  /** `HAVING <predicate>`. Chains with AND if called multiple times. */
-  def having(f: ColumnsView[Cols] => Where): ProjectedSelect[R, Cols, Row] = {
-    val view = ColumnsView(relation.columns)
-    val next = havingOpt match {
-      case Some(existing) => existing && f(view)
-      case None           => f(view)
-    }
+  def having(f: SelectView[Ss] => Where): ProjectedSelect[Ss, Row] = {
+    val next = havingOpt.fold(f(view))(_ && f(view))
     copy(havingOpt = Some(next))
   }
 
-  // ---- Row-level locking: gated on R <:< Table[Cols, ?]. ----
-  def forUpdate(using ev: R <:< Table[Cols, ?]): ProjectedSelect[R, Cols, Row] =
+  def limit(n: Int): ProjectedSelect[Ss, Row]  = copy(limitOpt = Some(n))
+  def offset(n: Int): ProjectedSelect[Ss, Row] = copy(offsetOpt = Some(n))
+
+  def distinctRows: ProjectedSelect[Ss, Row] = copy(distinct = true)
+
+  def forUpdate(using ev: IsSingleTable[Ss]): ProjectedSelect[Ss, Row] =
     copy(lockingOpt = Some(Locking(LockMode.ForUpdate)))
-
-  def forNoKeyUpdate(using ev: R <:< Table[Cols, ?]): ProjectedSelect[R, Cols, Row] =
+  def forNoKeyUpdate(using ev: IsSingleTable[Ss]): ProjectedSelect[Ss, Row] =
     copy(lockingOpt = Some(Locking(LockMode.ForNoKeyUpdate)))
-
-  def forShare(using ev: R <:< Table[Cols, ?]): ProjectedSelect[R, Cols, Row] =
+  def forShare(using ev: IsSingleTable[Ss]): ProjectedSelect[Ss, Row] =
     copy(lockingOpt = Some(Locking(LockMode.ForShare)))
-
-  def forKeyShare(using ev: R <:< Table[Cols, ?]): ProjectedSelect[R, Cols, Row] =
+  def forKeyShare(using ev: IsSingleTable[Ss]): ProjectedSelect[Ss, Row] =
     copy(lockingOpt = Some(Locking(LockMode.ForKeyShare)))
-
-  def skipLocked(using ev: R <:< Table[Cols, ?]): ProjectedSelect[R, Cols, Row] =
+  def skipLocked(using ev: IsSingleTable[Ss]): ProjectedSelect[Ss, Row] =
     copy(lockingOpt = lockingOpt.map(_.copy(waitPolicy = WaitPolicy.SkipLocked)))
-
-  def noWait(using ev: R <:< Table[Cols, ?]): ProjectedSelect[R, Cols, Row] =
+  def noWait(using ev: IsSingleTable[Ss]): ProjectedSelect[Ss, Row] =
     copy(lockingOpt = lockingOpt.map(_.copy(waitPolicy = WaitPolicy.NoWait)))
 
   /**
-   * Lift result rows into a case class `T`. Purely about decoding — the SQL is unchanged. `Row` must already be a tuple
-   * whose element types line up with `T`'s fields (verified at compile time via `Mirror.ProductOf`).
-   *
-   * Named `.to` rather than `.as` to keep a clean separation from [[TypedExpr.as]], which renames a column in the
-   * emitted SQL (`<expr> AS "<label>"`). `.as` operates on one expression and changes rendering; `.to` operates on the
-   * whole row and changes decoding.
+   * Lift result rows into a case class `T`. Pure decoder transformation — SQL is unchanged. `Row` must be a tuple
+   * whose element types align with `T`'s fields.
    */
   def to[T <: Product](using
     m: scala.deriving.Mirror.ProductOf[T] { type MirroredElemTypes = Row & Tuple }
-  ): ProjectedSelect[R, Cols, T] = {
+  ): ProjectedSelect[Ss, T] = {
     val newCodec: Codec[T] = codec.imap[T](r => m.fromProduct(r.asInstanceOf[Product]))(t =>
       Tuple.fromProductTyped[T](t)(using m).asInstanceOf[Row]
     )
-    new ProjectedSelect[R, Cols, T](
-      relation,
+    new ProjectedSelect[Ss, T](
+      sources,
       distinct,
       projections,
       newCodec,
@@ -371,55 +326,160 @@ final class ProjectedSelect[R <: Relation[Cols], Cols <: Tuple, Row](
   }
 
   def compile: CompiledQuery[Row] = {
+    val entries  = sources.toList.asInstanceOf[List[SourceEntry[?, ?, ?, ?]]]
     val projList = TypedExpr.joined(projections.map(_.render), ", ")
     val keyword  = if (distinct) "SELECT DISTINCT " else "SELECT "
     val header   =
-      if (relation.hasFromClause)
-        TypedExpr.raw(keyword) |+| projList |+| TypedExpr.raw(s" FROM ${relation.qualifiedName}")
-      else
+      if (entries.isEmpty || !entries.head.relation.hasFromClause)
         TypedExpr.raw(keyword) |+| projList
-    val withWhere = whereOpt.fold(header)(w => header |+| TypedExpr.raw(" WHERE ") |+| w.render)
-    val withGroup =
-      if (groupBys.isEmpty) withWhere
-      else withWhere |+| TypedExpr.raw(" GROUP BY ") |+| TypedExpr.joined(groupBys.map(_.render), ", ")
-    val withHaving = havingOpt.fold(withGroup)(h => withGroup |+| TypedExpr.raw(" HAVING ") |+| h.render)
-    val withOrder  =
-      if (orderBys.isEmpty) withHaving
-      else withHaving |+| TypedExpr.raw(" ORDER BY " + orderBys.map(_.sql).mkString(", "))
-    val withLimit   = limitOpt.fold(withOrder)(n => withOrder |+| TypedExpr.raw(s" LIMIT $n"))
-    val withOffset  = offsetOpt.fold(withLimit)(n => withLimit |+| TypedExpr.raw(s" OFFSET $n"))
-    val withLocking = lockingOpt.fold(withOffset)(l => withOffset |+| TypedExpr.raw(" " + l.sql))
-    CompiledQuery(withLocking, codec)
+      else {
+        val head       = entries.head
+        val headFrag   = TypedExpr.raw(keyword) |+| projList |+| TypedExpr.raw(s" FROM ${aliasedFromEntry(head)}")
+        entries.tail.foldLeft(headFrag) { (acc, s) =>
+          val fromFrag = TypedExpr.raw(s" ${s.kind.sql} ${aliasedFromEntry(s)}")
+          s.onPredOpt.fold(acc |+| fromFrag)(p => acc |+| fromFrag |+| TypedExpr.raw(" ON ") |+| p.render)
+        }
+      }
+    val withClauses = renderClauses(header, whereOpt, groupBys, havingOpt, orderBys, limitOpt, offsetOpt, lockingOpt)
+    CompiledQuery(withClauses, codec)
   }
 
 }
 
-/**
- * Start a SELECT query: `users.select`. Extension lives on [[Relation]], so both [[Table]] and [[View]] work.
- *
- *   - `users.select` → `SelectBuilder[Cols]` (whole row); chain `.where`, `.orderBy`, `.limit`, `.offset`,
- *     `.distinctRows`, `.forUpdate` / `.forShare` / `.forNoKeyUpdate` / `.forKeyShare` (+ `.skipLocked` / `.noWait`),
- *     or call `.apply(u => …)` to narrow to a projection.
- *   - `empty.select(_ => Pg.now)` → FROM-less query via the dedicated `empty` relation.
- *
- * Multi-table JOINs will need a dedicated entry (roadmap).
- */
-extension [R <: Relation[Cols], Cols <: Tuple](relation: R) {
+// ---- Shared render helper ---------------------------------------------------------------------
 
-  def select: SelectBuilder[R, Cols] =
-    new SelectBuilder[R, Cols](
-      relation,
-      distinct = false,
-      whereOpt = None,
-      groupBys = Nil,
-      havingOpt = None,
-      orderBys = Nil,
-      limitOpt = None,
-      offsetOpt = None,
-      lockingOpt = None
-    )
-
+private[dsl] def renderClauses(
+  header: skunk.AppliedFragment,
+  whereOpt: Option[Where],
+  groupBys: List[TypedExpr[?]],
+  havingOpt: Option[Where],
+  orderBys: List[OrderBy],
+  limitOpt: Option[Int],
+  offsetOpt: Option[Int],
+  lockingOpt: Option[Locking]
+): skunk.AppliedFragment = {
+  val withWhere = whereOpt.fold(header)(w => header |+| TypedExpr.raw(" WHERE ") |+| w.render)
+  val withGroup =
+    if (groupBys.isEmpty) withWhere
+    else withWhere |+| TypedExpr.raw(" GROUP BY ") |+| TypedExpr.joined(groupBys.map(_.render), ", ")
+  val withHaving = havingOpt.fold(withGroup)(h => withGroup |+| TypedExpr.raw(" HAVING ") |+| h.render)
+  val withOrder =
+    if (orderBys.isEmpty) withHaving
+    else withHaving |+| TypedExpr.raw(" ORDER BY " + orderBys.map(_.sql).mkString(", "))
+  val withLimit  = limitOpt.fold(withOrder)(n => withOrder |+| TypedExpr.raw(s" LIMIT $n"))
+  val withOffset = offsetOpt.fold(withLimit)(n => withLimit |+| TypedExpr.raw(s" OFFSET $n"))
+  lockingOpt.fold(withOffset)(l => withOffset |+| TypedExpr.raw(" " + l.sql))
 }
+
+// ---- Entry points -----------------------------------------------------------------------------
+
+/**
+ * `.select` on any relation-like value — bare `Table` / `View` (auto-aliased to its own name) or an already-aliased
+ * `AliasedRelation`. Produces a single-source [[SelectBuilder]], from which `.where` / `.select(f)` / `.innerJoin`
+ * etc. can be called.
+ */
+extension [L, RL <: Relation[CL], CL <: Tuple, AL <: String & Singleton](left: L)(using
+  aL: AsAliased.Aux[L, RL, CL, AL]
+) {
+  def select: SelectBuilder[SourceEntry[RL, CL, CL, AL] *: EmptyTuple] = {
+    val entry = makeBaseEntry[L, RL, CL, AL](aL, left)
+    new SelectBuilder[SourceEntry[RL, CL, CL, AL] *: EmptyTuple](entry *: EmptyTuple)
+  }
+}
+
+/**
+ * `empty.select(f)` — FROM-less SELECT, e.g. `empty.select(_ => Pg.now)` → `SELECT now()`. Lives separately from the
+ * main `.select` extension because `empty` has no alias / Name, so it can't flow through the `AsAliased` machinery.
+ */
+extension (rel: skunk.sharp.empty.type) {
+  transparent inline def select[X](inline f: ColumnsView[EmptyTuple] => X): ProjectedSelect[EmptyTuple, ProjResult[X]] = {
+    val v = ColumnsView(EmptyTuple)
+    f(v) match {
+      case expr: TypedExpr[?] =>
+        new ProjectedSelect[EmptyTuple, ProjResult[X]](
+          EmptyTuple,
+          false,
+          List(expr),
+          expr.codec.asInstanceOf[Codec[ProjResult[X]]],
+          None,
+          Nil,
+          None,
+          Nil,
+          None,
+          None,
+          None
+        )
+      case tup: NonEmptyTuple =>
+        val exprs = tup.toList.asInstanceOf[List[TypedExpr[?]]]
+        val codec = tupleCodec(exprs.map(_.codec)).asInstanceOf[Codec[ProjResult[X]]]
+        new ProjectedSelect[EmptyTuple, ProjResult[X]](
+          EmptyTuple,
+          false,
+          exprs,
+          codec,
+          None,
+          Nil,
+          None,
+          Nil,
+          None,
+          None,
+          None
+        )
+    }
+  }
+}
+
+// ---- Match type: view receiver for lambdas -----------------------------------------------------
+
+/**
+ * The view type that `.where` / `.select` / `.orderBy` / `.groupBy` / `.having` receive. For a single source, this
+ * reduces to `ColumnsView[Cols]` — the user writes `u.email`. For 2+ sources, it reduces to `JoinedView[Ss]` — the
+ * user writes `r.users.email`.
+ *
+ * Pattern-matches the concrete `SourceEntry[?, ?, c, ?] *: EmptyTuple` shape directly in the first arm so the
+ * reduction fires at call sites without needing extra evidence.
+ */
+type SelectView[Ss <: Tuple] = Ss match {
+  case SourceEntry[?, ?, c, ?] *: EmptyTuple => ColumnsView[c]
+  case _                                     => JoinedView[Ss]
+}
+
+private[sharp] def buildSelectView[Ss <: Tuple](sources: Ss): SelectView[Ss] =
+  sources.toList.asInstanceOf[List[SourceEntry[?, ?, ?, ?]]] match {
+    // Single source: bare column names in WHERE/ORDER BY (matches the pre-unification SelectBuilder behaviour and
+    // avoids redundant qualifiers when there's only one source to qualify against).
+    case single :: Nil => ColumnsView(single.effectiveCols).asInstanceOf[SelectView[Ss]]
+    case _             => buildJoinedView[Ss](sources).asInstanceOf[SelectView[Ss]]
+  }
+
+// ---- Evidence typeclasses ----------------------------------------------------------------------
+
+/**
+ * Evidence that `Ss` is a single source anchored at a [[Table]] — the only shape where Postgres allows
+ * `SELECT … FOR UPDATE` and the other row-level locks.
+ */
+sealed trait IsSingleTable[Ss]
+object IsSingleTable {
+  given [Cols <: Tuple, N <: String & Singleton, A <: String & Singleton]
+    : IsSingleTable[SourceEntry[Table[Cols, N], Cols, Cols, A] *: EmptyTuple] =
+    new IsSingleTable[SourceEntry[Table[Cols, N], Cols, Cols, A] *: EmptyTuple] {}
+}
+
+/**
+ * Evidence that `Ss` has exactly one source, of any kind (Table or View). Required for the whole-row default
+ * `.compile` — multi-source builders must project first.
+ */
+sealed trait IsSingleSource[Ss] {
+  type Cols <: Tuple
+}
+object IsSingleSource {
+  type Aux[Ss, C] = IsSingleSource[Ss] { type Cols = C }
+  given [RR <: Relation[C], C <: Tuple, A <: String & Singleton]
+    : IsSingleSource.Aux[SourceEntry[RR, C, C, A] *: EmptyTuple, C] =
+    new IsSingleSource[SourceEntry[RR, C, C, A] *: EmptyTuple] { type Cols = C }
+}
+
+// ---- Locking enums + OrderBy + projection helpers ---------------------------------------------
 
 /** Postgres row-level locking mode. */
 enum LockMode(val sql: String) {
@@ -446,37 +506,21 @@ type ExprOutputs[T <: Tuple] <: Tuple = T match {
   case TypedExpr[t] *: tail => t *: ExprOutputs[tail]
 }
 
-/**
- * Input-shape-aware projection result.
- *
- *   - Single `TypedExpr[T]` → `T`.
- *   - Tuple (named or plain) of `TypedExpr`s → plain tuple of their output types.
- *
- * If you need a named result shape, pipe through `.to[MyCaseClass]` (see [[ProjectedSelect.to]]) to lift the decoded
- * tuple into a case class.
- *
- * Synthesising a named-tuple Row shape that mixes bare columns (whose singleton names we could track) with
- * `AliasedExpr[T, N]` elements is a roadmap item — the `AliasedExpr.N` singleton gives us the piece we were missing,
- * and the twiddles tuple library (or Scala 3's own tuple ops) can assemble the names tuple + values tuple into a
- * `NamedTuple[Ns, Vs]` at the type level. The challenge is side-stepping the match-type soundness issue that blocks the
- * naive `X match { case NamedTuple.AnyNamedTuple => … }` arm (opaque-type semantics leave a plain tuple
- * indistinguishable from a named tuple to the prover). To revisit with JOINs and the GROUP-BY compile-time check.
- */
+/** Input-shape-aware projection result — single `TypedExpr[T]` → `T`, tuple → tuple of output types. */
 type ProjResult[X] = X match {
   case TypedExpr[t]  => t
   case NonEmptyTuple => ExprOutputs[X & NonEmptyTuple]
 }
 
-/** Type-level lookup: for a tuple of column names `Names`, the tuple of their Scala value types from `Cols`. */
+/** Type-level lookup: tuple of column names → tuple of value types. */
 type LookupTypes[Cols <: Tuple, Names <: Tuple] <: Tuple = Names match {
   case EmptyTuple => EmptyTuple
   case n *: rest  => ColumnType[Cols, n & String & Singleton] *: LookupTypes[Cols, rest]
 }
 
 /**
- * ORDER BY clause. Produced by `.asc` / `.desc` on a [[TypedColumn]]. Chain `.nullsFirst` / `.nullsLast` on an
- * `OrderBy` to control where NULL values land — useful on nullable columns where Postgres's default (`NULLS LAST` for
- * ASC, `NULLS FIRST` for DESC) doesn't match what you want.
+ * ORDER BY clause — produced by `.asc` / `.desc` on a [[TypedColumn]]. Chain `.nullsFirst` / `.nullsLast` to control
+ * where NULLs land.
  */
 final case class OrderBy(sql: String) {
   def nullsFirst: OrderBy = OrderBy(sql + " NULLS FIRST")

--- a/modules/core/src/main/scala/skunk/sharp/dsl/Select.scala
+++ b/modules/core/src/main/scala/skunk/sharp/dsl/Select.scala
@@ -3,7 +3,7 @@ package skunk.sharp.dsl
 import skunk.Codec
 import skunk.sharp.*
 import skunk.sharp.internal.{rowCodec, tupleCodec}
-import skunk.sharp.where.{Where, &&}
+import skunk.sharp.where.{&&, Where}
 
 /**
  * Unified SELECT builder — one class for single-source, JOINed, or CROSS-joined queries. Every lambda-taking method
@@ -199,7 +199,7 @@ final class SelectBuilder[Ss <: Tuple] private[sharp] (
     val cols    = head.effectiveCols.toList.asInstanceOf[List[Column[?, ?, ?, ?]]]
     val projStr = cols.map(c => s""""${c.name}"""").mkString(", ")
     val keyword = if (distinct) "SELECT DISTINCT " else "SELECT "
-    val header =
+    val header  =
       if (head.relation.hasFromClause)
         TypedExpr.raw(s"$keyword$projStr FROM ${aliasedFromEntry(head)}")
       else
@@ -289,20 +289,25 @@ final class ProjectedSelect[Ss <: Tuple, Row](
 
   def forUpdate(using ev: IsSingleTable[Ss]): ProjectedSelect[Ss, Row] =
     copy(lockingOpt = Some(Locking(LockMode.ForUpdate)))
+
   def forNoKeyUpdate(using ev: IsSingleTable[Ss]): ProjectedSelect[Ss, Row] =
     copy(lockingOpt = Some(Locking(LockMode.ForNoKeyUpdate)))
+
   def forShare(using ev: IsSingleTable[Ss]): ProjectedSelect[Ss, Row] =
     copy(lockingOpt = Some(Locking(LockMode.ForShare)))
+
   def forKeyShare(using ev: IsSingleTable[Ss]): ProjectedSelect[Ss, Row] =
     copy(lockingOpt = Some(Locking(LockMode.ForKeyShare)))
+
   def skipLocked(using ev: IsSingleTable[Ss]): ProjectedSelect[Ss, Row] =
     copy(lockingOpt = lockingOpt.map(_.copy(waitPolicy = WaitPolicy.SkipLocked)))
+
   def noWait(using ev: IsSingleTable[Ss]): ProjectedSelect[Ss, Row] =
     copy(lockingOpt = lockingOpt.map(_.copy(waitPolicy = WaitPolicy.NoWait)))
 
   /**
-   * Lift result rows into a case class `T`. Pure decoder transformation — SQL is unchanged. `Row` must be a tuple
-   * whose element types align with `T`'s fields.
+   * Lift result rows into a case class `T`. Pure decoder transformation — SQL is unchanged. `Row` must be a tuple whose
+   * element types align with `T`'s fields.
    */
   def to[T <: Product](using
     m: scala.deriving.Mirror.ProductOf[T] { type MirroredElemTypes = Row & Tuple }
@@ -333,8 +338,8 @@ final class ProjectedSelect[Ss <: Tuple, Row](
       if (entries.isEmpty || !entries.head.relation.hasFromClause)
         TypedExpr.raw(keyword) |+| projList
       else {
-        val head       = entries.head
-        val headFrag   = TypedExpr.raw(keyword) |+| projList |+| TypedExpr.raw(s" FROM ${aliasedFromEntry(head)}")
+        val head     = entries.head
+        val headFrag = TypedExpr.raw(keyword) |+| projList |+| TypedExpr.raw(s" FROM ${aliasedFromEntry(head)}")
         entries.tail.foldLeft(headFrag) { (acc, s) =>
           val fromFrag = TypedExpr.raw(s" ${s.kind.sql} ${aliasedFromEntry(s)}")
           s.onPredOpt.fold(acc |+| fromFrag)(p => acc |+| fromFrag |+| TypedExpr.raw(" ON ") |+| p.render)
@@ -363,7 +368,7 @@ private[dsl] def renderClauses(
     if (groupBys.isEmpty) withWhere
     else withWhere |+| TypedExpr.raw(" GROUP BY ") |+| TypedExpr.joined(groupBys.map(_.render), ", ")
   val withHaving = havingOpt.fold(withGroup)(h => withGroup |+| TypedExpr.raw(" HAVING ") |+| h.render)
-  val withOrder =
+  val withOrder  =
     if (orderBys.isEmpty) withHaving
     else withHaving |+| TypedExpr.raw(" ORDER BY " + orderBys.map(_.sql).mkString(", "))
   val withLimit  = limitOpt.fold(withOrder)(n => withOrder |+| TypedExpr.raw(s" LIMIT $n"))
@@ -375,16 +380,18 @@ private[dsl] def renderClauses(
 
 /**
  * `.select` on any relation-like value — bare `Table` / `View` (auto-aliased to its own name) or an already-aliased
- * `AliasedRelation`. Produces a single-source [[SelectBuilder]], from which `.where` / `.select(f)` / `.innerJoin`
- * etc. can be called.
+ * `AliasedRelation`. Produces a single-source [[SelectBuilder]], from which `.where` / `.select(f)` / `.innerJoin` etc.
+ * can be called.
  */
 extension [L, RL <: Relation[CL], CL <: Tuple, AL <: String & Singleton](left: L)(using
   aL: AsAliased.Aux[L, RL, CL, AL]
 ) {
+
   def select: SelectBuilder[SourceEntry[RL, CL, CL, AL] *: EmptyTuple] = {
     val entry = makeBaseEntry[L, RL, CL, AL](aL, left)
     new SelectBuilder[SourceEntry[RL, CL, CL, AL] *: EmptyTuple](entry *: EmptyTuple)
   }
+
 }
 
 /**
@@ -392,7 +399,9 @@ extension [L, RL <: Relation[CL], CL <: Tuple, AL <: String & Singleton](left: L
  * main `.select` extension because `empty` has no alias / Name, so it can't flow through the `AsAliased` machinery.
  */
 extension (rel: skunk.sharp.empty.type) {
-  transparent inline def select[X](inline f: ColumnsView[EmptyTuple] => X): ProjectedSelect[EmptyTuple, ProjResult[X]] = {
+
+  transparent inline def select[X](inline f: ColumnsView[EmptyTuple] => X)
+    : ProjectedSelect[EmptyTuple, ProjResult[X]] = {
     val v = ColumnsView(EmptyTuple)
     f(v) match {
       case expr: TypedExpr[?] =>
@@ -427,17 +436,18 @@ extension (rel: skunk.sharp.empty.type) {
         )
     }
   }
+
 }
 
 // ---- Match type: view receiver for lambdas -----------------------------------------------------
 
 /**
  * The view type that `.where` / `.select` / `.orderBy` / `.groupBy` / `.having` receive. For a single source, this
- * reduces to `ColumnsView[Cols]` — the user writes `u.email`. For 2+ sources, it reduces to `JoinedView[Ss]` — the
- * user writes `r.users.email`.
+ * reduces to `ColumnsView[Cols]` — the user writes `u.email`. For 2+ sources, it reduces to `JoinedView[Ss]` — the user
+ * writes `r.users.email`.
  *
- * Pattern-matches the concrete `SourceEntry[?, ?, c, ?] *: EmptyTuple` shape directly in the first arm so the
- * reduction fires at call sites without needing extra evidence.
+ * Pattern-matches the concrete `SourceEntry[?, ?, c, ?] *: EmptyTuple` shape directly in the first arm so the reduction
+ * fires at call sites without needing extra evidence.
  */
 type SelectView[Ss <: Tuple] = Ss match {
   case SourceEntry[?, ?, c, ?] *: EmptyTuple => ColumnsView[c]
@@ -465,24 +475,30 @@ private[sharp] def buildSelectView[Ss <: Tuple](sources: Ss): SelectView[Ss] =
  * `SELECT … FOR UPDATE` and the other row-level locks.
  */
 sealed trait IsSingleTable[Ss]
+
 object IsSingleTable {
+
   given [Cols <: Tuple, N <: String & Singleton, A <: String & Singleton]
     : IsSingleTable[SourceEntry[Table[Cols, N], Cols, Cols, A] *: EmptyTuple] =
     new IsSingleTable[SourceEntry[Table[Cols, N], Cols, Cols, A] *: EmptyTuple] {}
+
 }
 
 /**
- * Evidence that `Ss` has exactly one source, of any kind (Table or View). Required for the whole-row default
- * `.compile` — multi-source builders must project first.
+ * Evidence that `Ss` has exactly one source, of any kind (Table or View). Required for the whole-row default `.compile`
+ * — multi-source builders must project first.
  */
 sealed trait IsSingleSource[Ss] {
   type Cols <: Tuple
 }
+
 object IsSingleSource {
   type Aux[Ss, C] = IsSingleSource[Ss] { type Cols = C }
+
   given [RR <: Relation[C], C <: Tuple, A <: String & Singleton]
     : IsSingleSource.Aux[SourceEntry[RR, C, C, A] *: EmptyTuple, C] =
     new IsSingleSource[SourceEntry[RR, C, C, A] *: EmptyTuple] { type Cols = C }
+
 }
 
 // ---- Locking enums + OrderBy + projection helpers ---------------------------------------------

--- a/modules/core/src/main/scala/skunk/sharp/dsl/Update.scala
+++ b/modules/core/src/main/scala/skunk/sharp/dsl/Update.scala
@@ -4,7 +4,7 @@ import skunk.{AppliedFragment, Codec}
 import skunk.sharp.*
 import skunk.sharp.internal.tupleCodec
 import skunk.sharp.pg.PgTypeFor
-import skunk.sharp.where.{Where, &&}
+import skunk.sharp.where.{&&, Where}
 
 /**
  * UPDATE builder — compile-time staged so you can't accidentally run a rowset-nuking `UPDATE` with no WHERE.

--- a/modules/core/src/main/scala/skunk/sharp/dsl/Update.scala
+++ b/modules/core/src/main/scala/skunk/sharp/dsl/Update.scala
@@ -4,7 +4,7 @@ import skunk.{AppliedFragment, Codec}
 import skunk.sharp.*
 import skunk.sharp.internal.tupleCodec
 import skunk.sharp.pg.PgTypeFor
-import skunk.sharp.where.Where
+import skunk.sharp.where.{Where, &&}
 
 /**
  * UPDATE builder — compile-time staged so you can't accidentally run a rowset-nuking `UPDATE` with no WHERE.

--- a/modules/core/src/main/scala/skunk/sharp/dsl/package.scala
+++ b/modules/core/src/main/scala/skunk/sharp/dsl/package.scala
@@ -63,7 +63,7 @@ package object dsl {
   type Where = skunk.sharp.where.Where
   val Where: skunk.sharp.where.Where.type = skunk.sharp.where.Where
 
-  export skunk.sharp.where.{!==, <, <=, ===, ====, >, >=, &&, ||, and, or, not, ilike, in, isNotNull, isNull, like}
+  export skunk.sharp.where.{!==, &&, <, <=, ===, ====, >, >=, ||, and, ilike, in, isNotNull, isNull, like, not, or}
   export skunk.sharp.where.Stripped
 
   // ---- Schema validation ----

--- a/modules/core/src/main/scala/skunk/sharp/dsl/package.scala
+++ b/modules/core/src/main/scala/skunk/sharp/dsl/package.scala
@@ -84,4 +84,15 @@ package object dsl {
   type PgTypeFor[T] = skunk.sharp.pg.PgTypeFor[T]
   val PgTypeFor: skunk.sharp.pg.PgTypeFor.type = skunk.sharp.pg.PgTypeFor
 
+  // ---- Literal shorthands ----
+  //
+  // `lit(1)` / `lit("x")` is the short form of [[skunk.sharp.TypedExpr.lit]]. Anywhere a `TypedExpr[T]` is required
+  // (SELECT projection, UPDATE SET RHS, function arguments, …), `lit(v)` lifts a Scala value into a bound-parameter
+  // expression. Deliberately not an implicit conversion — Scala 3 discourages those and the extra two characters
+  // keep the lifting point explicit for readers.
+  //
+  // WHERE operators (`===`, `!==`, `<`, `<=`, `>`, `>=`, `in`, `like`, `ilike`) already accept raw values directly
+  // on the RHS, so `.where(u => u.age >= 18)` works without `lit`.
+  inline def lit[T](v: T)(using pf: PgTypeFor[T]): skunk.sharp.TypedExpr[T] = skunk.sharp.TypedExpr.lit(v)
+
 }

--- a/modules/core/src/main/scala/skunk/sharp/dsl/package.scala
+++ b/modules/core/src/main/scala/skunk/sharp/dsl/package.scala
@@ -63,7 +63,7 @@ package object dsl {
   type Where = skunk.sharp.where.Where
   val Where: skunk.sharp.where.Where.type = skunk.sharp.where.Where
 
-  export skunk.sharp.where.{!==, <, <=, ===, ====, >, >=, ilike, in, isNotNull, isNull, like}
+  export skunk.sharp.where.{!==, <, <=, ===, ====, >, >=, &&, ||, and, or, not, ilike, in, isNotNull, isNull, like}
   export skunk.sharp.where.Stripped
 
   // ---- Schema validation ----

--- a/modules/core/src/main/scala/skunk/sharp/where/Ops.scala
+++ b/modules/core/src/main/scala/skunk/sharp/where/Ops.scala
@@ -66,11 +66,11 @@ extension [T](lhs: TypedExpr[T])(using @unused ord: cats.Order[Stripped[T]]) {
 /**
  * Evidence that `Rhs` can sit on the right-hand side of `lhs IN (...)`. Ships two givens:
  *
- *   - A `Reducible` container of values (`NonEmptyList[T]`, `NonEmptyVector[T]`, …) → renders as
- *     `(lit1, lit2, …)` with each value bound as a parameter.
- *   - A [[skunk.sharp.dsl.CompiledQuery]]`[T]` → renders as `(<subquery>)`. Correlation is automatic when the
- *     subquery is built inside an outer `.where` / `.select` lambda — outer [[skunk.sharp.TypedColumn]]s render
- *     alias-qualified and reference the outer source.
+ *   - A `Reducible` container of values (`NonEmptyList[T]`, `NonEmptyVector[T]`, …) → renders as `(lit1, lit2, …)` with
+ *     each value bound as a parameter.
+ *   - A [[skunk.sharp.dsl.CompiledQuery]]`[T]` → renders as `(<subquery>)`. Correlation is automatic when the subquery
+ *     is built inside an outer `.where` / `.select` lambda — outer [[skunk.sharp.TypedColumn]]s render alias-qualified
+ *     and reference the outer source.
  *
  * Unified behind one `.in` extension to avoid Scala 3 overload-resolution pitfalls when re-exported from the `dsl`
  * package object.
@@ -102,8 +102,8 @@ object InRhs {
 extension [T](lhs: TypedExpr[T]) {
 
   /**
-   * `lhs IN (...)`. The right-hand side is anything with an [[InRhs]] instance — a `Reducible` container of values
-   * or a [[skunk.sharp.dsl.CompiledQuery]] for subquery IN.
+   * `lhs IN (...)`. The right-hand side is anything with an [[InRhs]] instance — a `Reducible` container of values or a
+   * [[skunk.sharp.dsl.CompiledQuery]] for subquery IN.
    */
   def in[Rhs](rhs: Rhs)(using ev: InRhs[Stripped[T], Rhs]): Where = {
     val rendered = lhs.render |+| TypedExpr.raw(" IN ") |+| ev.renderParens(rhs)

--- a/modules/core/src/main/scala/skunk/sharp/where/Ops.scala
+++ b/modules/core/src/main/scala/skunk/sharp/where/Ops.scala
@@ -63,17 +63,50 @@ extension [T](lhs: TypedExpr[T])(using @unused ord: cats.Order[Stripped[T]]) {
   def >=(rhs: Stripped[T])(using pf: PgTypeFor[Stripped[T]]): Where = binOp(">=", lhs, TypedExpr.lit(rhs))
 }
 
+/**
+ * Evidence that `Rhs` can sit on the right-hand side of `lhs IN (...)`. Ships two givens:
+ *
+ *   - A `Reducible` container of values (`NonEmptyList[T]`, `NonEmptyVector[T]`, …) → renders as
+ *     `(lit1, lit2, …)` with each value bound as a parameter.
+ *   - A [[skunk.sharp.dsl.CompiledQuery]]`[T]` → renders as `(<subquery>)`. Correlation is automatic when the
+ *     subquery is built inside an outer `.where` / `.select` lambda — outer [[skunk.sharp.TypedColumn]]s render
+ *     alias-qualified and reference the outer source.
+ *
+ * Unified behind one `.in` extension to avoid Scala 3 overload-resolution pitfalls when re-exported from the `dsl`
+ * package object.
+ */
+sealed trait InRhs[T, Rhs] {
+  def renderParens(rhs: Rhs): skunk.AppliedFragment
+}
+
+object InRhs {
+
+  given reducibleIn[T, F[_]](using R: cats.Reducible[F], pf: PgTypeFor[T]): InRhs[T, F[T]] =
+    new InRhs[T, F[T]] {
+      def renderParens(values: F[T]): skunk.AppliedFragment = {
+        val literals = R.toNonEmptyList(values).toList.map(v => TypedExpr.lit(v).render)
+        TypedExpr.raw("(") |+| TypedExpr.joined(literals, ", ") |+| TypedExpr.raw(")")
+      }
+    }
+
+  given subqueryIn[T, Q](using ev: skunk.sharp.dsl.AsSubquery[Q, T]): InRhs[T, Q] =
+    new InRhs[T, Q] {
+      def renderParens(q: Q): skunk.AppliedFragment = {
+        val cq = ev.toCompiled(q)
+        TypedExpr.raw("(") |+| cq.af |+| TypedExpr.raw(")")
+      }
+    }
+
+}
+
 extension [T](lhs: TypedExpr[T]) {
 
   /**
-   * `lhs IN (val1, val2, …)`. Takes any `cats.Reducible` container — `NonEmptyList`, `NonEmptyVector`, `NonEmptyChain`,
-   * `NonEmptySeq`, … — so the non-emptiness is guaranteed at the type level and the generated SQL is always valid.
-   * Matches the [[skunk.sharp.dsl.InsertBuilder.values]] shape.
+   * `lhs IN (...)`. The right-hand side is anything with an [[InRhs]] instance — a `Reducible` container of values
+   * or a [[skunk.sharp.dsl.CompiledQuery]] for subquery IN.
    */
-  def in[F[_]: cats.Reducible](values: F[Stripped[T]])(using pf: PgTypeFor[Stripped[T]]): Where = {
-    val literals = cats.Reducible[F].toNonEmptyList(values).toList.map(v => TypedExpr.lit(v).render)
-    val rendered =
-      lhs.render |+| TypedExpr.raw(" IN (") |+| TypedExpr.joined(literals, ", ") |+| TypedExpr.raw(")")
+  def in[Rhs](rhs: Rhs)(using ev: InRhs[Stripped[T], Rhs]): Where = {
+    val rendered = lhs.render |+| TypedExpr.raw(" IN ") |+| ev.renderParens(rhs)
     Where(new TypedExpr[Boolean] {
       val render = rendered
       val codec  = skunk.codec.all.bool

--- a/modules/core/src/main/scala/skunk/sharp/where/Where.scala
+++ b/modules/core/src/main/scala/skunk/sharp/where/Where.scala
@@ -1,31 +1,24 @@
 package skunk.sharp.where
 
-import skunk.AppliedFragment
 import skunk.sharp.TypedExpr
 
 /**
- * A WHERE-clause predicate. Thin wrapper around a `TypedExpr[Boolean]` so the compiler stays open to extension: any
- * third-party operator that produces a `TypedExpr[Boolean]` slots in as a `Where` via `.toWhere`.
+ * A WHERE-clause predicate — just a `TypedExpr[Boolean]`. Used to live as a thin wrapper class; collapsed into a type
+ * alias so any expression producing a boolean value (user operators, `Pg.exists`, subqueries, extension-module
+ * predicates) can be used directly without a `Where(...)` wrap at call sites.
  *
- * Not a sealed ADT on purpose — the compiler never pattern-matches on variants, it just calls `render`.
+ * All chaining methods (`&&`, `and`, `||`, `or`, unary `!`, `not`) live as extension methods on `TypedExpr[Boolean]`
+ * — see [[WhereOps]] below.
  */
-final class Where private[where] (val expr: TypedExpr[Boolean]) {
-
-  def render: AppliedFragment = expr.render
-
-  def &&(other: Where): Where  = Where.and(this, other)
-  def and(other: Where): Where = Where.and(this, other)
-
-  def ||(other: Where): Where = Where.or(this, other)
-  def or(other: Where): Where = Where.or(this, other)
-
-  def unary_! : Where = Where.not(this)
-}
+type Where = TypedExpr[Boolean]
 
 object Where {
 
-  /** Lift a boolean expression into a Where predicate. */
-  def apply(expr: TypedExpr[Boolean]): Where = new Where(expr)
+  /**
+   * Identity helper kept for source compatibility with call sites that read more naturally as
+   * `Where(Pg.exists(sub))`. `Where(e)` now just is `e`, so prefer passing `TypedExpr[Boolean]` directly.
+   */
+  inline def apply(expr: TypedExpr[Boolean]): Where = expr
 
   /** AND two predicates. */
   def and(l: Where, r: Where): Where = {
@@ -45,10 +38,23 @@ object Where {
     lift(rendered)
   }
 
-  private def lift(af: AppliedFragment): Where =
-    new Where(new TypedExpr[Boolean] {
+  private def lift(af: skunk.AppliedFragment): Where =
+    new TypedExpr[Boolean] {
       val render = af
       val codec  = skunk.codec.all.bool
-    })
+    }
 
+}
+
+/**
+ * Chaining ops on any `TypedExpr[Boolean]` (= `Where`) — `&&` / `and`, `||` / `or`, unary `!` / `not`. Because `Where`
+ * is now a type alias, these are equally available on any boolean expression: `Pg.exists(sub) && u.age >= 18`.
+ */
+extension (lhs: Where) {
+  def &&(rhs: Where): Where  = Where.and(lhs, rhs)
+  def and(rhs: Where): Where = Where.and(lhs, rhs)
+  def ||(rhs: Where): Where  = Where.or(lhs, rhs)
+  def or(rhs: Where): Where  = Where.or(lhs, rhs)
+  def unary_! : Where        = Where.not(lhs)
+  def not: Where             = Where.not(lhs)
 }

--- a/modules/core/src/main/scala/skunk/sharp/where/Where.scala
+++ b/modules/core/src/main/scala/skunk/sharp/where/Where.scala
@@ -7,16 +7,16 @@ import skunk.sharp.TypedExpr
  * alias so any expression producing a boolean value (user operators, `Pg.exists`, subqueries, extension-module
  * predicates) can be used directly without a `Where(...)` wrap at call sites.
  *
- * All chaining methods (`&&`, `and`, `||`, `or`, unary `!`, `not`) live as extension methods on `TypedExpr[Boolean]`
- * — see [[WhereOps]] below.
+ * All chaining methods (`&&`, `and`, `||`, `or`, unary `!`, `not`) live as extension methods on `TypedExpr[Boolean]` —
+ * see [[WhereOps]] below.
  */
 type Where = TypedExpr[Boolean]
 
 object Where {
 
   /**
-   * Identity helper kept for source compatibility with call sites that read more naturally as
-   * `Where(Pg.exists(sub))`. `Where(e)` now just is `e`, so prefer passing `TypedExpr[Boolean]` directly.
+   * Identity helper kept for source compatibility with call sites that read more naturally as `Where(Pg.exists(sub))`.
+   * `Where(e)` now just is `e`, so prefer passing `TypedExpr[Boolean]` directly.
    */
   inline def apply(expr: TypedExpr[Boolean]): Where = expr
 

--- a/modules/core/src/test/scala/skunk/sharp/dsl/JoinSuite.scala
+++ b/modules/core/src/test/scala/skunk/sharp/dsl/JoinSuite.scala
@@ -8,6 +8,7 @@ import java.util.UUID
 object JoinSuite {
   case class User(id: UUID, email: String, age: Int)
   case class Post(id: UUID, user_id: UUID, title: String, created_at: OffsetDateTime)
+  case class Tag(id: UUID, post_id: UUID, name: String)
 }
 
 class JoinSuite extends munit.FunSuite {
@@ -15,6 +16,7 @@ class JoinSuite extends munit.FunSuite {
 
   private val users = Table.of[User]("users")
   private val posts = Table.of[Post]("posts")
+  private val tags  = Table.of[Tag]("tags")
 
   test("INNER JOIN (no explicit alias) — table names used as aliases") {
     val af = users
@@ -113,7 +115,7 @@ class JoinSuite extends munit.FunSuite {
     )
   }
 
-  test(".compile without .on does not exist (IncompleteJoin2 has no .compile)") {
+  test(".compile without .on does not exist (IncompleteJoin has no .compile)") {
     val errs = compiletime.testing.typeCheckErrors("""
       import skunk.sharp.dsl.*
       val users = Table.of[JoinSuite.User]("users")
@@ -121,5 +123,61 @@ class JoinSuite extends munit.FunSuite {
       users.innerJoin(posts).compile
     """)
     assert(errs.nonEmpty, "expected a compile error: .on is required before .compile")
+  }
+
+  test("three-table INNER JOIN chain") {
+    val af = users
+      .innerJoin(posts).on(r => r.users.id ==== r.posts.user_id)
+      .innerJoin(tags).on(r => r.posts.id ==== r.tags.post_id)
+      .select(r => (r.users.email, r.posts.title, r.tags.name))
+      .compile
+      .af
+
+    assertEquals(
+      af.fragment.sql,
+      """SELECT "users"."email", "posts"."title", "tags"."name" FROM "users" INNER JOIN "posts" ON "users"."id" = "posts"."user_id" INNER JOIN "tags" ON "posts"."id" = "tags"."post_id""""
+    )
+  }
+
+  test("three-table mixed INNER + LEFT — right-most cols flip to Option") {
+    // The compile-time type of the last projection is Option[String] because tags was left-joined.
+    val q: CompiledQuery[(String, String, Option[String])] = users
+      .innerJoin(posts).on(r => r.users.id ==== r.posts.user_id)
+      .leftJoin(tags).on(r => r.posts.id ==== r.tags.post_id)
+      .select(r => (r.users.email, r.posts.title, r.tags.name))
+      .compile
+
+    assert(
+      q.af.fragment.sql.contains("LEFT JOIN \"tags\" ON \"posts\".\"id\" = \"tags\".\"post_id\""),
+      q.af.fragment.sql
+    )
+  }
+
+  test(".crossJoin renders CROSS JOIN; .where supplies the join predicate") {
+    val af = users
+      .crossJoin(posts)
+      .select(r => (r.users.email, r.posts.title))
+      .where(r => r.users.id ==== r.posts.user_id)
+      .compile
+      .af
+
+    assertEquals(
+      af.fragment.sql,
+      """SELECT "users"."email", "posts"."title" FROM "users" CROSS JOIN "posts" WHERE "users"."id" = "posts"."user_id""""
+    )
+  }
+
+  test("three-way .crossJoin chain") {
+    val af = users
+      .crossJoin(posts)
+      .crossJoin(tags)
+      .select(r => (r.users.email, r.posts.title, r.tags.name))
+      .compile
+      .af
+
+    assertEquals(
+      af.fragment.sql,
+      """SELECT "users"."email", "posts"."title", "tags"."name" FROM "users" CROSS JOIN "posts" CROSS JOIN "tags""""
+    )
   }
 }

--- a/modules/core/src/test/scala/skunk/sharp/dsl/SubquerySuite.scala
+++ b/modules/core/src/test/scala/skunk/sharp/dsl/SubquerySuite.scala
@@ -97,7 +97,9 @@ class SubquerySuite extends munit.FunSuite {
       .af
 
     assert(
-      af.fragment.sql.contains("""WHERE ("u"."age" >= $1 AND EXISTS (SELECT $2 FROM "posts" WHERE "user_id" = "u"."id"))"""),
+      af.fragment.sql.contains(
+        """WHERE ("u"."age" >= $1 AND EXISTS (SELECT $2 FROM "posts" WHERE "user_id" = "u"."id"))"""
+      ),
       af.fragment.sql
     )
   }

--- a/modules/core/src/test/scala/skunk/sharp/dsl/SubquerySuite.scala
+++ b/modules/core/src/test/scala/skunk/sharp/dsl/SubquerySuite.scala
@@ -78,7 +78,7 @@ class SubquerySuite extends munit.FunSuite {
     val af = users
       .alias("u")
       .select(u => u.email)
-      .where(u => Pg.exists(posts.select(_ => TypedExpr.lit(1)).where(p => p.user_id ==== u.id)))
+      .where(u => Pg.exists(posts.select(_ => lit(1)).where(p => p.user_id ==== u.id)))
       .compile
       .af
 
@@ -92,7 +92,7 @@ class SubquerySuite extends munit.FunSuite {
     val af = users
       .alias("u")
       .select(u => u.email)
-      .where(u => u.age >= 18 && Pg.exists(posts.select(_ => TypedExpr.lit(1)).where(p => p.user_id ==== u.id)))
+      .where(u => u.age >= 18 && Pg.exists(posts.select(_ => lit(1)).where(p => p.user_id ==== u.id)))
       .compile
       .af
 

--- a/modules/core/src/test/scala/skunk/sharp/dsl/SubquerySuite.scala
+++ b/modules/core/src/test/scala/skunk/sharp/dsl/SubquerySuite.scala
@@ -1,0 +1,104 @@
+package skunk.sharp.dsl
+
+import skunk.sharp.dsl.*
+
+import java.time.OffsetDateTime
+import java.util.UUID
+
+object SubquerySuite {
+  case class User(id: UUID, email: String, age: Int)
+  case class Post(id: UUID, user_id: UUID, title: String, created_at: OffsetDateTime)
+}
+
+class SubquerySuite extends munit.FunSuite {
+  import SubquerySuite.*
+
+  private val users = Table.of[User]("users")
+  private val posts = Table.of[Post]("posts")
+
+  // ---- Uncorrelated subqueries — inner builders, no `.compile` at the inner level --------------
+
+  test("uncorrelated scalar subquery as a projection value") {
+    val af = users
+      .select(u => (u.email, posts.select(_ => Pg.countAll).asExpr))
+      .compile
+      .af
+
+    assertEquals(
+      af.fragment.sql,
+      """SELECT "email", (SELECT count(*) FROM "posts") FROM "users""""
+    )
+  }
+
+  test("uncorrelated .in(subquery)") {
+    val af = users.select
+      .where(u => u.id.in(posts.select(p => p.user_id)))
+      .compile
+      .af
+
+    assertEquals(
+      af.fragment.sql,
+      """SELECT "id", "email", "age" FROM "users" WHERE "id" IN (SELECT "user_id" FROM "posts")"""
+    )
+  }
+
+  test("uncorrelated EXISTS — no .compile, no Where(…) wrap") {
+    val af = users.select
+      .where(_ => Pg.exists(posts.select))
+      .compile
+      .af
+
+    assertEquals(
+      af.fragment.sql,
+      """SELECT "id", "email", "age" FROM "users" WHERE EXISTS (SELECT "id", "user_id", "title", "created_at" FROM "posts")"""
+    )
+  }
+
+  // ---- Correlated (inner built inside outer lambda, closes over outer column) ------------------
+
+  test("correlated scalar subquery — per-user post count in projection") {
+    val af = users
+      .alias("u")
+      .select(u =>
+        (
+          u.email,
+          posts.select(_ => Pg.countAll).where(p => p.user_id ==== u.id).asExpr
+        )
+      )
+      .compile
+      .af
+
+    assertEquals(
+      af.fragment.sql,
+      """SELECT "u"."email", (SELECT count(*) FROM "posts" WHERE "user_id" = "u"."id") FROM "users" AS "u""""
+    )
+  }
+
+  test("correlated EXISTS — users that have at least one post") {
+    val af = users
+      .alias("u")
+      .select(u => u.email)
+      .where(u => Pg.exists(posts.select(_ => TypedExpr.lit(1)).where(p => p.user_id ==== u.id)))
+      .compile
+      .af
+
+    assertEquals(
+      af.fragment.sql,
+      """SELECT "u"."email" FROM "users" AS "u" WHERE EXISTS (SELECT $1 FROM "posts" WHERE "user_id" = "u"."id")"""
+    )
+  }
+
+  test("correlated WHERE combining AND with EXISTS") {
+    val af = users
+      .alias("u")
+      .select(u => u.email)
+      .where(u => u.age >= 18 && Pg.exists(posts.select(_ => TypedExpr.lit(1)).where(p => p.user_id ==== u.id)))
+      .compile
+      .af
+
+    assert(
+      af.fragment.sql.contains("""WHERE ("u"."age" >= $1 AND EXISTS (SELECT $2 FROM "posts" WHERE "user_id" = "u"."id"))"""),
+      af.fragment.sql
+    )
+  }
+}

--- a/modules/tests/src/test/resources/migrations/V5__tags.sql
+++ b/modules/tests/src/test/resources/migrations/V5__tags.sql
@@ -1,0 +1,5 @@
+CREATE TABLE tags (
+  id      uuid PRIMARY KEY,
+  post_id uuid NOT NULL REFERENCES posts (id),
+  name    text NOT NULL
+);

--- a/modules/tests/src/test/scala/skunk/sharp/tests/JoinSuite.scala
+++ b/modules/tests/src/test/scala/skunk/sharp/tests/JoinSuite.scala
@@ -9,6 +9,7 @@ import java.util.UUID
 object JoinSuite {
   case class User(id: UUID, email: String, age: Int, created_at: OffsetDateTime, deleted_at: Option[OffsetDateTime])
   case class Post(id: UUID, user_id: UUID, title: String, created_at: OffsetDateTime)
+  case class Tag(id: UUID, post_id: UUID, name: String)
 }
 
 class JoinSuite extends PgFixture {
@@ -16,6 +17,7 @@ class JoinSuite extends PgFixture {
 
   private val users = Table.of[User]("users").withDefault("created_at")
   private val posts = Table.of[Post]("posts").withDefault("created_at")
+  private val tags  = Table.of[Tag]("tags")
 
   test("INNER JOIN round-trips users + posts (auto-alias)") {
     withContainers { containers =>
@@ -81,6 +83,60 @@ class JoinSuite extends PgFixture {
             .compile
             .run(s)
           _ = assertEquals(rows, List(("many@x", 3L)))
+        } yield ()
+      }
+    }
+  }
+
+  test("three-table chain INNER + LEFT with auto-alias") {
+    withContainers { containers =>
+      session(containers).use { s =>
+        val uid = UUID.randomUUID
+        val pid = UUID.randomUUID
+        for {
+          _ <- users
+            .insert((id = uid, email = "chain@x", age = 33, deleted_at = Option.empty[OffsetDateTime]))
+            .compile.run(s)
+          _    <- posts.insert((id = pid, user_id = uid, title = "chain-post")).compile.run(s)
+          _    <- tags.insert((id = UUID.randomUUID, post_id = pid, name = "alpha")).compile.run(s)
+          _    <- tags.insert((id = UUID.randomUUID, post_id = pid, name = "beta")).compile.run(s)
+          rows <- users
+            .innerJoin(posts).on(r => r.users.id ==== r.posts.user_id)
+            .leftJoin(tags).on(r => r.posts.id ==== r.tags.post_id)
+            .select(r => (r.users.email, r.posts.title, r.tags.name))
+            .where(r => r.users.id === uid)
+            .orderBy(r => r.tags.name.asc)
+            .compile
+            .run(s)
+          _ = assertEquals(
+            rows,
+            List(
+              ("chain@x", "chain-post", Option("alpha")),
+              ("chain@x", "chain-post", Option("beta"))
+            )
+          )
+        } yield ()
+      }
+    }
+  }
+
+  test(".crossJoin renders CROSS JOIN; WHERE supplies the join predicate") {
+    withContainers { containers =>
+      session(containers).use { s =>
+        val uid = UUID.randomUUID
+        val pid = UUID.randomUUID
+        for {
+          _ <- users
+            .insert((id = uid, email = "cross@x", age = 27, deleted_at = Option.empty[OffsetDateTime]))
+            .compile.run(s)
+          _    <- posts.insert((id = pid, user_id = uid, title = "cross-post")).compile.run(s)
+          rows <- users
+            .crossJoin(posts)
+            .select(r => (r.users.email, r.posts.title))
+            .where(r => r.users.id ==== r.posts.user_id && r.users.id === uid)
+            .compile
+            .run(s)
+          _ = assertEquals(rows, List(("cross@x", "cross-post")))
         } yield ()
       }
     }

--- a/modules/tests/src/test/scala/skunk/sharp/tests/SubquerySuite.scala
+++ b/modules/tests/src/test/scala/skunk/sharp/tests/SubquerySuite.scala
@@ -1,0 +1,93 @@
+package skunk.sharp.tests
+
+import skunk.sharp.dsl.*
+
+import java.time.OffsetDateTime
+import java.util.UUID
+
+object SubquerySuite {
+  case class User(id: UUID, email: String, age: Int, created_at: OffsetDateTime, deleted_at: Option[OffsetDateTime])
+  case class Post(id: UUID, user_id: UUID, title: String, created_at: OffsetDateTime)
+}
+
+class SubquerySuite extends PgFixture {
+  import SubquerySuite.*
+
+  private val users = Table.of[User]("users").withDefault("created_at")
+  private val posts = Table.of[Post]("posts").withDefault("created_at")
+
+  test("uncorrelated IN-subquery — users who have posts") {
+    withContainers { containers =>
+      session(containers).use { s =>
+        val uidA = UUID.randomUUID
+        val uidB = UUID.randomUUID
+        for {
+          _ <- users
+            .insert((id = uidA, email = "has-posts@x", age = 30, deleted_at = Option.empty[OffsetDateTime]))
+            .compile.run(s)
+          _ <- users
+            .insert((id = uidB, email = "no-posts@x", age = 31, deleted_at = Option.empty[OffsetDateTime]))
+            .compile.run(s)
+          _ <- posts.insert((id = UUID.randomUUID, user_id = uidA, title = "hello")).compile.run(s)
+          rows <- users
+            .select(u => u.email)
+            .where(u => u.id.in(posts.select(p => p.user_id)))
+            .compile.run(s)
+          _ = assertEquals(rows, List("has-posts@x"))
+        } yield ()
+      }
+    }
+  }
+
+  test("correlated EXISTS — users who have at least one post") {
+    withContainers { containers =>
+      session(containers).use { s =>
+        val uidWith = UUID.randomUUID
+        val uidWO   = UUID.randomUUID
+        for {
+          _ <- users
+            .insert((id = uidWith, email = "exw@x", age = 40, deleted_at = Option.empty[OffsetDateTime]))
+            .compile.run(s)
+          _ <- users
+            .insert((id = uidWO, email = "exo@x", age = 41, deleted_at = Option.empty[OffsetDateTime]))
+            .compile.run(s)
+          _ <- posts.insert((id = UUID.randomUUID, user_id = uidWith, title = "ex")).compile.run(s)
+          // Inner query built inside the outer lambda — references u.id (an outer column) by closure. The
+          // outer alias makes u.id render as "u"."id" so Postgres correlates it to the outer source.
+          rows <- users
+            .alias("u")
+            .select(u => u.email)
+            .where(u => Pg.exists(posts.select(_ => TypedExpr.lit(1)).where(p => p.user_id ==== u.id)))
+            .compile.run(s)
+          _ = assertEquals(rows.toSet, Set("has-posts@x", "exw@x"))
+        } yield ()
+      }
+    }
+  }
+
+  test("correlated scalar subquery in projection — email + per-user post count") {
+    withContainers { containers =>
+      session(containers).use { s =>
+        val uid = UUID.randomUUID
+        for {
+          _ <- users
+            .insert((id = uid, email = "scalar@x", age = 22, deleted_at = Option.empty[OffsetDateTime]))
+            .compile.run(s)
+          _    <- posts.insert((id = UUID.randomUUID, user_id = uid, title = "a")).compile.run(s)
+          _    <- posts.insert((id = UUID.randomUUID, user_id = uid, title = "b")).compile.run(s)
+          rows <- users
+            .alias("u")
+            .select(u =>
+              (
+                u.email,
+                posts.select(_ => Pg.countAll).where(p => p.user_id ==== u.id).asExpr
+              )
+            )
+            .where(u => u.id === uid)
+            .compile.run(s)
+          _ = assertEquals(rows, List(("scalar@x", 2L)))
+        } yield ()
+      }
+    }
+  }
+}

--- a/modules/tests/src/test/scala/skunk/sharp/tests/SubquerySuite.scala
+++ b/modules/tests/src/test/scala/skunk/sharp/tests/SubquerySuite.scala
@@ -57,7 +57,7 @@ class SubquerySuite extends PgFixture {
           rows <- users
             .alias("u")
             .select(u => u.email)
-            .where(u => Pg.exists(posts.select(_ => TypedExpr.lit(1)).where(p => p.user_id ==== u.id)))
+            .where(u => Pg.exists(posts.select(_ => lit(1)).where(p => p.user_id ==== u.id)))
             .compile.run(s)
           _ = assertEquals(rows.toSet, Set("has-posts@x", "exw@x"))
         } yield ()

--- a/modules/tests/src/test/scala/skunk/sharp/tests/SubquerySuite.scala
+++ b/modules/tests/src/test/scala/skunk/sharp/tests/SubquerySuite.scala
@@ -28,7 +28,7 @@ class SubquerySuite extends PgFixture {
           _ <- users
             .insert((id = uidB, email = "no-posts@x", age = 31, deleted_at = Option.empty[OffsetDateTime]))
             .compile.run(s)
-          _ <- posts.insert((id = UUID.randomUUID, user_id = uidA, title = "hello")).compile.run(s)
+          _    <- posts.insert((id = UUID.randomUUID, user_id = uidA, title = "hello")).compile.run(s)
           rows <- users
             .select(u => u.email)
             .where(u => u.id.in(posts.select(p => p.user_id)))


### PR DESCRIPTION
## Summary

- **N-source SelectBuilder.** One `SelectBuilder[Sources <: Tuple]` handles single-source, 2+ way joins, and CROSS joins. The lambda receiver is a match-type `SelectView[Ss]` that reduces to `ColumnsView[Cols]` for 1 source (user writes `u.email`) or `JoinedView[Ss]` for N sources (user writes `r.users.email`). Row locking gated on `IsSingleTable[Ss]` evidence.
- **Auto-alias joins.** `users.innerJoin(posts)` now works without explicit `.alias(...)` — alias defaults to the table's `Name` type parameter. `AS "x"` is elided from FROM when alias equals the relation name.
- **CROSS JOIN.** `.crossJoin(other)` skips `.on(...)`. Chains N-ways like INNER/LEFT.
- **Chained joins after SELECT.** `users.select.where(...).innerJoin(posts).on(...)` — previously impossible.
- **Subqueries via `AsSubquery[Q, T]` typeclass.** `Pg.exists(...)`, `.in(...)`, `.asExpr` accept any builder (`SelectBuilder[Ss]` / `ProjectedSelect[Ss, T]` / `CompiledQuery[T]`) — no inner `.compile`. Correlation is automatic via closure over outer columns.
- **`Where` is now `type Where = TypedExpr[Boolean]`.** No more `Where(Pg.exists(sub))` wraps; `&&` / `and` / `||` / `or` / `!` / `not` are extensions on `TypedExpr[Boolean]`.
- **`lit(v)` shorthand.** Top-level `lit(1)` instead of `TypedExpr.lit(1)`. Deliberately not an implicit conversion.

Net LOC: Select + Join went 1045 → 884 (-15%) even with new features added.

## Test plan

- [x] `sbt core/test` — 129 pass (5 new subquery cases, 8 new join cases including 3-source chains, CROSS JOIN, explicit-alias + mixed).
- [x] `sbt iron/test` — 4 pass.
- [x] `sbt tests/test` — 36 integration pass, including:
  - Auto-alias INNER / LEFT JOIN round-trips
  - 3-table INNER + LEFT chain
  - CROSS JOIN + predicate-style WHERE
  - Correlated EXISTS + correlated scalar subquery
  - `.in(subquery)` round-trip
- [x] `sbt scalafmtCheckAll` clean.

## Files

- `modules/core/src/main/scala/skunk/sharp/dsl/Select.scala` — unified SelectBuilder + ProjectedSelect.
- `modules/core/src/main/scala/skunk/sharp/dsl/Join.scala` — SourceEntry, IncompleteJoin, AsAliased typeclass, join entry extensions, match types.
- `modules/core/src/main/scala/skunk/sharp/dsl/Compiled.scala` — AsSubquery typeclass + `.asExpr` extension.
- `modules/core/src/main/scala/skunk/sharp/where/Where.scala` — now a type alias; `&&` / `||` / `not` extensions.
- `modules/core/src/main/scala/skunk/sharp/where/Ops.scala` — `InRhs` typeclass for `.in` dispatch.
- `modules/core/src/main/scala/skunk/sharp/PgFunction.scala` — `Pg.exists` / `Pg.notExists`.
- `modules/core/src/main/scala/skunk/sharp/Table.scala` / `View.scala` / `TableBuilder.scala` — `Name` type param promoted; `.of[T]` uses continuation to dodge all-or-nothing inference.
- New tests: `core/dsl/JoinSuite.scala` (expanded), `core/dsl/SubquerySuite.scala`, `tests/JoinSuite.scala` (expanded), `tests/SubquerySuite.scala`, migrations/`V5__tags.sql`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)