### PR TITLE
README: state project goals and non-goals

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,16 +5,32 @@
 
 A Scala 3 library for **compile-time checked Postgres queries** on top of [skunk](https://typelevel.org/skunk). Describe a table once, then write SELECT / INSERT / UPDATE / DELETE / JOIN statements where column names, operator/value types, nullability, INSERT completeness, and mutability (table vs view) are all verified by the compiler. Validate your table descriptions against a live database at service init.
 
-> :warning: Early development. APIs will change.
+> :warning: Early development. APIs will change. **This is mostly an experiment** — see the goals below.
 
-## Why?
+## Goals and non-goals
 
-Skunk gives you correct encoders/decoders and the `sql""` macro, but queries still live as SQL strings with codecs attached separately. If a column is renamed, a comparison targets the wrong type, or a nullable value is treated as non-null, you find out at runtime. skunk-sharp moves those failures into `sbt compile`, and validates that your declared tables still match the database at boot.
+**Goals:**
+
+- A **type-safer** way to write SQL on top of skunk. Not replacing SQL — this is still SQL, just validated. Column names, operator/value types, nullability, INSERT completeness, mutation vs read-only (Table vs View), locking scope — all checked by the compiler.
+- **Schema validation** against a live database at service init — `information_schema` diff, report-only or fail-fast.
+- **Scala 3 only.** Deliberately leaning into the modern type system: match types, opaque tags with upper bounds, extension methods, `inline`, named tuples, polymorphic function types.
+- **Compile-time as much as possible** — but not at any cost. Low-level macro wizardry is avoided when a match type + `inline` reads well enough. Macros are the last resort, not the first.
+- **AI-assisted delivery.** Function catalogues, operator sets, mechanical rewrites across modules — these are the kind of work an LLM is good at and a human is slow at. The design decisions stay with the human; the busywork doesn't.
+- **Extensible where it's cheap.** The DSL's vocabulary is `TypedExpr[T]`; third-party modules add operators and functions via `extension` methods, tags, and mixin traits (`Pg` is a stack of `PgNumeric`/`PgString`/… — users can swap in their own bundle).
+- **Postgres-only, skunk-only.** No pretence of multi-backend support. Postgres is rich enough and skunk is good enough that abstracting doesn't earn its keep.
+
+**Non-goals:**
+
+- **Not replacing SQL.** You still think in SQL. The DSL mirrors the SQL you'd write. If you want an ORM or a query abstraction, look elsewhere.
+- **Not more than SQL — no DDL.** Schema is owned by migrations (dumbo, Flyway, whatever). We validate against it; we don't generate it.
+- **No speculative extension points.** We add extension hooks when a concrete module needs one (jsonb, ltree, arrays), not to "support a future that isn't now". Sealed stays sealed until an actual use case shows up.
+- **Not cross-database.** No MySQL, no SQLite, no H2.
 
 ## Modules
 
 - `skunk-sharp-core` — the DSL: table/view descriptions, WHERE / ORDER BY / GROUP BY / HAVING / LIMIT / OFFSET, SELECT / INSERT / UPDATE / DELETE, N-way INNER / LEFT / CROSS JOINs with auto-alias, row locking, `ON CONFLICT`, `RETURNING`, aggregates, subqueries (scalar / `IN` / `EXISTS`, correlated or uncorrelated), and the schema validator.
 - `skunk-sharp-iron` — optional [Iron](https://iltotore.github.io/iron/) refinement support (e.g. `String :| MaxLength[256]` maps to `varchar(256)`).
+- `skunk-sharp-circe` — Postgres `json` / `jsonb` via [skunk-circe](https://typelevel.org/skunk), with parametric `Jsonb[A]` / `Json[A]` tags that round-trip typed case classes.
 
 ## Quick tour
 

--- a/README.md
+++ b/README.md
@@ -5,13 +5,22 @@
 
 A Scala 3 library for **compile-time checked Postgres queries** on top of [skunk](https://typelevel.org/skunk). Describe a table once, then write SELECT / INSERT / UPDATE / DELETE / JOIN statements where column names, operator/value types, nullability, INSERT completeness, and mutability (table vs view) are all verified by the compiler. Validate your table descriptions against a live database at service init.
 
-> :warning: Early development. APIs will change. **This is mostly an experiment** — see the goals below.
+> :warning: Early development. APIs will change. **This is mostly an experiment** — see the scope below.
+
+## Scope: this is not a SQL replacement
+
+**skunk-sharp does not replace SQL.** It is a *type-safer* way to write a subset of common SQL on top of skunk, and nothing more:
+
+- **SQL is the target.** The DSL mirrors the SQL you'd otherwise hand-write. If you already know SQL, skunk-sharp reads like SQL. If you want a query abstraction that hides SQL, look elsewhere — this isn't that.
+- **This won't cover every SQL feature, and it shouldn't try.** Postgres's SQL surface is vast. Attempting 100% coverage through a typed DSL would either mean a mountain of machinery nobody needs or a leaky abstraction that lies about what Postgres does. Neither is worth shipping.
+- **If you need the full flexibility of SQL, use skunk's `sql"…"` directly.** That interpolator is the ground truth. skunk-sharp covers the queries that are repetitive, mechanical, and easy to get wrong in string form (typo in a column name, comparison against the wrong type, forgetting a required column in an INSERT, nullable mishandled as non-null). Anything beyond that — recursive CTEs with clever tricks, window functions with custom frames, obscure `plpgsql`, server-side procedural code — belongs in raw SQL.
+- **Mixed use is fine and expected.** Your codebase can have skunk-sharp queries for the common cases and raw `sql"…"` queries for the complex ones. They share the same session; they share the same codecs. There's no lock-in either way.
 
 ## Goals and non-goals
 
 **Goals:**
 
-- A **type-safer** way to write SQL on top of skunk. Not replacing SQL — this is still SQL, just validated. Column names, operator/value types, nullability, INSERT completeness, mutation vs read-only (Table vs View), locking scope — all checked by the compiler.
+- A **type-safer** way to write the *common* subset of SQL on top of skunk. Column names, operator/value types, nullability, INSERT completeness, mutation vs read-only (Table vs View), locking scope — all checked by the compiler.
 - **Schema validation** against a live database at service init — `information_schema` diff, report-only or fail-fast.
 - **Scala 3 only.** Deliberately leaning into the modern type system: match types, opaque tags with upper bounds, extension methods, `inline`, named tuples, polymorphic function types.
 - **Compile-time as much as possible** — but not at any cost. Low-level macro wizardry is avoided when a match type + `inline` reads well enough. Macros are the last resort, not the first.
@@ -21,7 +30,8 @@ A Scala 3 library for **compile-time checked Postgres queries** on top of [skunk
 
 **Non-goals:**
 
-- **Not replacing SQL.** You still think in SQL. The DSL mirrors the SQL you'd write. If you want an ORM or a query abstraction, look elsewhere.
+- **Not replacing SQL.** Not an ORM. Not a query abstraction that hides the SQL shape. Drop to `sql"…"` whenever skunk-sharp doesn't fit.
+- **Not full SQL coverage.** Niche / rarely-used features stay in `sql"…"`. The DSL targets the common path.
 - **Not more than SQL — no DDL.** Schema is owned by migrations (dumbo, Flyway, whatever). We validate against it; we don't generate it.
 - **No speculative extension points.** We add extension hooks when a concrete module needs one (jsonb, ltree, arrays), not to "support a future that isn't now". Sealed stays sealed until an actual use case shows up.
 - **Not cross-database.** No MySQL, no SQLite, no H2.

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ A Scala 3 library for **compile-time checked Postgres queries** on top of [skunk
 - **Not replacing SQL.** Not an ORM. Not a query abstraction that hides the SQL shape. Drop to `sql"…"` whenever skunk-sharp doesn't fit.
 - **Not full SQL coverage.** Niche / rarely-used features stay in `sql"…"`. The DSL targets the common path.
 - **Not more than SQL — no DDL.** Schema is owned by migrations (dumbo, Flyway, whatever). We validate against it; we don't generate it.
+- **No query optimisation of any kind.** skunk-sharp translates a typed builder to the corresponding SQL, nothing more — no rewrite passes, no predicate push-down, no join reordering, no hint injection. The Postgres planner is in charge. If a rendered query is slow, the fix is in the query you wrote (or in an `EXPLAIN` + index you're missing), not in anything we'll do to the tree.
 - **No speculative extension points.** We add extension hooks when a concrete module needs one (jsonb, ltree, arrays), not to "support a future that isn't now". Sealed stays sealed until an actual use case shows up.
 - **Not cross-database.** No MySQL, no SQLite, no H2.
 


### PR DESCRIPTION
Spell out scope: typesafer SQL (not replacing SQL), schema validation, Scala 3 only, compile-time where cheap, AI-assisted delivery, extensible where concrete, Postgres-only. Explicit non-goals: no DDL, no speculative extension points, no cross-database. Also lists skunk-sharp-circe in Modules (was missing since #25).