### PR TITLE
Pg string functions accept tagged inputs

### DIFF
--- a/modules/core/src/main/scala/skunk/sharp/PgFunction.scala
+++ b/modules/core/src/main/scala/skunk/sharp/PgFunction.scala
@@ -87,16 +87,30 @@ object Pg {
   val localTimestamp: TypedExpr[LocalDateTime] =
     TypedExpr(TypedExpr.raw("localtimestamp"), skunk.codec.all.timestamp)
 
-  /** `lower(s)`. */
-  val lower: TypedExpr[String] => TypedExpr[String] = PgFunction.unary[String, String]("lower")
+  /**
+   * `lower(s)` — fold to lowercase. Accepts any string-like `TypedExpr` (bare `String`, tag types like `Varchar[N]` /
+   * `Bpchar[N]` / `Text`, or their `Option` variants — anything where `Stripped[T] <:< String`). Returns the input
+   * type back: tag information is preserved in the Scala type (PG returns `text` on the wire, but `Varchar[N]` /
+   * `Text` etc. all decode the same text bytes through the same codec, so the value is correct).
+   */
+  def lower[T](e: TypedExpr[T])(using @annotation.unused ev: skunk.sharp.where.Stripped[T] <:< String): TypedExpr[T] =
+    TypedExpr(TypedExpr.raw("lower(") |+| e.render |+| TypedExpr.raw(")"), e.codec)
 
-  /** `upper(s)`. */
-  val upper: TypedExpr[String] => TypedExpr[String] = PgFunction.unary[String, String]("upper")
+  /** `upper(s)` — fold to uppercase. Shape mirrors [[lower]]. */
+  def upper[T](e: TypedExpr[T])(using @annotation.unused ev: skunk.sharp.where.Stripped[T] <:< String): TypedExpr[T] =
+    TypedExpr(TypedExpr.raw("upper(") |+| e.render |+| TypedExpr.raw(")"), e.codec)
 
-  /** `length(s)`. */
-  val length: TypedExpr[String] => TypedExpr[Int] = PgFunction.unary[String, Int]("length")
+  /**
+   * `length(s)` — character count. Output nullability tracks the input: `TypedExpr[String]` → `TypedExpr[Int]`;
+   * `TypedExpr[Option[Varchar[N]]]` → `TypedExpr[Option[Int]]` (PG's strict null propagation).
+   */
+  def length[T](e: TypedExpr[T])(using
+    @annotation.unused ev: skunk.sharp.where.Stripped[T] <:< String,
+    pf: PgTypeFor[Lift[T, Int]]
+  ): TypedExpr[Lift[T, Int]] =
+    TypedExpr(TypedExpr.raw("length(") |+| e.render |+| TypedExpr.raw(")"), pf.codec)
 
-  /** `concat(a, b, c, …)`. */
+  /** `concat(a, b, c, …)` — string concatenation. Each arg may carry its own string-like tag. */
   def concat(args: TypedExpr[String]*): TypedExpr[String] =
     PgFunction.nary[String]("concat", args*)
 
@@ -156,8 +170,13 @@ object Pg {
   def max[T](expr: TypedExpr[T]): TypedExpr[T] =
     TypedExpr(TypedExpr.raw("max(") |+| expr.render |+| TypedExpr.raw(")"), expr.codec)
 
-  /** `string_agg(expr, sep)` — concatenate string values with a separator. */
-  def stringAgg(expr: TypedExpr[String], sep: String): TypedExpr[String] =
+  /**
+   * `string_agg(expr, sep)` — concatenate string values with a separator. Accepts any string-like tag on the
+   * aggregated expression.
+   */
+  def stringAgg[T](expr: TypedExpr[T], sep: String)(using
+    @annotation.unused ev: skunk.sharp.where.Stripped[T] <:< String
+  ): TypedExpr[String] =
     TypedExpr(
       TypedExpr.raw("string_agg(") |+| expr.render |+| TypedExpr.raw(", ") |+|
         TypedExpr.lit(sep).render |+| TypedExpr.raw(")"),
@@ -189,6 +208,16 @@ object Pg {
     TypedExpr(TypedExpr.raw("NOT EXISTS (") |+| cq.af |+| TypedExpr.raw(")"), skunk.codec.all.bool)
   }
 
+}
+
+/**
+ * Preserve `T`'s nullability (or lack thereof) while changing the "base" type to `U`. Used by PG functions that have
+ * a fixed non-input return type but still propagate NULL — e.g. `length(null) → null`, so
+ * `length(TypedExpr[Option[String]]) → TypedExpr[Option[Int]]`.
+ */
+type Lift[T, U] = T match {
+  case Option[x] => Option[U]
+  case _         => U
 }
 
 /**

--- a/modules/core/src/main/scala/skunk/sharp/PgFunction.scala
+++ b/modules/core/src/main/scala/skunk/sharp/PgFunction.scala
@@ -65,6 +65,13 @@ object PgOperator {
 }
 
 /**
+ * Shorthand: evidence that `T` (possibly wrapped in `Option`) is a string-like type — covers `String`, all string tag
+ * types (`Varchar[N]`, `Bpchar[N]`, `Text`), and their `Option` variants. Used as an implicit constraint on
+ * string-taking [[Pg]] functions so callers retain tag information through the call.
+ */
+type StrLike[T] = skunk.sharp.where.Stripped[T] <:< String
+
+/**
  * A small set of built-in Postgres functions provided out of the box. Users write `Pg.now`, `Pg.lower(col)`, etc.
  * Extension modules are expected to add their own namespaces (`Jsonb.`, `Ltree.`, …) following the same pattern.
  */
@@ -93,22 +100,17 @@ object Pg {
    * back: tag information is preserved in the Scala type (PG returns `text` on the wire, but `Varchar[N]` / `Text` etc.
    * all decode the same text bytes through the same codec, so the value is correct).
    */
-  def lower[T](e: TypedExpr[T])(using @annotation.unused ev: skunk.sharp.where.Stripped[T] <:< String): TypedExpr[T] =
-    TypedExpr(TypedExpr.raw("lower(") |+| e.render |+| TypedExpr.raw(")"), e.codec)
+  def lower[T](e: TypedExpr[T])(using StrLike[T]): TypedExpr[T] = stringPreserveFn("lower", e)
 
   /** `upper(s)` — fold to uppercase. Shape mirrors [[lower]]. */
-  def upper[T](e: TypedExpr[T])(using @annotation.unused ev: skunk.sharp.where.Stripped[T] <:< String): TypedExpr[T] =
-    TypedExpr(TypedExpr.raw("upper(") |+| e.render |+| TypedExpr.raw(")"), e.codec)
+  def upper[T](e: TypedExpr[T])(using StrLike[T]): TypedExpr[T] = stringPreserveFn("upper", e)
 
   /**
    * `length(s)` — character count. Output nullability tracks the input: `TypedExpr[String]` → `TypedExpr[Int]`;
    * `TypedExpr[Option[Varchar[N]]]` → `TypedExpr[Option[Int]]` (PG's strict null propagation).
    */
-  def length[T](e: TypedExpr[T])(using
-    @annotation.unused ev: skunk.sharp.where.Stripped[T] <:< String,
-    pf: PgTypeFor[Lift[T, Int]]
-  ): TypedExpr[Lift[T, Int]] =
-    TypedExpr(TypedExpr.raw("length(") |+| e.render |+| TypedExpr.raw(")"), pf.codec)
+  def length[T](e: TypedExpr[T])(using StrLike[T], PgTypeFor[Lift[T, Int]]): TypedExpr[Lift[T, Int]] =
+    stringToIntFn("length", e)
 
   /** `concat(a, b, c, …)` — string concatenation. Each arg may carry its own string-like tag. */
   def concat(args: TypedExpr[String]*): TypedExpr[String] =
@@ -125,24 +127,19 @@ object Pg {
   // execution time. Return type = input type so callers retain tag information (Int2, Numeric[P, S], …).
 
   /** `abs(x)` — absolute value. Same type as input. */
-  def abs[T](e: TypedExpr[T]): TypedExpr[T] =
-    TypedExpr(TypedExpr.raw("abs(") |+| e.render |+| TypedExpr.raw(")"), e.codec)
+  def abs[T](e: TypedExpr[T]): TypedExpr[T] = sameTypeFn("abs", e)
 
   /** `ceil(x)` — nearest integer greater than or equal to `x`. */
-  def ceil[T](e: TypedExpr[T]): TypedExpr[T] =
-    TypedExpr(TypedExpr.raw("ceil(") |+| e.render |+| TypedExpr.raw(")"), e.codec)
+  def ceil[T](e: TypedExpr[T]): TypedExpr[T] = sameTypeFn("ceil", e)
 
   /** `floor(x)` — nearest integer less than or equal to `x`. */
-  def floor[T](e: TypedExpr[T]): TypedExpr[T] =
-    TypedExpr(TypedExpr.raw("floor(") |+| e.render |+| TypedExpr.raw(")"), e.codec)
+  def floor[T](e: TypedExpr[T]): TypedExpr[T] = sameTypeFn("floor", e)
 
   /** `trunc(x)` — truncate toward zero. */
-  def trunc[T](e: TypedExpr[T]): TypedExpr[T] =
-    TypedExpr(TypedExpr.raw("trunc(") |+| e.render |+| TypedExpr.raw(")"), e.codec)
+  def trunc[T](e: TypedExpr[T]): TypedExpr[T] = sameTypeFn("trunc", e)
 
   /** `round(x)` — round to nearest integer. */
-  def round[T](e: TypedExpr[T]): TypedExpr[T] =
-    TypedExpr(TypedExpr.raw("round(") |+| e.render |+| TypedExpr.raw(")"), e.codec)
+  def round[T](e: TypedExpr[T]): TypedExpr[T] = sameTypeFn("round", e)
 
   /** `round(x, digits)` — round to `digits` places. Only defined for `numeric` in Postgres. */
   def round[T](e: TypedExpr[T], digits: Int): TypedExpr[T] =
@@ -179,8 +176,7 @@ object Pg {
   // -------- Math with fixed `Double` return (NULL-propagating) --------
 
   /** `sqrt(x)`. */
-  def sqrt[T](e: TypedExpr[T])(using pf: PgTypeFor[Lift[T, Double]]): TypedExpr[Lift[T, Double]] =
-    TypedExpr(TypedExpr.raw("sqrt(") |+| e.render |+| TypedExpr.raw(")"), pf.codec)
+  def sqrt[T](e: TypedExpr[T])(using PgTypeFor[Lift[T, Double]]): TypedExpr[Lift[T, Double]] = doubleFn("sqrt", e)
 
   /** `power(a, b)` — `a` raised to the power `b`. Postgres always returns double precision. */
   def power[A, B](a: TypedExpr[A], b: TypedExpr[B])(using
@@ -192,16 +188,13 @@ object Pg {
     )
 
   /** `exp(x)`. */
-  def exp[T](e: TypedExpr[T])(using pf: PgTypeFor[Lift[T, Double]]): TypedExpr[Lift[T, Double]] =
-    TypedExpr(TypedExpr.raw("exp(") |+| e.render |+| TypedExpr.raw(")"), pf.codec)
+  def exp[T](e: TypedExpr[T])(using PgTypeFor[Lift[T, Double]]): TypedExpr[Lift[T, Double]] = doubleFn("exp", e)
 
   /** `ln(x)`. */
-  def ln[T](e: TypedExpr[T])(using pf: PgTypeFor[Lift[T, Double]]): TypedExpr[Lift[T, Double]] =
-    TypedExpr(TypedExpr.raw("ln(") |+| e.render |+| TypedExpr.raw(")"), pf.codec)
+  def ln[T](e: TypedExpr[T])(using PgTypeFor[Lift[T, Double]]): TypedExpr[Lift[T, Double]] = doubleFn("ln", e)
 
   /** `log(x)` — base-10. */
-  def log[T](e: TypedExpr[T])(using pf: PgTypeFor[Lift[T, Double]]): TypedExpr[Lift[T, Double]] =
-    TypedExpr(TypedExpr.raw("log(") |+| e.render |+| TypedExpr.raw(")"), pf.codec)
+  def log[T](e: TypedExpr[T])(using PgTypeFor[Lift[T, Double]]): TypedExpr[Lift[T, Double]] = doubleFn("log", e)
 
   /** `pi()` — constant. */
   val pi: TypedExpr[Double] = TypedExpr(TypedExpr.raw("pi()"), skunk.codec.all.float8)
@@ -226,13 +219,10 @@ object Pg {
   // -------- String (preserve tag — return input type) --------
 
   /** `trim(s)` — strip leading / trailing whitespace. */
-  def trim[T](e: TypedExpr[T])(using @annotation.unused ev: skunk.sharp.where.Stripped[T] <:< String): TypedExpr[T] =
-    TypedExpr(TypedExpr.raw("trim(") |+| e.render |+| TypedExpr.raw(")"), e.codec)
+  def trim[T](e: TypedExpr[T])(using StrLike[T]): TypedExpr[T] = stringPreserveFn("trim", e)
 
   /** `trim(chars FROM s)` — strip any of `chars` from both ends. */
-  def trim[T](e: TypedExpr[T], chars: String)(using
-    @annotation.unused ev: skunk.sharp.where.Stripped[T] <:< String
-  ): TypedExpr[T] =
+  def trim[T](e: TypedExpr[T], chars: String)(using StrLike[T]): TypedExpr[T] =
     TypedExpr(
       TypedExpr.raw("trim(") |+| TypedExpr.lit(chars).render |+| TypedExpr.raw(" FROM ") |+| e.render |+|
         TypedExpr.raw(")"),
@@ -240,17 +230,13 @@ object Pg {
     )
 
   /** `ltrim(s)`. */
-  def ltrim[T](e: TypedExpr[T])(using @annotation.unused ev: skunk.sharp.where.Stripped[T] <:< String): TypedExpr[T] =
-    TypedExpr(TypedExpr.raw("ltrim(") |+| e.render |+| TypedExpr.raw(")"), e.codec)
+  def ltrim[T](e: TypedExpr[T])(using StrLike[T]): TypedExpr[T] = stringPreserveFn("ltrim", e)
 
   /** `rtrim(s)`. */
-  def rtrim[T](e: TypedExpr[T])(using @annotation.unused ev: skunk.sharp.where.Stripped[T] <:< String): TypedExpr[T] =
-    TypedExpr(TypedExpr.raw("rtrim(") |+| e.render |+| TypedExpr.raw(")"), e.codec)
+  def rtrim[T](e: TypedExpr[T])(using StrLike[T]): TypedExpr[T] = stringPreserveFn("rtrim", e)
 
   /** `replace(s, from, to)`. */
-  def replace[T](e: TypedExpr[T], from: String, to: String)(using
-    @annotation.unused ev: skunk.sharp.where.Stripped[T] <:< String
-  ): TypedExpr[T] =
+  def replace[T](e: TypedExpr[T], from: String, to: String)(using StrLike[T]): TypedExpr[T] =
     TypedExpr(
       TypedExpr.raw("replace(") |+| e.render |+| TypedExpr.raw(", ") |+| TypedExpr.lit(from).render |+|
         TypedExpr.raw(", ") |+| TypedExpr.lit(to).render |+| TypedExpr.raw(")"),
@@ -258,51 +244,30 @@ object Pg {
     )
 
   /** `substring(s FROM n)` — 1-indexed start, no length cap. */
-  def substring[T](e: TypedExpr[T], from: Int)(using
-    @annotation.unused ev: skunk.sharp.where.Stripped[T] <:< String
-  ): TypedExpr[T] =
-    TypedExpr(
-      TypedExpr.raw("substring(") |+| e.render |+| TypedExpr.raw(s" FROM $from)"),
-      e.codec
-    )
+  def substring[T](e: TypedExpr[T], from: Int)(using StrLike[T]): TypedExpr[T] =
+    TypedExpr(TypedExpr.raw("substring(") |+| e.render |+| TypedExpr.raw(s" FROM $from)"), e.codec)
 
   /** `substring(s FROM n FOR m)` — 1-indexed start, `m` characters. */
-  def substring[T](e: TypedExpr[T], from: Int, forLen: Int)(using
-    @annotation.unused ev: skunk.sharp.where.Stripped[T] <:< String
-  ): TypedExpr[T] =
-    TypedExpr(
-      TypedExpr.raw("substring(") |+| e.render |+| TypedExpr.raw(s" FROM $from FOR $forLen)"),
-      e.codec
-    )
+  def substring[T](e: TypedExpr[T], from: Int, forLen: Int)(using StrLike[T]): TypedExpr[T] =
+    TypedExpr(TypedExpr.raw("substring(") |+| e.render |+| TypedExpr.raw(s" FROM $from FOR $forLen)"), e.codec)
 
   /** `left(s, n)` — first `n` chars (negative `n` drops the last `|n|`). */
-  def left[T](e: TypedExpr[T], n: Int)(using
-    @annotation.unused ev: skunk.sharp.where.Stripped[T] <:< String
-  ): TypedExpr[T] =
+  def left[T](e: TypedExpr[T], n: Int)(using StrLike[T]): TypedExpr[T] =
     TypedExpr(TypedExpr.raw("left(") |+| e.render |+| TypedExpr.raw(s", $n)"), e.codec)
 
   /** `right(s, n)` — last `n` chars. */
-  def right[T](e: TypedExpr[T], n: Int)(using
-    @annotation.unused ev: skunk.sharp.where.Stripped[T] <:< String
-  ): TypedExpr[T] =
+  def right[T](e: TypedExpr[T], n: Int)(using StrLike[T]): TypedExpr[T] =
     TypedExpr(TypedExpr.raw("right(") |+| e.render |+| TypedExpr.raw(s", $n)"), e.codec)
 
   /** `repeat(s, n)` — `s` repeated `n` times. */
-  def repeat[T](e: TypedExpr[T], n: Int)(using
-    @annotation.unused ev: skunk.sharp.where.Stripped[T] <:< String
-  ): TypedExpr[T] =
+  def repeat[T](e: TypedExpr[T], n: Int)(using StrLike[T]): TypedExpr[T] =
     TypedExpr(TypedExpr.raw("repeat(") |+| e.render |+| TypedExpr.raw(s", $n)"), e.codec)
 
   /** `reverse(s)`. */
-  def reverse[T](e: TypedExpr[T])(using
-    @annotation.unused ev: skunk.sharp.where.Stripped[T] <:< String
-  ): TypedExpr[T] =
-    TypedExpr(TypedExpr.raw("reverse(") |+| e.render |+| TypedExpr.raw(")"), e.codec)
+  def reverse[T](e: TypedExpr[T])(using StrLike[T]): TypedExpr[T] = stringPreserveFn("reverse", e)
 
   /** `regexp_replace(s, pattern, replacement)`. */
-  def regexpReplace[T](e: TypedExpr[T], pattern: String, replacement: String)(using
-    @annotation.unused ev: skunk.sharp.where.Stripped[T] <:< String
-  ): TypedExpr[T] =
+  def regexpReplace[T](e: TypedExpr[T], pattern: String, replacement: String)(using StrLike[T]): TypedExpr[T] =
     TypedExpr(
       TypedExpr.raw("regexp_replace(") |+| e.render |+| TypedExpr.raw(", ") |+|
         TypedExpr.lit(pattern).render |+| TypedExpr.raw(", ") |+| TypedExpr.lit(replacement).render |+|
@@ -311,9 +276,7 @@ object Pg {
     )
 
   /** `split_part(s, delim, field)` — split `s` on `delim`, return the 1-indexed `field`-th piece. */
-  def splitPart[T](e: TypedExpr[T], delim: String, field: Int)(using
-    @annotation.unused ev: skunk.sharp.where.Stripped[T] <:< String
-  ): TypedExpr[T] =
+  def splitPart[T](e: TypedExpr[T], delim: String, field: Int)(using StrLike[T]): TypedExpr[T] =
     TypedExpr(
       TypedExpr.raw("split_part(") |+| e.render |+| TypedExpr.raw(", ") |+|
         TypedExpr.lit(delim).render |+| TypedExpr.raw(s", $field)"),
@@ -323,22 +286,16 @@ object Pg {
   // -------- String functions with fixed `Int` return (NULL-propagating via [[Lift]]) --------
 
   /** `char_length(s)` — character count (synonym of [[length]]). */
-  def charLength[T](e: TypedExpr[T])(using
-    @annotation.unused ev: skunk.sharp.where.Stripped[T] <:< String,
-    pf: PgTypeFor[Lift[T, Int]]
-  ): TypedExpr[Lift[T, Int]] =
-    TypedExpr(TypedExpr.raw("char_length(") |+| e.render |+| TypedExpr.raw(")"), pf.codec)
+  def charLength[T](e: TypedExpr[T])(using StrLike[T], PgTypeFor[Lift[T, Int]]): TypedExpr[Lift[T, Int]] =
+    stringToIntFn("char_length", e)
 
   /** `octet_length(s)` — byte count. */
-  def octetLength[T](e: TypedExpr[T])(using
-    @annotation.unused ev: skunk.sharp.where.Stripped[T] <:< String,
-    pf: PgTypeFor[Lift[T, Int]]
-  ): TypedExpr[Lift[T, Int]] =
-    TypedExpr(TypedExpr.raw("octet_length(") |+| e.render |+| TypedExpr.raw(")"), pf.codec)
+  def octetLength[T](e: TypedExpr[T])(using StrLike[T], PgTypeFor[Lift[T, Int]]): TypedExpr[Lift[T, Int]] =
+    stringToIntFn("octet_length", e)
 
   /** `position(substr IN str)` — 1-indexed; returns 0 if not found, NULL if `str` is NULL. */
   def position[T](substr: String, in: TypedExpr[T])(using
-    @annotation.unused ev: skunk.sharp.where.Stripped[T] <:< String,
+    ev: StrLike[T],
     pf: PgTypeFor[Lift[T, Int]]
   ): TypedExpr[Lift[T, Int]] =
     TypedExpr(
@@ -346,6 +303,25 @@ object Pg {
         in.render |+| TypedExpr.raw(")"),
       pf.codec
     )
+
+  // -------- Private shape helpers — collapse repeated "fn(e)" wrappers --------
+
+  private def sameTypeFn[T](name: String, e: TypedExpr[T]): TypedExpr[T] =
+    TypedExpr(TypedExpr.raw(s"$name(") |+| e.render |+| TypedExpr.raw(")"), e.codec)
+
+  private def stringPreserveFn[T](name: String, e: TypedExpr[T])(using StrLike[T]): TypedExpr[T] =
+    TypedExpr(TypedExpr.raw(s"$name(") |+| e.render |+| TypedExpr.raw(")"), e.codec)
+
+  private def doubleFn[T](name: String, e: TypedExpr[T])(using
+    pf: PgTypeFor[Lift[T, Double]]
+  ): TypedExpr[Lift[T, Double]] =
+    TypedExpr(TypedExpr.raw(s"$name(") |+| e.render |+| TypedExpr.raw(")"), pf.codec)
+
+  private def stringToIntFn[T](name: String, e: TypedExpr[T])(using
+    ev: StrLike[T],
+    pf: PgTypeFor[Lift[T, Int]]
+  ): TypedExpr[Lift[T, Int]] =
+    TypedExpr(TypedExpr.raw(s"$name(") |+| e.render |+| TypedExpr.raw(")"), pf.codec)
 
   // -------- Aggregate functions --------
   //
@@ -378,8 +354,8 @@ object Pg {
    *   - `sum(double precision)` → `double precision` (`Double`)
    *
    * Codec for the result type is resolved via [[skunk.sharp.pg.PgTypeFor]] — no per-function typeclass needed. Users
-   * with custom numeric opaque types can either (a) provide a `PgTypeFor` and a `SumOf` case that routes through it,
-   * or (b) just use [[TypedExpr.cast]] at the call site.
+   * with custom numeric opaque types can either (a) provide a `PgTypeFor` and a `SumOf` case that routes through it, or
+   * (b) just use [[TypedExpr.cast]] at the call site.
    */
   def sum[I](expr: TypedExpr[I])(using pf: PgTypeFor[SumOf[I]]): TypedExpr[SumOf[I]] =
     TypedExpr(TypedExpr.raw("sum(") |+| expr.render |+| TypedExpr.raw(")"), pf.codec)
@@ -455,10 +431,10 @@ type Lift[T, U] = T match {
  * types) or by supplying your own `PgTypeFor[Out]` for a custom opaque type.
  */
 type SumOf[I] = I match {
-  case Short | Int            => Long
-  case Long | BigDecimal      => BigDecimal
-  case Float                  => Float
-  case Double                 => Double
+  case Short | Int       => Long
+  case Long | BigDecimal => BigDecimal
+  case Float             => Float
+  case Double            => Double
 }
 
 /** Type-level mapping of Postgres's `avg(I)` result type. See [[SumOf]] for the same rationale. */

--- a/modules/core/src/main/scala/skunk/sharp/PgFunction.scala
+++ b/modules/core/src/main/scala/skunk/sharp/PgFunction.scala
@@ -89,9 +89,9 @@ object Pg {
 
   /**
    * `lower(s)` — fold to lowercase. Accepts any string-like `TypedExpr` (bare `String`, tag types like `Varchar[N]` /
-   * `Bpchar[N]` / `Text`, or their `Option` variants — anything where `Stripped[T] <:< String`). Returns the input
-   * type back: tag information is preserved in the Scala type (PG returns `text` on the wire, but `Varchar[N]` /
-   * `Text` etc. all decode the same text bytes through the same codec, so the value is correct).
+   * `Bpchar[N]` / `Text`, or their `Option` variants — anything where `Stripped[T] <:< String`). Returns the input type
+   * back: tag information is preserved in the Scala type (PG returns `text` on the wire, but `Varchar[N]` / `Text` etc.
+   * all decode the same text bytes through the same codec, so the value is correct).
    */
   def lower[T](e: TypedExpr[T])(using @annotation.unused ev: skunk.sharp.where.Stripped[T] <:< String): TypedExpr[T] =
     TypedExpr(TypedExpr.raw("lower(") |+| e.render |+| TypedExpr.raw(")"), e.codec)
@@ -117,6 +117,235 @@ object Pg {
   /** Coalesce: `coalesce(a, b, c, …)` — returns the first non-null argument. */
   def coalesce[T](args: TypedExpr[T]*)(using pfr: PgTypeFor[T]): TypedExpr[T] =
     PgFunction.nary[T]("coalesce", args*)
+
+  // -------- Math (same type as input — codec is threaded through) --------
+  //
+  // Postgres is permissive about what numeric types these accept (smallint / integer / bigint / numeric / real /
+  // double precision). We don't bound `T` — if you pass a non-numeric `TypedExpr`, Postgres raises the error at
+  // execution time. Return type = input type so callers retain tag information (Int2, Numeric[P, S], …).
+
+  /** `abs(x)` — absolute value. Same type as input. */
+  def abs[T](e: TypedExpr[T]): TypedExpr[T] =
+    TypedExpr(TypedExpr.raw("abs(") |+| e.render |+| TypedExpr.raw(")"), e.codec)
+
+  /** `ceil(x)` — nearest integer greater than or equal to `x`. */
+  def ceil[T](e: TypedExpr[T]): TypedExpr[T] =
+    TypedExpr(TypedExpr.raw("ceil(") |+| e.render |+| TypedExpr.raw(")"), e.codec)
+
+  /** `floor(x)` — nearest integer less than or equal to `x`. */
+  def floor[T](e: TypedExpr[T]): TypedExpr[T] =
+    TypedExpr(TypedExpr.raw("floor(") |+| e.render |+| TypedExpr.raw(")"), e.codec)
+
+  /** `trunc(x)` — truncate toward zero. */
+  def trunc[T](e: TypedExpr[T]): TypedExpr[T] =
+    TypedExpr(TypedExpr.raw("trunc(") |+| e.render |+| TypedExpr.raw(")"), e.codec)
+
+  /** `round(x)` — round to nearest integer. */
+  def round[T](e: TypedExpr[T]): TypedExpr[T] =
+    TypedExpr(TypedExpr.raw("round(") |+| e.render |+| TypedExpr.raw(")"), e.codec)
+
+  /** `round(x, digits)` — round to `digits` places. Only defined for `numeric` in Postgres. */
+  def round[T](e: TypedExpr[T], digits: Int): TypedExpr[T] =
+    TypedExpr(
+      TypedExpr.raw("round(") |+| e.render |+| TypedExpr.raw(s", $digits)"),
+      e.codec
+    )
+
+  /** `mod(a, b)` — remainder. Same type as input (both arguments must agree). */
+  def mod[T](a: TypedExpr[T], b: TypedExpr[T]): TypedExpr[T] =
+    TypedExpr(
+      TypedExpr.raw("mod(") |+| a.render |+| TypedExpr.raw(", ") |+| b.render |+| TypedExpr.raw(")"),
+      a.codec
+    )
+
+  /** `greatest(a, b, …)` — largest of the arguments, SQL-NULL-tolerant (Postgres: non-null wins). */
+  def greatest[T](args: TypedExpr[T]*): TypedExpr[T] = {
+    require(args.nonEmpty, "greatest() needs at least one argument")
+    TypedExpr(
+      TypedExpr.raw("greatest(") |+| TypedExpr.joined(args.map(_.render).toList, ", ") |+| TypedExpr.raw(")"),
+      args.head.codec
+    )
+  }
+
+  /** `least(a, b, …)` — smallest of the arguments. */
+  def least[T](args: TypedExpr[T]*): TypedExpr[T] = {
+    require(args.nonEmpty, "least() needs at least one argument")
+    TypedExpr(
+      TypedExpr.raw("least(") |+| TypedExpr.joined(args.map(_.render).toList, ", ") |+| TypedExpr.raw(")"),
+      args.head.codec
+    )
+  }
+
+  // -------- Math with fixed `Double` return (NULL-propagating) --------
+
+  /** `sqrt(x)`. */
+  def sqrt[T](e: TypedExpr[T])(using pf: PgTypeFor[Lift[T, Double]]): TypedExpr[Lift[T, Double]] =
+    TypedExpr(TypedExpr.raw("sqrt(") |+| e.render |+| TypedExpr.raw(")"), pf.codec)
+
+  /** `power(a, b)` — `a` raised to the power `b`. Postgres always returns double precision. */
+  def power[A, B](a: TypedExpr[A], b: TypedExpr[B])(using
+    pf: PgTypeFor[Lift[A, Double]]
+  ): TypedExpr[Lift[A, Double]] =
+    TypedExpr(
+      TypedExpr.raw("power(") |+| a.render |+| TypedExpr.raw(", ") |+| b.render |+| TypedExpr.raw(")"),
+      pf.codec
+    )
+
+  /** `exp(x)`. */
+  def exp[T](e: TypedExpr[T])(using pf: PgTypeFor[Lift[T, Double]]): TypedExpr[Lift[T, Double]] =
+    TypedExpr(TypedExpr.raw("exp(") |+| e.render |+| TypedExpr.raw(")"), pf.codec)
+
+  /** `ln(x)`. */
+  def ln[T](e: TypedExpr[T])(using pf: PgTypeFor[Lift[T, Double]]): TypedExpr[Lift[T, Double]] =
+    TypedExpr(TypedExpr.raw("ln(") |+| e.render |+| TypedExpr.raw(")"), pf.codec)
+
+  /** `log(x)` — base-10. */
+  def log[T](e: TypedExpr[T])(using pf: PgTypeFor[Lift[T, Double]]): TypedExpr[Lift[T, Double]] =
+    TypedExpr(TypedExpr.raw("log(") |+| e.render |+| TypedExpr.raw(")"), pf.codec)
+
+  /** `pi()` — constant. */
+  val pi: TypedExpr[Double] = TypedExpr(TypedExpr.raw("pi()"), skunk.codec.all.float8)
+
+  /** `random()` — uniformly distributed in `[0, 1)`. */
+  val random: TypedExpr[Double] = TypedExpr(TypedExpr.raw("random()"), skunk.codec.all.float8)
+
+  // -------- NULL handling --------
+
+  /**
+   * `nullif(a, b)` — returns NULL if `a = b`, else `a`. Result is always nullable because the caller hasn't proven
+   * `a ≠ b` statically. `b` must have the same underlying type as `a` (modulo `Option` wrapping).
+   */
+  def nullif[T](a: TypedExpr[T], b: skunk.sharp.where.Stripped[T])(using
+    pf: PgTypeFor[skunk.sharp.where.Stripped[T]]
+  ): TypedExpr[Option[skunk.sharp.where.Stripped[T]]] =
+    TypedExpr(
+      TypedExpr.raw("nullif(") |+| a.render |+| TypedExpr.raw(", ") |+| TypedExpr.lit(b).render |+| TypedExpr.raw(")"),
+      pf.codec.opt
+    )
+
+  // -------- String (preserve tag — return input type) --------
+
+  /** `trim(s)` — strip leading / trailing whitespace. */
+  def trim[T](e: TypedExpr[T])(using @annotation.unused ev: skunk.sharp.where.Stripped[T] <:< String): TypedExpr[T] =
+    TypedExpr(TypedExpr.raw("trim(") |+| e.render |+| TypedExpr.raw(")"), e.codec)
+
+  /** `trim(chars FROM s)` — strip any of `chars` from both ends. */
+  def trim[T](e: TypedExpr[T], chars: String)(using
+    @annotation.unused ev: skunk.sharp.where.Stripped[T] <:< String
+  ): TypedExpr[T] =
+    TypedExpr(
+      TypedExpr.raw("trim(") |+| TypedExpr.lit(chars).render |+| TypedExpr.raw(" FROM ") |+| e.render |+|
+        TypedExpr.raw(")"),
+      e.codec
+    )
+
+  /** `ltrim(s)`. */
+  def ltrim[T](e: TypedExpr[T])(using @annotation.unused ev: skunk.sharp.where.Stripped[T] <:< String): TypedExpr[T] =
+    TypedExpr(TypedExpr.raw("ltrim(") |+| e.render |+| TypedExpr.raw(")"), e.codec)
+
+  /** `rtrim(s)`. */
+  def rtrim[T](e: TypedExpr[T])(using @annotation.unused ev: skunk.sharp.where.Stripped[T] <:< String): TypedExpr[T] =
+    TypedExpr(TypedExpr.raw("rtrim(") |+| e.render |+| TypedExpr.raw(")"), e.codec)
+
+  /** `replace(s, from, to)`. */
+  def replace[T](e: TypedExpr[T], from: String, to: String)(using
+    @annotation.unused ev: skunk.sharp.where.Stripped[T] <:< String
+  ): TypedExpr[T] =
+    TypedExpr(
+      TypedExpr.raw("replace(") |+| e.render |+| TypedExpr.raw(", ") |+| TypedExpr.lit(from).render |+|
+        TypedExpr.raw(", ") |+| TypedExpr.lit(to).render |+| TypedExpr.raw(")"),
+      e.codec
+    )
+
+  /** `substring(s FROM n)` — 1-indexed start, no length cap. */
+  def substring[T](e: TypedExpr[T], from: Int)(using
+    @annotation.unused ev: skunk.sharp.where.Stripped[T] <:< String
+  ): TypedExpr[T] =
+    TypedExpr(
+      TypedExpr.raw("substring(") |+| e.render |+| TypedExpr.raw(s" FROM $from)"),
+      e.codec
+    )
+
+  /** `substring(s FROM n FOR m)` — 1-indexed start, `m` characters. */
+  def substring[T](e: TypedExpr[T], from: Int, forLen: Int)(using
+    @annotation.unused ev: skunk.sharp.where.Stripped[T] <:< String
+  ): TypedExpr[T] =
+    TypedExpr(
+      TypedExpr.raw("substring(") |+| e.render |+| TypedExpr.raw(s" FROM $from FOR $forLen)"),
+      e.codec
+    )
+
+  /** `left(s, n)` — first `n` chars (negative `n` drops the last `|n|`). */
+  def left[T](e: TypedExpr[T], n: Int)(using
+    @annotation.unused ev: skunk.sharp.where.Stripped[T] <:< String
+  ): TypedExpr[T] =
+    TypedExpr(TypedExpr.raw("left(") |+| e.render |+| TypedExpr.raw(s", $n)"), e.codec)
+
+  /** `right(s, n)` — last `n` chars. */
+  def right[T](e: TypedExpr[T], n: Int)(using
+    @annotation.unused ev: skunk.sharp.where.Stripped[T] <:< String
+  ): TypedExpr[T] =
+    TypedExpr(TypedExpr.raw("right(") |+| e.render |+| TypedExpr.raw(s", $n)"), e.codec)
+
+  /** `repeat(s, n)` — `s` repeated `n` times. */
+  def repeat[T](e: TypedExpr[T], n: Int)(using
+    @annotation.unused ev: skunk.sharp.where.Stripped[T] <:< String
+  ): TypedExpr[T] =
+    TypedExpr(TypedExpr.raw("repeat(") |+| e.render |+| TypedExpr.raw(s", $n)"), e.codec)
+
+  /** `reverse(s)`. */
+  def reverse[T](e: TypedExpr[T])(using
+    @annotation.unused ev: skunk.sharp.where.Stripped[T] <:< String
+  ): TypedExpr[T] =
+    TypedExpr(TypedExpr.raw("reverse(") |+| e.render |+| TypedExpr.raw(")"), e.codec)
+
+  /** `regexp_replace(s, pattern, replacement)`. */
+  def regexpReplace[T](e: TypedExpr[T], pattern: String, replacement: String)(using
+    @annotation.unused ev: skunk.sharp.where.Stripped[T] <:< String
+  ): TypedExpr[T] =
+    TypedExpr(
+      TypedExpr.raw("regexp_replace(") |+| e.render |+| TypedExpr.raw(", ") |+|
+        TypedExpr.lit(pattern).render |+| TypedExpr.raw(", ") |+| TypedExpr.lit(replacement).render |+|
+        TypedExpr.raw(")"),
+      e.codec
+    )
+
+  /** `split_part(s, delim, field)` — split `s` on `delim`, return the 1-indexed `field`-th piece. */
+  def splitPart[T](e: TypedExpr[T], delim: String, field: Int)(using
+    @annotation.unused ev: skunk.sharp.where.Stripped[T] <:< String
+  ): TypedExpr[T] =
+    TypedExpr(
+      TypedExpr.raw("split_part(") |+| e.render |+| TypedExpr.raw(", ") |+|
+        TypedExpr.lit(delim).render |+| TypedExpr.raw(s", $field)"),
+      e.codec
+    )
+
+  // -------- String functions with fixed `Int` return (NULL-propagating via [[Lift]]) --------
+
+  /** `char_length(s)` — character count (synonym of [[length]]). */
+  def charLength[T](e: TypedExpr[T])(using
+    @annotation.unused ev: skunk.sharp.where.Stripped[T] <:< String,
+    pf: PgTypeFor[Lift[T, Int]]
+  ): TypedExpr[Lift[T, Int]] =
+    TypedExpr(TypedExpr.raw("char_length(") |+| e.render |+| TypedExpr.raw(")"), pf.codec)
+
+  /** `octet_length(s)` — byte count. */
+  def octetLength[T](e: TypedExpr[T])(using
+    @annotation.unused ev: skunk.sharp.where.Stripped[T] <:< String,
+    pf: PgTypeFor[Lift[T, Int]]
+  ): TypedExpr[Lift[T, Int]] =
+    TypedExpr(TypedExpr.raw("octet_length(") |+| e.render |+| TypedExpr.raw(")"), pf.codec)
+
+  /** `position(substr IN str)` — 1-indexed; returns 0 if not found, NULL if `str` is NULL. */
+  def position[T](substr: String, in: TypedExpr[T])(using
+    @annotation.unused ev: skunk.sharp.where.Stripped[T] <:< String,
+    pf: PgTypeFor[Lift[T, Int]]
+  ): TypedExpr[Lift[T, Int]] =
+    TypedExpr(
+      TypedExpr.raw("position(") |+| TypedExpr.lit(substr).render |+| TypedExpr.raw(" IN ") |+|
+        in.render |+| TypedExpr.raw(")"),
+      pf.codec
+    )
 
   // -------- Aggregate functions --------
   //
@@ -171,8 +400,8 @@ object Pg {
     TypedExpr(TypedExpr.raw("max(") |+| expr.render |+| TypedExpr.raw(")"), expr.codec)
 
   /**
-   * `string_agg(expr, sep)` — concatenate string values with a separator. Accepts any string-like tag on the
-   * aggregated expression.
+   * `string_agg(expr, sep)` — concatenate string values with a separator. Accepts any string-like tag on the aggregated
+   * expression.
    */
   def stringAgg[T](expr: TypedExpr[T], sep: String)(using
     @annotation.unused ev: skunk.sharp.where.Stripped[T] <:< String
@@ -211,8 +440,8 @@ object Pg {
 }
 
 /**
- * Preserve `T`'s nullability (or lack thereof) while changing the "base" type to `U`. Used by PG functions that have
- * a fixed non-input return type but still propagate NULL — e.g. `length(null) → null`, so
+ * Preserve `T`'s nullability (or lack thereof) while changing the "base" type to `U`. Used by PG functions that have a
+ * fixed non-input return type but still propagate NULL — e.g. `length(null) → null`, so
  * `length(TypedExpr[Option[String]]) → TypedExpr[Option[Int]]`.
  */
 type Lift[T, U] = T match {

--- a/modules/core/src/main/scala/skunk/sharp/where/Ops.scala
+++ b/modules/core/src/main/scala/skunk/sharp/where/Ops.scala
@@ -115,9 +115,12 @@ extension [T](lhs: TypedExpr[T]) {
 
 }
 
-extension [T](lhs: TypedExpr[T])(using @unused ev: Stripped[T] =:= String) {
+extension [T](lhs: TypedExpr[T])(using @unused ev: Stripped[T] <:< String) {
 
-  /** `lhs LIKE pattern`. Works on both `TypedExpr[String]` and `TypedExpr[Option[String]]`. */
+  /**
+   * `lhs LIKE pattern`. Works on any string-like column — `TypedExpr[String]`, tag types
+   * (`TypedExpr[Varchar[N]]`, `TypedExpr[Bpchar[N]]`, `TypedExpr[Text]`), and their `Option` variants.
+   */
   def like(pattern: String): Where = binOp("LIKE", lhs, TypedExpr.lit(pattern))
 
   /** `lhs ILIKE pattern` (case-insensitive). */

--- a/modules/core/src/main/scala/skunk/sharp/where/Ops.scala
+++ b/modules/core/src/main/scala/skunk/sharp/where/Ops.scala
@@ -118,8 +118,8 @@ extension [T](lhs: TypedExpr[T]) {
 extension [T](lhs: TypedExpr[T])(using @unused ev: Stripped[T] <:< String) {
 
   /**
-   * `lhs LIKE pattern`. Works on any string-like column — `TypedExpr[String]`, tag types
-   * (`TypedExpr[Varchar[N]]`, `TypedExpr[Bpchar[N]]`, `TypedExpr[Text]`), and their `Option` variants.
+   * `lhs LIKE pattern`. Works on any string-like column — `TypedExpr[String]`, tag types (`TypedExpr[Varchar[N]]`,
+   * `TypedExpr[Bpchar[N]]`, `TypedExpr[Text]`), and their `Option` variants.
    */
   def like(pattern: String): Where = binOp("LIKE", lhs, TypedExpr.lit(pattern))
 

--- a/modules/core/src/test/scala/skunk/sharp/PgFunctionSuite.scala
+++ b/modules/core/src/test/scala/skunk/sharp/PgFunctionSuite.scala
@@ -1,0 +1,144 @@
+package skunk.sharp
+
+import skunk.sharp.dsl.*
+
+import java.util.UUID
+
+object PgFunctionSuite {
+  case class Product(id: UUID, name: String, price: BigDecimal, qty: Int, weight: Double)
+}
+
+class PgFunctionSuite extends munit.FunSuite {
+  import PgFunctionSuite.*
+
+  private val products = Table.of[Product]("products")
+
+  // ---- Math (same type as input) ----
+
+  test("abs / ceil / floor / trunc / round render correctly and preserve input type") {
+    val af = products
+      .select(p => (Pg.abs(p.price), Pg.ceil(p.weight), Pg.floor(p.weight), Pg.trunc(p.price), Pg.round(p.price)))
+      .compile
+      .af
+    assertEquals(
+      af.fragment.sql,
+      """SELECT abs("price"), ceil("weight"), floor("weight"), trunc("price"), round("price") FROM "products""""
+    )
+  }
+
+  test("round with digits") {
+    val af = products.select(p => Pg.round(p.price, 2)).compile.af
+    assertEquals(af.fragment.sql, """SELECT round("price", 2) FROM "products"""")
+  }
+
+  test("mod(a, b)") {
+    val af = products.select(p => Pg.mod(p.qty, p.qty)).compile.af
+    assertEquals(af.fragment.sql, """SELECT mod("qty", "qty") FROM "products"""")
+  }
+
+  test("greatest / least — varargs, same type across args") {
+    val af = products
+      .select(p => (Pg.greatest(p.price, p.price), Pg.least(p.weight, p.weight, p.weight)))
+      .compile
+      .af
+    assertEquals(
+      af.fragment.sql,
+      """SELECT greatest("price", "price"), least("weight", "weight", "weight") FROM "products""""
+    )
+  }
+
+  // ---- Math returning Double via Lift ----
+
+  test("sqrt / ln / exp / log / power return Double via Lift") {
+    val af = products
+      .select(p => (Pg.sqrt(p.price), Pg.ln(p.weight), Pg.exp(p.weight), Pg.log(p.price), Pg.power(p.qty, p.qty)))
+      .compile
+      .af
+    assertEquals(
+      af.fragment.sql,
+      """SELECT sqrt("price"), ln("weight"), exp("weight"), log("price"), power("qty", "qty") FROM "products""""
+    )
+  }
+
+  test("pi / random") {
+    val af = empty.select(_ => (Pg.pi, Pg.random)).compile.af
+    assertEquals(af.fragment.sql, "SELECT pi(), random()")
+  }
+
+  // ---- NULL handling ----
+
+  test("nullif returns an Option and binds b as a literal parameter") {
+    val q                             = products.select(p => Pg.nullif(p.qty, 0)).compile
+    val _: CompiledQuery[Option[Int]] = q
+    assertEquals(q.af.fragment.sql, """SELECT nullif("qty", $1) FROM "products"""")
+  }
+
+  // ---- String (preserve tag) ----
+
+  test("trim / ltrim / rtrim") {
+    val af = products
+      .select(p => (Pg.trim(p.name), Pg.ltrim(p.name), Pg.rtrim(p.name)))
+      .compile
+      .af
+    assertEquals(
+      af.fragment.sql,
+      """SELECT trim("name"), ltrim("name"), rtrim("name") FROM "products""""
+    )
+  }
+
+  test("trim with chars arg — `trim(chars FROM s)`") {
+    val af = products.select(p => Pg.trim(p.name, " \t")).compile.af
+    assertEquals(af.fragment.sql, """SELECT trim($1 FROM "name") FROM "products"""")
+  }
+
+  test("replace / repeat / reverse") {
+    val af = products
+      .select(p => (Pg.replace(p.name, "a", "b"), Pg.repeat(p.name, 3), Pg.reverse(p.name)))
+      .compile
+      .af
+    assert(af.fragment.sql.contains("""replace("name", $1, $2)"""), af.fragment.sql)
+    assert(af.fragment.sql.contains("""repeat("name", 3)"""), af.fragment.sql)
+    assert(af.fragment.sql.contains("""reverse("name")"""), af.fragment.sql)
+  }
+
+  test("substring — single-arg and with FOR length") {
+    val af = products
+      .select(p => (Pg.substring(p.name, 2), Pg.substring(p.name, 2, 3)))
+      .compile
+      .af
+    assertEquals(
+      af.fragment.sql,
+      """SELECT substring("name" FROM 2), substring("name" FROM 2 FOR 3) FROM "products""""
+    )
+  }
+
+  test("left / right") {
+    val af = products.select(p => (Pg.left(p.name, 5), Pg.right(p.name, 5))).compile.af
+    assertEquals(
+      af.fragment.sql,
+      """SELECT left("name", 5), right("name", 5) FROM "products""""
+    )
+  }
+
+  test("regexpReplace / splitPart") {
+    val af = products
+      .select(p => (Pg.regexpReplace(p.name, "^[a-z]+", ""), Pg.splitPart(p.name, "-", 1)))
+      .compile
+      .af
+    assert(af.fragment.sql.contains("""regexp_replace("name", $1, $2)"""), af.fragment.sql)
+    assert(af.fragment.sql.contains("""split_part("name", $3, 1)"""), af.fragment.sql)
+  }
+
+  // ---- String returning Int via Lift ----
+
+  test("charLength / octetLength / position — Lift preserves input nullability") {
+    val af = products
+      .select(p => (Pg.charLength(p.name), Pg.octetLength(p.name), Pg.position("x", p.name)))
+      .compile
+      .af
+    assertEquals(
+      af.fragment.sql,
+      """SELECT char_length("name"), octet_length("name"), position($1 IN "name") FROM "products""""
+    )
+  }
+}

--- a/modules/core/src/test/scala/skunk/sharp/pg/TagsSuite.scala
+++ b/modules/core/src/test/scala/skunk/sharp/pg/TagsSuite.scala
@@ -98,7 +98,7 @@ class TagsSuite extends munit.FunSuite {
 
   test("Pg.lower / Pg.upper / Pg.length accept tagged string columns (Varchar[N] / Bpchar[N])") {
     val customers = Table.of[Customer]("customers")
-    val af = customers
+    val af        = customers
       .select(c => (Pg.lower(c.email), Pg.upper(c.name), Pg.length(c.email)))
       .compile
       .af
@@ -111,7 +111,7 @@ class TagsSuite extends munit.FunSuite {
 
   test(".like / .ilike accept tagged string columns") {
     val customers = Table.of[Customer]("customers")
-    val af = customers
+    val af        = customers
       .select
       .where(c => c.email.like("%@example.com") && c.name.ilike("alice%"))
       .compile

--- a/modules/core/src/test/scala/skunk/sharp/pg/TagsSuite.scala
+++ b/modules/core/src/test/scala/skunk/sharp/pg/TagsSuite.scala
@@ -95,4 +95,29 @@ class TagsSuite extends munit.FunSuite {
     )
     assert(c.email.startsWith("hello"), c.email)
   }
+
+  test("Pg.lower / Pg.upper / Pg.length accept tagged string columns (Varchar[N] / Bpchar[N])") {
+    val customers = Table.of[Customer]("customers")
+    val af = customers
+      .select(c => (Pg.lower(c.email), Pg.upper(c.name), Pg.length(c.email)))
+      .compile
+      .af
+
+    assertEquals(
+      af.fragment.sql,
+      """SELECT lower("email"), upper("name"), length("email") FROM "customers""""
+    )
+  }
+
+  test(".like / .ilike accept tagged string columns") {
+    val customers = Table.of[Customer]("customers")
+    val af = customers
+      .select
+      .where(c => c.email.like("%@example.com") && c.name.ilike("alice%"))
+      .compile
+      .af
+
+    assert(af.fragment.sql.contains("""LIKE $1"""), af.fragment.sql)
+    assert(af.fragment.sql.contains("""ILIKE $2"""), af.fragment.sql)
+  }
 }

--- a/modules/tests/src/test/scala/skunk/sharp/tests/GroupBySuite.scala
+++ b/modules/tests/src/test/scala/skunk/sharp/tests/GroupBySuite.scala
@@ -132,4 +132,62 @@ class GroupBySuite extends PgFixture {
       }
     }
   }
+
+  test("countDistinct — deduplicates across input rows") {
+    withContainers { containers =>
+      session(containers).use { s =>
+        for {
+          _ <- users.insert((id = UUID.randomUUID, email = "cd1@x", age = 99, deleted_at = None)).compile.run(s)
+          _ <- users.insert((id = UUID.randomUUID, email = "cd2@x", age = 99, deleted_at = None)).compile.run(s)
+          _ <- users.insert((id = UUID.randomUUID, email = "cd3@x", age = 100, deleted_at = None)).compile.run(s)
+          n <- users.select(u => Pg.countDistinct(u.age)).where(u => u.age >= 99).compile.unique(s)
+          _ = assert(n >= 2L, s"distinct ages ≥ 99 should be ≥ 2, got $n")
+        } yield ()
+      }
+    }
+  }
+
+  test("stringAgg concatenates emails per age-bucket using a separator") {
+    withContainers { containers =>
+      session(containers).use { s =>
+        val bucket = 77
+        for {
+          _ <- users.insert((id = UUID.randomUUID, email = "sa1@x", age = bucket, deleted_at = None)).compile.run(s)
+          _ <- users.insert((id = UUID.randomUUID, email = "sa2@x", age = bucket, deleted_at = None)).compile.run(s)
+          concat <- users.select(u => Pg.stringAgg(u.email, ", ")).where(u => u.age === bucket).compile.unique(s)
+          _ = assert(concat.contains("sa1@x") && concat.contains("sa2@x"), s"got '$concat'")
+          _ = assert(concat.contains(", "), s"separator missing: '$concat'")
+        } yield ()
+      }
+    }
+  }
+
+  test("boolAnd / boolOr over a predicate expression") {
+    withContainers { containers =>
+      session(containers).use { s =>
+        val bucket = 55
+        for {
+          _ <- users.insert((id = UUID.randomUUID, email = "ba1@x", age = bucket, deleted_at = None)).compile.run(s)
+          _ <- users.insert((id = UUID.randomUUID, email = "ba2@x", age = bucket, deleted_at = None)).compile.run(s)
+          // All rows in this bucket have age >= 10 — boolAnd should be true.
+          allPos <- users
+            .select(u => Pg.boolAnd(u.age >= 10))
+            .where(u => u.age === bucket)
+            .compile.unique(s)
+          // Not all are ≥ 100 — boolAnd should be false, boolOr should also be false.
+          allBig <- users
+            .select(u => Pg.boolAnd(u.age >= 100))
+            .where(u => u.age === bucket)
+            .compile.unique(s)
+          anyBig <- users
+            .select(u => Pg.boolOr(u.age >= 100))
+            .where(u => u.age === bucket)
+            .compile.unique(s)
+          _ = assertEquals(allPos, true)
+          _ = assertEquals(allBig, false)
+          _ = assertEquals(anyBig, false)
+        } yield ()
+      }
+    }
+  }
 }

--- a/modules/tests/src/test/scala/skunk/sharp/tests/PgFunctionSuite.scala
+++ b/modules/tests/src/test/scala/skunk/sharp/tests/PgFunctionSuite.scala
@@ -196,6 +196,26 @@ class PgFunctionSuite extends PgFixture {
     }
   }
 
+  // ---- Time accessors ----
+
+  test("now / currentTimestamp / currentDate / localTimestamp — all return the expected SQL types") {
+    withContainers { containers =>
+      session(containers).use { s =>
+        for {
+          n  <- empty.select(_ => Pg.now).compile.unique(s)
+          ct <- empty.select(_ => Pg.currentTimestamp).compile.unique(s)
+          cd <- empty.select(_ => Pg.currentDate).compile.unique(s)
+          lt <- empty.select(_ => Pg.localTimestamp).compile.unique(s)
+          // Not asserting absolute values — just that we decoded something non-null.
+          _ = assert(n.toEpochSecond > 0L, n.toString)
+          _ = assert(ct.toEpochSecond > 0L, ct.toString)
+          _ = assert(cd.toEpochDay > 0L, cd.toString)
+          _ = assert(lt.toLocalDate.toEpochDay > 0L, lt.toString)
+        } yield ()
+      }
+    }
+  }
+
   test("concat / coalesce") {
     withContainers { containers =>
       session(containers).use { s =>

--- a/modules/tests/src/test/scala/skunk/sharp/tests/PgFunctionSuite.scala
+++ b/modules/tests/src/test/scala/skunk/sharp/tests/PgFunctionSuite.scala
@@ -1,0 +1,213 @@
+package skunk.sharp.tests
+
+import skunk.sharp.dsl.*
+
+/**
+ * Integration tests for the built-in [[skunk.sharp.Pg]] functions. Uses `empty.select(...)` everywhere so we don't need
+ * a table — every test is a FROM-less SELECT that exercises one function end-to-end.
+ */
+class PgFunctionSuite extends PgFixture {
+
+  // ---- Math (same type as input) ----
+
+  test("abs / ceil / floor / trunc / round round-trip against Postgres") {
+    withContainers { containers =>
+      session(containers).use { s =>
+        for {
+          absRow   <- empty.select(_ => Pg.abs(lit(-42))).compile.unique(s)
+          ceilRow  <- empty.select(_ => Pg.ceil(lit(BigDecimal("1.2")))).compile.unique(s)
+          floorRow <- empty.select(_ => Pg.floor(lit(BigDecimal("1.8")))).compile.unique(s)
+          truncRow <- empty.select(_ => Pg.trunc(lit(BigDecimal("-1.9")))).compile.unique(s)
+          roundRow <- empty.select(_ => Pg.round(lit(BigDecimal("1.5")))).compile.unique(s)
+          _ = assertEquals(absRow, 42)
+          _ = assertEquals(ceilRow, BigDecimal(2))
+          _ = assertEquals(floorRow, BigDecimal(1))
+          _ = assertEquals(truncRow, BigDecimal(-1))
+          _ = assertEquals(roundRow, BigDecimal(2))
+        } yield ()
+      }
+    }
+  }
+
+  test("round(x, digits)") {
+    withContainers { containers =>
+      session(containers).use { s =>
+        empty.select(_ => Pg.round(lit(BigDecimal("1.2345")), 2)).compile.unique(s).map { v =>
+          assertEquals(v, BigDecimal("1.23"))
+        }
+      }
+    }
+  }
+
+  test("mod(a, b)") {
+    withContainers { containers =>
+      session(containers).use { s =>
+        empty.select(_ => Pg.mod(lit(10), lit(3))).compile.unique(s).map(v => assertEquals(v, 1))
+      }
+    }
+  }
+
+  test("greatest / least") {
+    withContainers { containers =>
+      session(containers).use { s =>
+        for {
+          g <- empty.select(_ => Pg.greatest(lit(1), lit(5), lit(3))).compile.unique(s)
+          l <- empty.select(_ => Pg.least(lit(1), lit(5), lit(3))).compile.unique(s)
+          _ = assertEquals(g, 5)
+          _ = assertEquals(l, 1)
+        } yield ()
+      }
+    }
+  }
+
+  // ---- Math returning Double ----
+
+  test("sqrt / power / exp / ln / log") {
+    withContainers { containers =>
+      session(containers).use { s =>
+        for {
+          sq <- empty.select(_ => Pg.sqrt(lit(9.0))).compile.unique(s)
+          pw <- empty.select(_ => Pg.power(lit(2.0), lit(10.0))).compile.unique(s)
+          ex <- empty.select(_ => Pg.exp(lit(0.0))).compile.unique(s)
+          ln <- empty.select(_ => Pg.ln(lit(1.0))).compile.unique(s)
+          lg <- empty.select(_ => Pg.log(lit(100.0))).compile.unique(s)
+          _ = assertEquals(sq, 3.0)
+          _ = assertEquals(pw, 1024.0)
+          _ = assertEquals(ex, 1.0)
+          _ = assertEquals(ln, 0.0)
+          _ = assertEquals(lg, 2.0)
+        } yield ()
+      }
+    }
+  }
+
+  test("pi / random (random bounded in [0, 1))") {
+    withContainers { containers =>
+      session(containers).use { s =>
+        for {
+          p <- empty.select(_ => Pg.pi).compile.unique(s)
+          r <- empty.select(_ => Pg.random).compile.unique(s)
+          _ = assert(math.abs(p - math.Pi) < 1e-9, s"pi was $p")
+          _ = assert(r >= 0.0 && r < 1.0, s"random out of range: $r")
+        } yield ()
+      }
+    }
+  }
+
+  // ---- NULL handling ----
+
+  test("nullif — equal → NULL, unequal → the first value") {
+    withContainers { containers =>
+      session(containers).use { s =>
+        for {
+          eq  <- empty.select(_ => Pg.nullif(lit(5), 5)).compile.unique(s)
+          neq <- empty.select(_ => Pg.nullif(lit(5), 3)).compile.unique(s)
+          _ = assertEquals(eq, Option.empty[Int])
+          _ = assertEquals(neq, Option(5))
+        } yield ()
+      }
+    }
+  }
+
+  // ---- String functions preserving tag (return String) ----
+
+  test("lower / upper") {
+    withContainers { containers =>
+      session(containers).use { s =>
+        for {
+          lo <- empty.select(_ => Pg.lower(lit("HELLO"))).compile.unique(s)
+          up <- empty.select(_ => Pg.upper(lit("hello"))).compile.unique(s)
+          _ = assertEquals(lo, "hello")
+          _ = assertEquals(up, "HELLO")
+        } yield ()
+      }
+    }
+  }
+
+  test("trim / ltrim / rtrim / trim(chars, s)") {
+    withContainers { containers =>
+      session(containers).use { s =>
+        for {
+          t  <- empty.select(_ => Pg.trim(lit("  hi  "))).compile.unique(s)
+          lt <- empty.select(_ => Pg.ltrim(lit("  hi  "))).compile.unique(s)
+          rt <- empty.select(_ => Pg.rtrim(lit("  hi  "))).compile.unique(s)
+          tc <- empty.select(_ => Pg.trim(lit("xxhiyy"), "xy")).compile.unique(s)
+          _ = assertEquals(t, "hi")
+          _ = assertEquals(lt, "hi  ")
+          _ = assertEquals(rt, "  hi")
+          _ = assertEquals(tc, "hi")
+        } yield ()
+      }
+    }
+  }
+
+  test("replace / substring / left / right / repeat / reverse") {
+    withContainers { containers =>
+      session(containers).use { s =>
+        for {
+          r  <- empty.select(_ => Pg.replace(lit("a-b-c"), "-", "/")).compile.unique(s)
+          s1 <- empty.select(_ => Pg.substring(lit("hello world"), 7)).compile.unique(s)
+          s2 <- empty.select(_ => Pg.substring(lit("hello world"), 1, 5)).compile.unique(s)
+          lf <- empty.select(_ => Pg.left(lit("hello"), 3)).compile.unique(s)
+          rg <- empty.select(_ => Pg.right(lit("hello"), 3)).compile.unique(s)
+          rp <- empty.select(_ => Pg.repeat(lit("ab"), 3)).compile.unique(s)
+          rv <- empty.select(_ => Pg.reverse(lit("abc"))).compile.unique(s)
+          _ = assertEquals(r, "a/b/c")
+          _ = assertEquals(s1, "world")
+          _ = assertEquals(s2, "hello")
+          _ = assertEquals(lf, "hel")
+          _ = assertEquals(rg, "llo")
+          _ = assertEquals(rp, "ababab")
+          _ = assertEquals(rv, "cba")
+        } yield ()
+      }
+    }
+  }
+
+  test("regexpReplace / splitPart") {
+    withContainers { containers =>
+      session(containers).use { s =>
+        for {
+          rr <- empty.select(_ => Pg.regexpReplace(lit("foo123bar"), "[0-9]+", "-")).compile.unique(s)
+          sp <- empty.select(_ => Pg.splitPart(lit("a-b-c"), "-", 2)).compile.unique(s)
+          _ = assertEquals(rr, "foo-bar")
+          _ = assertEquals(sp, "b")
+        } yield ()
+      }
+    }
+  }
+
+  // ---- String functions returning Int ----
+
+  test("length / charLength / octetLength / position") {
+    withContainers { containers =>
+      session(containers).use { s =>
+        for {
+          l   <- empty.select(_ => Pg.length(lit("abc"))).compile.unique(s)
+          cl  <- empty.select(_ => Pg.charLength(lit("abc"))).compile.unique(s)
+          ol  <- empty.select(_ => Pg.octetLength(lit("abc"))).compile.unique(s)
+          pos <- empty.select(_ => Pg.position("b", lit("abc"))).compile.unique(s)
+          _ = assertEquals(l, 3)
+          _ = assertEquals(cl, 3)
+          _ = assertEquals(ol, 3)
+          _ = assertEquals(pos, 2)
+        } yield ()
+      }
+    }
+  }
+
+  test("concat / coalesce") {
+    withContainers { containers =>
+      session(containers).use { s =>
+        for {
+          cc <- empty.select(_ => Pg.concat(lit("a"), lit("b"), lit("c"))).compile.unique(s)
+          co <- empty.select(_ =>
+            Pg.coalesce(lit[Option[String]](None), lit[Option[String]](Some("fallback")))
+          ).compile.unique(s)
+          _ = assertEquals(cc, "abc")
+          _ = assertEquals(co, Option("fallback"))
+        } yield ()
+      }
+    }
+  }
+}

--- a/modules/tests/src/test/scala/skunk/sharp/tests/SubquerySuite.scala
+++ b/modules/tests/src/test/scala/skunk/sharp/tests/SubquerySuite.scala
@@ -65,6 +65,33 @@ class SubquerySuite extends PgFixture {
     }
   }
 
+  test("correlated NOT EXISTS — users with no posts") {
+    withContainers { containers =>
+      session(containers).use { s =>
+        val uidWith = UUID.randomUUID
+        val uidWO   = UUID.randomUUID
+        for {
+          _ <- users
+            .insert((id = uidWith, email = "nex-with@x", age = 50, deleted_at = Option.empty[OffsetDateTime]))
+            .compile.run(s)
+          _ <- users
+            .insert((id = uidWO, email = "nex-without@x", age = 51, deleted_at = Option.empty[OffsetDateTime]))
+            .compile.run(s)
+          _    <- posts.insert((id = UUID.randomUUID, user_id = uidWith, title = "nex")).compile.run(s)
+          rows <- users
+            .alias("u")
+            .select(u => u.email)
+            .where(u =>
+              u.id.in(cats.data.NonEmptyList.of(uidWith, uidWO)) &&
+                Pg.notExists(posts.select(_ => lit(1)).where(p => p.user_id ==== u.id))
+            )
+            .compile.run(s)
+          _ = assertEquals(rows, List("nex-without@x"))
+        } yield ()
+      }
+    }
+  }
+
   test("correlated scalar subquery in projection — email + per-user post count") {
     withContainers { containers =>
       session(containers).use { s =>


### PR DESCRIPTION
## Summary

- `Pg.lower` / `Pg.upper` / `Pg.length` / `Pg.stringAgg` and `.like` / `.ilike` now accept every string-like tag (`Varchar[N]`, `Bpchar[N]`, `Text`) and their `Option` variants — constrained on `Stripped[T] <:< String`.
- `lower` / `upper` preserve the input type; `length` returns `Lift[T, Int]` via a new generic match type that preserves input nullability.

## Rationale

`TypedExpr` is invariant, so even though `Varchar[256] <: String`, `TypedExpr[Varchar[256]]` is **not** a subtype of `TypedExpr[String]`. The old val-based signatures (`TypedExpr[String] => TypedExpr[String]`) silently blocked any tagged input from compiling. Now they accept anything that reduces to a string via `Stripped[T]`, which covers every tag we ship plus `Option`-wrapped variants.

The new `Lift[T, U]` match type is reusable for every PG function with a fixed non-input return type that still propagates NULL (there'll be more once we land the Tier 1 function batch).

## Test plan

- [x] 2 new TagsSuite cases: `Pg.lower`/`upper`/`length` on `Varchar[N]`/`Bpchar[N]`, and `.like`/`.ilike` on tagged columns.
- [x] `sbt core/test` — 131 green.

## Notes

Match types see through opaque subtyping, so the sum/avg refactor in #18 gets tag-input support "for free" (`Pg.sum(int2Col)` → `TypedExpr[Long]` via `Int2 <: Short`). No change needed in that PR beyond what's already there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)