### PR TITLE
Integration tests: migrate to munit-cats-effect assertIO

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,16 +5,32 @@
 
 A Scala 3 library for **compile-time checked Postgres queries** on top of [skunk](https://typelevel.org/skunk). Describe a table once, then write SELECT / INSERT / UPDATE / DELETE / JOIN statements where column names, operator/value types, nullability, INSERT completeness, and mutability (table vs view) are all verified by the compiler. Validate your table descriptions against a live database at service init.
 
-> :warning: Early development. APIs will change.
+> :warning: Early development. APIs will change. **This is mostly an experiment** — see the goals below.
 
-## Why?
+## Goals and non-goals
 
-Skunk gives you correct encoders/decoders and the `sql""` macro, but queries still live as SQL strings with codecs attached separately. If a column is renamed, a comparison targets the wrong type, or a nullable value is treated as non-null, you find out at runtime. skunk-sharp moves those failures into `sbt compile`, and validates that your declared tables still match the database at boot.
+**Goals:**
+
+- A **type-safer** way to write SQL on top of skunk. Not replacing SQL — this is still SQL, just validated. Column names, operator/value types, nullability, INSERT completeness, mutation vs read-only (Table vs View), locking scope — all checked by the compiler.
+- **Schema validation** against a live database at service init — `information_schema` diff, report-only or fail-fast.
+- **Scala 3 only.** Deliberately leaning into the modern type system: match types, opaque tags with upper bounds, extension methods, `inline`, named tuples, polymorphic function types.
+- **Compile-time as much as possible** — but not at any cost. Low-level macro wizardry is avoided when a match type + `inline` reads well enough. Macros are the last resort, not the first.
+- **AI-assisted delivery.** Function catalogues, operator sets, mechanical rewrites across modules — these are the kind of work an LLM is good at and a human is slow at. The design decisions stay with the human; the busywork doesn't.
+- **Extensible where it's cheap.** The DSL's vocabulary is `TypedExpr[T]`; third-party modules add operators and functions via `extension` methods, tags, and mixin traits (`Pg` is a stack of `PgNumeric`/`PgString`/… — users can swap in their own bundle).
+- **Postgres-only, skunk-only.** No pretence of multi-backend support. Postgres is rich enough and skunk is good enough that abstracting doesn't earn its keep.
+
+**Non-goals:**
+
+- **Not replacing SQL.** You still think in SQL. The DSL mirrors the SQL you'd write. If you want an ORM or a query abstraction, look elsewhere.
+- **Not more than SQL — no DDL.** Schema is owned by migrations (dumbo, Flyway, whatever). We validate against it; we don't generate it.
+- **No speculative extension points.** We add extension hooks when a concrete module needs one (jsonb, ltree, arrays), not to "support a future that isn't now". Sealed stays sealed until an actual use case shows up.
+- **Not cross-database.** No MySQL, no SQLite, no H2.
 
 ## Modules
 
 - `skunk-sharp-core` — the DSL: table/view descriptions, WHERE / ORDER BY / GROUP BY / HAVING / LIMIT / OFFSET, SELECT / INSERT / UPDATE / DELETE, N-way INNER / LEFT / CROSS JOINs with auto-alias, row locking, `ON CONFLICT`, `RETURNING`, aggregates, subqueries (scalar / `IN` / `EXISTS`, correlated or uncorrelated), and the schema validator.
 - `skunk-sharp-iron` — optional [Iron](https://iltotore.github.io/iron/) refinement support (e.g. `String :| MaxLength[256]` maps to `varchar(256)`).
+- `skunk-sharp-circe` — Postgres `json` / `jsonb` via [skunk-circe](https://typelevel.org/skunk), with parametric `Jsonb[A]` / `Json[A]` tags that round-trip typed case classes.
 
 ## Quick tour
 

--- a/README.md
+++ b/README.md
@@ -5,13 +5,22 @@
 
 A Scala 3 library for **compile-time checked Postgres queries** on top of [skunk](https://typelevel.org/skunk). Describe a table once, then write SELECT / INSERT / UPDATE / DELETE / JOIN statements where column names, operator/value types, nullability, INSERT completeness, and mutability (table vs view) are all verified by the compiler. Validate your table descriptions against a live database at service init.
 
-> :warning: Early development. APIs will change. **This is mostly an experiment** — see the goals below.
+> :warning: Early development. APIs will change. **This is mostly an experiment** — see the scope below.
+
+## Scope: this is not a SQL replacement
+
+**skunk-sharp does not replace SQL.** It is a *type-safer* way to write a subset of common SQL on top of skunk, and nothing more:
+
+- **SQL is the target.** The DSL mirrors the SQL you'd otherwise hand-write. If you already know SQL, skunk-sharp reads like SQL. If you want a query abstraction that hides SQL, look elsewhere — this isn't that.
+- **This won't cover every SQL feature, and it shouldn't try.** Postgres's SQL surface is vast. Attempting 100% coverage through a typed DSL would either mean a mountain of machinery nobody needs or a leaky abstraction that lies about what Postgres does. Neither is worth shipping.
+- **If you need the full flexibility of SQL, use skunk's `sql"…"` directly.** That interpolator is the ground truth. skunk-sharp covers the queries that are repetitive, mechanical, and easy to get wrong in string form (typo in a column name, comparison against the wrong type, forgetting a required column in an INSERT, nullable mishandled as non-null). Anything beyond that — recursive CTEs with clever tricks, window functions with custom frames, obscure `plpgsql`, server-side procedural code — belongs in raw SQL.
+- **Mixed use is fine and expected.** Your codebase can have skunk-sharp queries for the common cases and raw `sql"…"` queries for the complex ones. They share the same session; they share the same codecs. There's no lock-in either way.
 
 ## Goals and non-goals
 
 **Goals:**
 
-- A **type-safer** way to write SQL on top of skunk. Not replacing SQL — this is still SQL, just validated. Column names, operator/value types, nullability, INSERT completeness, mutation vs read-only (Table vs View), locking scope — all checked by the compiler.
+- A **type-safer** way to write the *common* subset of SQL on top of skunk. Column names, operator/value types, nullability, INSERT completeness, mutation vs read-only (Table vs View), locking scope — all checked by the compiler.
 - **Schema validation** against a live database at service init — `information_schema` diff, report-only or fail-fast.
 - **Scala 3 only.** Deliberately leaning into the modern type system: match types, opaque tags with upper bounds, extension methods, `inline`, named tuples, polymorphic function types.
 - **Compile-time as much as possible** — but not at any cost. Low-level macro wizardry is avoided when a match type + `inline` reads well enough. Macros are the last resort, not the first.
@@ -21,7 +30,8 @@ A Scala 3 library for **compile-time checked Postgres queries** on top of [skunk
 
 **Non-goals:**
 
-- **Not replacing SQL.** You still think in SQL. The DSL mirrors the SQL you'd write. If you want an ORM or a query abstraction, look elsewhere.
+- **Not replacing SQL.** Not an ORM. Not a query abstraction that hides the SQL shape. Drop to `sql"…"` whenever skunk-sharp doesn't fit.
+- **Not full SQL coverage.** Niche / rarely-used features stay in `sql"…"`. The DSL targets the common path.
 - **Not more than SQL — no DDL.** Schema is owned by migrations (dumbo, Flyway, whatever). We validate against it; we don't generate it.
 - **No speculative extension points.** We add extension hooks when a concrete module needs one (jsonb, ltree, arrays), not to "support a future that isn't now". Sealed stays sealed until an actual use case shows up.
 - **Not cross-database.** No MySQL, no SQLite, no H2.

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ A Scala 3 library for **compile-time checked Postgres queries** on top of [skunk
 - **Not replacing SQL.** Not an ORM. Not a query abstraction that hides the SQL shape. Drop to `sql"…"` whenever skunk-sharp doesn't fit.
 - **Not full SQL coverage.** Niche / rarely-used features stay in `sql"…"`. The DSL targets the common path.
 - **Not more than SQL — no DDL.** Schema is owned by migrations (dumbo, Flyway, whatever). We validate against it; we don't generate it.
+- **No query optimisation of any kind.** skunk-sharp translates a typed builder to the corresponding SQL, nothing more — no rewrite passes, no predicate push-down, no join reordering, no hint injection. The Postgres planner is in charge. If a rendered query is slow, the fix is in the query you wrote (or in an `EXPLAIN` + index you're missing), not in anything we'll do to the tree.
 - **No speculative extension points.** We add extension hooks when a concrete module needs one (jsonb, ltree, arrays), not to "support a future that isn't now". Sealed stays sealed until an actual use case shows up.
 - **Not cross-database.** No MySQL, no SQLite, no H2.
 

--- a/modules/tests/src/test/scala/skunk/sharp/tests/DslRoundTripSuite.scala
+++ b/modules/tests/src/test/scala/skunk/sharp/tests/DslRoundTripSuite.scala
@@ -1,6 +1,5 @@
 package skunk.sharp.tests
 
-import cats.effect.IO
 import skunk.sharp.dsl.*
 
 import java.time.OffsetDateTime
@@ -39,16 +38,12 @@ class DslRoundTripSuite extends PgFixture {
               created_at = now,
               deleted_at = None
             )).compile.run(s)
-          all <- users.select.compile.run(s)
-          _ = assertEquals(all.size, 2)
-          adult <- users.select.where(u => u.age >= 18).compile.run(s)
-          _ = assertEquals(adult.size, 2)
-          _     <- users.update.set(u => u.age := 31).where(u => u.id === aliceId).compile.run(s)
-          alice <- users.select.where(u => u.id === aliceId).compile.run(s)
-          _ = assertEquals(alice.map(_.age), List(31))
-          _      <- users.delete.where(u => u.id === bobId).compile.run(s)
-          final_ <- users.select.compile.run(s)
-          _ = assertEquals(final_.size, 1)
+          _ <- assertIO(users.select.compile.run(s).map(_.size), 2)
+          _ <- assertIO(users.select.where(u => u.age >= 18).compile.run(s).map(_.size), 2)
+          _ <- users.update.set(u => u.age := 31).where(u => u.id === aliceId).compile.run(s)
+          _ <- assertIO(users.select.where(u => u.id === aliceId).compile.run(s).map(_.map(_.age)), List(31))
+          _ <- users.delete.where(u => u.id === bobId).compile.run(s)
+          _ <- assertIO(users.select.compile.run(s).map(_.size), 1)
         } yield ()
       }
     }
@@ -62,14 +57,17 @@ class DslRoundTripSuite extends PgFixture {
         val c   = UUID.fromString("40000000-0000-0000-0000-000000000003")
         val now = OffsetDateTime.now()
         for {
-          _   <- users.insert((id = a, email = "aaa@x", age = 30, created_at = now, deleted_at = None)).compile.run(s)
-          _   <- users.insert((id = b, email = "bbb@x", age = 10, created_at = now, deleted_at = None)).compile.run(s)
-          _   <- users.insert((id = c, email = "ccc@x", age = 20, created_at = now, deleted_at = None)).compile.run(s)
-          asc <- users.select.where(u => u.email.like("%@x")).orderBy(u => u.age.asc).apply(u => u.email).compile.run(s)
-          _ = assertEquals(asc, List("bbb@x", "ccc@x", "aaa@x"))
-          desc <-
-            users.select.where(u => u.email.like("%@x")).orderBy(u => u.age.desc).apply(u => u.email).compile.run(s)
-          _ = assertEquals(desc, List("aaa@x", "ccc@x", "bbb@x"))
+          _ <- users.insert((id = a, email = "aaa@x", age = 30, created_at = now, deleted_at = None)).compile.run(s)
+          _ <- users.insert((id = b, email = "bbb@x", age = 10, created_at = now, deleted_at = None)).compile.run(s)
+          _ <- users.insert((id = c, email = "ccc@x", age = 20, created_at = now, deleted_at = None)).compile.run(s)
+          _ <- assertIO(
+            users.select.where(u => u.email.like("%@x")).orderBy(u => u.age.asc).apply(u => u.email).compile.run(s),
+            List("bbb@x", "ccc@x", "aaa@x")
+          )
+          _ <- assertIO(
+            users.select.where(u => u.email.like("%@x")).orderBy(u => u.age.desc).apply(u => u.email).compile.run(s),
+            List("aaa@x", "ccc@x", "bbb@x")
+          )
         } yield ()
       }
     }
@@ -87,8 +85,10 @@ class DslRoundTripSuite extends PgFixture {
             created_at = OffsetDateTime.now(),
             deleted_at = None
           )).compile.run(s)
-          rows <- active.select.where(u => u.id === id).compile.run(s)
-          _ = assertEquals(rows.map(_.email), List("carol@example.com"))
+          _ <- assertIO(
+            active.select.where(u => u.id === id).compile.run(s).map(_.map(_.email)),
+            List("carol@example.com")
+          )
         } yield ()
       }
     }

--- a/modules/tests/src/test/scala/skunk/sharp/tests/GroupBySuite.scala
+++ b/modules/tests/src/test/scala/skunk/sharp/tests/GroupBySuite.scala
@@ -1,6 +1,5 @@
 package skunk.sharp.tests
 
-import cats.effect.IO
 import cats.syntax.all.*
 import skunk.sharp.dsl.*
 
@@ -31,10 +30,9 @@ class GroupBySuite extends PgFixture {
               .compile
               .run(s)
           )
-          total  <- users.select(_ => Pg.countAll).compile.unique(s)
-          ageCnt <- users.select(u => Pg.count(u.age)).compile.unique(s)
+          total <- users.select(_ => Pg.countAll).compile.unique(s)
           _ = assert(total >= 3L, s"expected at least 3 rows, got $total")
-          _ = assertEquals(ageCnt, total)
+          _ <- assertIO(users.select(u => Pg.count(u.age)).compile.unique(s), total)
         } yield ()
       }
     }
@@ -170,22 +168,28 @@ class GroupBySuite extends PgFixture {
           _ <- users.insert((id = UUID.randomUUID, email = "ba1@x", age = bucket, deleted_at = None)).compile.run(s)
           _ <- users.insert((id = UUID.randomUUID, email = "ba2@x", age = bucket, deleted_at = None)).compile.run(s)
           // All rows in this bucket have age >= 10 — boolAnd should be true.
-          allPos <- users
-            .select(u => Pg.boolAnd(u.age >= 10))
-            .where(u => u.age === bucket)
-            .compile.unique(s)
+          _ <- assertIO(
+            users
+              .select(u => Pg.boolAnd(u.age >= 10))
+              .where(u => u.age === bucket)
+              .compile.unique(s),
+            true
+          )
           // Not all are ≥ 100 — boolAnd should be false, boolOr should also be false.
-          allBig <- users
-            .select(u => Pg.boolAnd(u.age >= 100))
-            .where(u => u.age === bucket)
-            .compile.unique(s)
-          anyBig <- users
-            .select(u => Pg.boolOr(u.age >= 100))
-            .where(u => u.age === bucket)
-            .compile.unique(s)
-          _ = assertEquals(allPos, true)
-          _ = assertEquals(allBig, false)
-          _ = assertEquals(anyBig, false)
+          _ <- assertIO(
+            users
+              .select(u => Pg.boolAnd(u.age >= 100))
+              .where(u => u.age === bucket)
+              .compile.unique(s),
+            false
+          )
+          _ <- assertIO(
+            users
+              .select(u => Pg.boolOr(u.age >= 100))
+              .where(u => u.age === bucket)
+              .compile.unique(s),
+            false
+          )
         } yield ()
       }
     }

--- a/modules/tests/src/test/scala/skunk/sharp/tests/InsertReturningSuite.scala
+++ b/modules/tests/src/test/scala/skunk/sharp/tests/InsertReturningSuite.scala
@@ -1,6 +1,5 @@
 package skunk.sharp.tests
 
-import cats.effect.IO
 import skunk.sharp.dsl.*
 
 import java.time.OffsetDateTime
@@ -20,17 +19,19 @@ class InsertReturningSuite extends PgFixture {
       session(containers).use { s =>
         val id = UUID.fromString("dddddddd-dddd-dddd-dddd-dddddddddddd")
         for {
-          returned <- users
-            .insert((
-              id = id,
-              email = "ret-single@example.com",
-              age = 27,
-              created_at = OffsetDateTime.now(),
-              deleted_at = None
-            ))
-            .returning(u => u.id)
-            .compile.unique(s)
-          _ = assertEquals(returned, id)
+          _ <- assertIO(
+            users
+              .insert((
+                id = id,
+                email = "ret-single@example.com",
+                age = 27,
+                created_at = OffsetDateTime.now(),
+                deleted_at = None
+              ))
+              .returning(u => u.id)
+              .compile.unique(s),
+            id
+          )
         } yield ()
       }
     }
@@ -41,17 +42,19 @@ class InsertReturningSuite extends PgFixture {
       session(containers).use { s =>
         val id = UUID.fromString("eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee")
         for {
-          tup <- users
-            .insert((
-              id = id,
-              email = "ret-tuple@example.com",
-              age = 55,
-              created_at = OffsetDateTime.now(),
-              deleted_at = None
-            ))
-            .returningTuple(u => (u.id, u.age))
-            .compile.unique(s)
-          _ = assertEquals(tup, (id, 55))
+          _ <- assertIO(
+            users
+              .insert((
+                id = id,
+                email = "ret-tuple@example.com",
+                age = 55,
+                created_at = OffsetDateTime.now(),
+                deleted_at = None
+              ))
+              .returningTuple(u => (u.id, u.age))
+              .compile.unique(s),
+            (id, 55)
+          )
         } yield ()
       }
     }

--- a/modules/tests/src/test/scala/skunk/sharp/tests/JoinSuite.scala
+++ b/modules/tests/src/test/scala/skunk/sharp/tests/JoinSuite.scala
@@ -1,6 +1,5 @@
 package skunk.sharp.tests
 
-import cats.effect.IO
 import skunk.sharp.dsl.*
 
 import java.time.OffsetDateTime
@@ -28,15 +27,17 @@ class JoinSuite extends PgFixture {
           _ <- users
             .insert((id = uid, email = "join-u@x", age = 30, deleted_at = Option.empty[OffsetDateTime]))
             .compile.run(s)
-          _    <- posts.insert((id = pid, user_id = uid, title = "hello")).compile.run(s)
-          rows <- users
-            .innerJoin(posts)
-            .on(r => r.users.id ==== r.posts.user_id)
-            .select(r => (r.users.email, r.posts.title))
-            .where(r => r.posts.id === pid)
-            .compile
-            .run(s)
-          _ = assertEquals(rows, List(("join-u@x", "hello")))
+          _ <- posts.insert((id = pid, user_id = uid, title = "hello")).compile.run(s)
+          _ <- assertIO(
+            users
+              .innerJoin(posts)
+              .on(r => r.users.id ==== r.posts.user_id)
+              .select(r => (r.users.email, r.posts.title))
+              .where(r => r.posts.id === pid)
+              .compile
+              .run(s),
+            List(("join-u@x", "hello"))
+          )
         } yield ()
       }
     }
@@ -50,14 +51,16 @@ class JoinSuite extends PgFixture {
           _ <- users
             .insert((id = uid, email = "solo@x", age = 40, deleted_at = Option.empty[OffsetDateTime]))
             .compile.run(s)
-          rows <- users
-            .leftJoin(posts)
-            .on(r => r.users.id ==== r.posts.user_id)
-            .select(r => (r.users.email, r.posts.title))
-            .where(r => r.users.id === uid)
-            .compile
-            .run(s)
-          _ = assertEquals(rows, List(("solo@x", Option.empty[String])))
+          _ <- assertIO(
+            users
+              .leftJoin(posts)
+              .on(r => r.users.id ==== r.posts.user_id)
+              .select(r => (r.users.email, r.posts.title))
+              .where(r => r.users.id === uid)
+              .compile
+              .run(s),
+            List(("solo@x", Option.empty[String]))
+          )
         } yield ()
       }
     }
@@ -71,18 +74,20 @@ class JoinSuite extends PgFixture {
           _ <- users
             .insert((id = uid, email = "many@x", age = 28, deleted_at = Option.empty[OffsetDateTime]))
             .compile.run(s)
-          _    <- posts.insert((id = UUID.randomUUID, user_id = uid, title = "a")).compile.run(s)
-          _    <- posts.insert((id = UUID.randomUUID, user_id = uid, title = "b")).compile.run(s)
-          _    <- posts.insert((id = UUID.randomUUID, user_id = uid, title = "c")).compile.run(s)
-          rows <- users
-            .leftJoin(posts)
-            .on(r => r.users.id ==== r.posts.user_id)
-            .select(r => (r.users.email, Pg.count(r.posts.id).as("n")))
-            .where(r => r.users.id === uid)
-            .groupBy(r => r.users.email)
-            .compile
-            .run(s)
-          _ = assertEquals(rows, List(("many@x", 3L)))
+          _ <- posts.insert((id = UUID.randomUUID, user_id = uid, title = "a")).compile.run(s)
+          _ <- posts.insert((id = UUID.randomUUID, user_id = uid, title = "b")).compile.run(s)
+          _ <- posts.insert((id = UUID.randomUUID, user_id = uid, title = "c")).compile.run(s)
+          _ <- assertIO(
+            users
+              .leftJoin(posts)
+              .on(r => r.users.id ==== r.posts.user_id)
+              .select(r => (r.users.email, Pg.count(r.posts.id).as("n")))
+              .where(r => r.users.id === uid)
+              .groupBy(r => r.users.email)
+              .compile
+              .run(s),
+            List(("many@x", 3L))
+          )
         } yield ()
       }
     }
@@ -97,19 +102,18 @@ class JoinSuite extends PgFixture {
           _ <- users
             .insert((id = uid, email = "chain@x", age = 33, deleted_at = Option.empty[OffsetDateTime]))
             .compile.run(s)
-          _    <- posts.insert((id = pid, user_id = uid, title = "chain-post")).compile.run(s)
-          _    <- tags.insert((id = UUID.randomUUID, post_id = pid, name = "alpha")).compile.run(s)
-          _    <- tags.insert((id = UUID.randomUUID, post_id = pid, name = "beta")).compile.run(s)
-          rows <- users
-            .innerJoin(posts).on(r => r.users.id ==== r.posts.user_id)
-            .leftJoin(tags).on(r => r.posts.id ==== r.tags.post_id)
-            .select(r => (r.users.email, r.posts.title, r.tags.name))
-            .where(r => r.users.id === uid)
-            .orderBy(r => r.tags.name.asc)
-            .compile
-            .run(s)
-          _ = assertEquals(
-            rows,
+          _ <- posts.insert((id = pid, user_id = uid, title = "chain-post")).compile.run(s)
+          _ <- tags.insert((id = UUID.randomUUID, post_id = pid, name = "alpha")).compile.run(s)
+          _ <- tags.insert((id = UUID.randomUUID, post_id = pid, name = "beta")).compile.run(s)
+          _ <- assertIO(
+            users
+              .innerJoin(posts).on(r => r.users.id ==== r.posts.user_id)
+              .leftJoin(tags).on(r => r.posts.id ==== r.tags.post_id)
+              .select(r => (r.users.email, r.posts.title, r.tags.name))
+              .where(r => r.users.id === uid)
+              .orderBy(r => r.tags.name.asc)
+              .compile
+              .run(s),
             List(
               ("chain@x", "chain-post", Option("alpha")),
               ("chain@x", "chain-post", Option("beta"))
@@ -129,14 +133,16 @@ class JoinSuite extends PgFixture {
           _ <- users
             .insert((id = uid, email = "cross@x", age = 27, deleted_at = Option.empty[OffsetDateTime]))
             .compile.run(s)
-          _    <- posts.insert((id = pid, user_id = uid, title = "cross-post")).compile.run(s)
-          rows <- users
-            .crossJoin(posts)
-            .select(r => (r.users.email, r.posts.title))
-            .where(r => r.users.id ==== r.posts.user_id && r.users.id === uid)
-            .compile
-            .run(s)
-          _ = assertEquals(rows, List(("cross@x", "cross-post")))
+          _ <- posts.insert((id = pid, user_id = uid, title = "cross-post")).compile.run(s)
+          _ <- assertIO(
+            users
+              .crossJoin(posts)
+              .select(r => (r.users.email, r.posts.title))
+              .where(r => r.users.id ==== r.posts.user_id && r.users.id === uid)
+              .compile
+              .run(s),
+            List(("cross@x", "cross-post"))
+          )
         } yield ()
       }
     }
@@ -151,16 +157,18 @@ class JoinSuite extends PgFixture {
           _ <- users
             .insert((id = uid, email = "aliased@x", age = 22, deleted_at = Option.empty[OffsetDateTime]))
             .compile.run(s)
-          _    <- posts.insert((id = pid, user_id = uid, title = "aliased-hello")).compile.run(s)
-          rows <- users
-            .alias("u")
-            .innerJoin(posts.alias("p"))
-            .on(r => r.u.id ==== r.p.user_id)
-            .select(r => (r.u.email, r.p.title))
-            .where(r => r.p.id === pid)
-            .compile
-            .run(s)
-          _ = assertEquals(rows, List(("aliased@x", "aliased-hello")))
+          _ <- posts.insert((id = pid, user_id = uid, title = "aliased-hello")).compile.run(s)
+          _ <- assertIO(
+            users
+              .alias("u")
+              .innerJoin(posts.alias("p"))
+              .on(r => r.u.id ==== r.p.user_id)
+              .select(r => (r.u.email, r.p.title))
+              .where(r => r.p.id === pid)
+              .compile
+              .run(s),
+            List(("aliased@x", "aliased-hello"))
+          )
         } yield ()
       }
     }

--- a/modules/tests/src/test/scala/skunk/sharp/tests/JsonbSuite.scala
+++ b/modules/tests/src/test/scala/skunk/sharp/tests/JsonbSuite.scala
@@ -49,13 +49,15 @@ class JsonbSuite extends PgFixture {
         val inactive = CirceJson.obj("status" -> CirceJson.fromString("inactive"), "n" -> CirceJson.fromInt(2))
         val probe    = CirceJson.obj("status" -> CirceJson.fromString("active"))
         for {
-          _   <- docs.insert((id = matches, body = Jsonb(active))).compile.run(s)
-          _   <- docs.insert((id = misses, body = Jsonb(inactive))).compile.run(s)
-          ids <- docs
-            .select(d => d.id)
-            .where(d => d.body.contains(lit(Jsonb(probe))))
-            .compile.run(s)
-          _ = assertEquals(ids.toSet, Set(matches))
+          _ <- docs.insert((id = matches, body = Jsonb(active))).compile.run(s)
+          _ <- docs.insert((id = misses, body = Jsonb(inactive))).compile.run(s)
+          _ <- assertIO(
+            docs
+              .select(d => d.id)
+              .where(d => d.body.contains(lit(Jsonb(probe))))
+              .compile.run(s).map(_.toSet),
+            Set(matches)
+          )
         } yield ()
       }
     }
@@ -69,14 +71,17 @@ class JsonbSuite extends PgFixture {
         val withEmail    = CirceJson.obj("email" -> CirceJson.fromString("a@x"), "tag" -> CirceJson.fromString("t"))
         val withoutEmail = CirceJson.obj("phone" -> CirceJson.fromString("555"))
         for {
-          _          <- docs.insert((id = a, body = Jsonb(withEmail))).compile.run(s)
-          _          <- docs.insert((id = b, body = Jsonb(withoutEmail))).compile.run(s)
-          withKey    <- docs.select(d => d.id).where(d => d.body.hasKey("email")).compile.run(s)
-          anyContact <- docs.select(d => d.id).where(d => d.body.hasAnyKey("email", "phone")).compile.run(s)
-          bothFields <- docs.select(d => d.id).where(d => d.body.hasAllKeys("email", "tag")).compile.run(s)
-          _ = assertEquals(withKey.toSet, Set(a))
-          _ = assertEquals(anyContact.toSet, Set(a, b))
-          _ = assertEquals(bothFields.toSet, Set(a))
+          _ <- docs.insert((id = a, body = Jsonb(withEmail))).compile.run(s)
+          _ <- docs.insert((id = b, body = Jsonb(withoutEmail))).compile.run(s)
+          _ <- assertIO(docs.select(d => d.id).where(d => d.body.hasKey("email")).compile.run(s).map(_.toSet), Set(a))
+          _ <- assertIO(
+            docs.select(d => d.id).where(d => d.body.hasAnyKey("email", "phone")).compile.run(s).map(_.toSet),
+            Set(a, b)
+          )
+          _ <- assertIO(
+            docs.select(d => d.id).where(d => d.body.hasAllKeys("email", "tag")).compile.run(s).map(_.toSet),
+            Set(a)
+          )
         } yield ()
       }
     }
@@ -127,27 +132,34 @@ class JsonbSuite extends PgFixture {
           _ <- pdocs.insert((id = idA, body = Jsonb(alice))).compile.run(s)
           _ <- pdocs.insert((id = idB, body = Jsonb(bob))).compile.run(s)
 
-          // Filter via .getText — jsonb ->> 'name' = 'alice'.
-          aliceOnly <- pdocs
-            .select(d => d.body) // decodes straight to Profile
-            .where(d => d.body.getText("name") === "jb-alice")
-            .compile.run(s)
+          // Filter via .getText — jsonb ->> 'name' = 'alice'. The IO returns `List[Jsonb[Profile]]`; opaque-type
+          // direction (`Jsonb[A] <: A`) means we need to widen explicitly to match the expected `List[Profile]`.
+          _ <- assertIO(
+            pdocs
+              .select(d => d.body)
+              .where(d => d.body.getText("name") === "jb-alice")
+              .compile.run(s)
+              .map(xs => xs: List[Profile]),
+            List(alice)
+          )
 
           // Filter via .contains — jsonb @> '{"name":"jb-alice"}'::jsonb.
-          containsAlice <- pdocs
-            .select(d => d.id)
-            .where(d => d.body.contains(lit(Jsonb[Cj](Cj.obj("name" -> Cj.fromString("jb-alice"))))))
-            .compile.run(s)
+          _ <- assertIO(
+            pdocs
+              .select(d => d.id)
+              .where(d => d.body.contains(lit(Jsonb[Cj](Cj.obj("name" -> Cj.fromString("jb-alice"))))))
+              .compile.run(s),
+            List(idA)
+          )
 
           // Project .getText as a String alongside .hasKey.
-          projected <- pdocs
-            .select(d => (d.id, d.body.getText("name"), d.body.hasKey("tags")))
-            .where(d => d.id === idA)
-            .compile.unique(s)
-
-          _ = assertEquals(aliceOnly, List(alice))
-          _ = assertEquals(containsAlice, List(idA))
-          _ = assertEquals(projected, (idA, "jb-alice", true))
+          _ <- assertIO(
+            pdocs
+              .select(d => (d.id, d.body.getText("name"), d.body.hasKey("tags")))
+              .where(d => d.id === idA)
+              .compile.unique(s),
+            (idA, "jb-alice", true)
+          )
         } yield ()
       }
     }

--- a/modules/tests/src/test/scala/skunk/sharp/tests/PgFunctionSuite.scala
+++ b/modules/tests/src/test/scala/skunk/sharp/tests/PgFunctionSuite.scala
@@ -14,16 +14,11 @@ class PgFunctionSuite extends PgFixture {
     withContainers { containers =>
       session(containers).use { s =>
         for {
-          absRow   <- empty.select(_ => Pg.abs(lit(-42))).compile.unique(s)
-          ceilRow  <- empty.select(_ => Pg.ceil(lit(BigDecimal("1.2")))).compile.unique(s)
-          floorRow <- empty.select(_ => Pg.floor(lit(BigDecimal("1.8")))).compile.unique(s)
-          truncRow <- empty.select(_ => Pg.trunc(lit(BigDecimal("-1.9")))).compile.unique(s)
-          roundRow <- empty.select(_ => Pg.round(lit(BigDecimal("1.5")))).compile.unique(s)
-          _ = assertEquals(absRow, 42)
-          _ = assertEquals(ceilRow, BigDecimal(2))
-          _ = assertEquals(floorRow, BigDecimal(1))
-          _ = assertEquals(truncRow, BigDecimal(-1))
-          _ = assertEquals(roundRow, BigDecimal(2))
+          _ <- assertIO(empty.select(_ => Pg.abs(lit(-42))).compile.unique(s), 42)
+          _ <- assertIO(empty.select(_ => Pg.ceil(lit(BigDecimal("1.2")))).compile.unique(s), BigDecimal(2))
+          _ <- assertIO(empty.select(_ => Pg.floor(lit(BigDecimal("1.8")))).compile.unique(s), BigDecimal(1))
+          _ <- assertIO(empty.select(_ => Pg.trunc(lit(BigDecimal("-1.9")))).compile.unique(s), BigDecimal(-1))
+          _ <- assertIO(empty.select(_ => Pg.round(lit(BigDecimal("1.5")))).compile.unique(s), BigDecimal(2))
         } yield ()
       }
     }
@@ -32,9 +27,10 @@ class PgFunctionSuite extends PgFixture {
   test("round(x, digits)") {
     withContainers { containers =>
       session(containers).use { s =>
-        empty.select(_ => Pg.round(lit(BigDecimal("1.2345")), 2)).compile.unique(s).map { v =>
-          assertEquals(v, BigDecimal("1.23"))
-        }
+        assertIO(
+          empty.select(_ => Pg.round(lit(BigDecimal("1.2345")), 2)).compile.unique(s),
+          BigDecimal("1.23")
+        )
       }
     }
   }
@@ -42,7 +38,7 @@ class PgFunctionSuite extends PgFixture {
   test("mod(a, b)") {
     withContainers { containers =>
       session(containers).use { s =>
-        empty.select(_ => Pg.mod(lit(10), lit(3))).compile.unique(s).map(v => assertEquals(v, 1))
+        assertIO(empty.select(_ => Pg.mod(lit(10), lit(3))).compile.unique(s), 1)
       }
     }
   }
@@ -51,10 +47,8 @@ class PgFunctionSuite extends PgFixture {
     withContainers { containers =>
       session(containers).use { s =>
         for {
-          g <- empty.select(_ => Pg.greatest(lit(1), lit(5), lit(3))).compile.unique(s)
-          l <- empty.select(_ => Pg.least(lit(1), lit(5), lit(3))).compile.unique(s)
-          _ = assertEquals(g, 5)
-          _ = assertEquals(l, 1)
+          _ <- assertIO(empty.select(_ => Pg.greatest(lit(1), lit(5), lit(3))).compile.unique(s), 5)
+          _ <- assertIO(empty.select(_ => Pg.least(lit(1), lit(5), lit(3))).compile.unique(s), 1)
         } yield ()
       }
     }
@@ -66,16 +60,11 @@ class PgFunctionSuite extends PgFixture {
     withContainers { containers =>
       session(containers).use { s =>
         for {
-          sq <- empty.select(_ => Pg.sqrt(lit(9.0))).compile.unique(s)
-          pw <- empty.select(_ => Pg.power(lit(2.0), lit(10.0))).compile.unique(s)
-          ex <- empty.select(_ => Pg.exp(lit(0.0))).compile.unique(s)
-          ln <- empty.select(_ => Pg.ln(lit(1.0))).compile.unique(s)
-          lg <- empty.select(_ => Pg.log(lit(100.0))).compile.unique(s)
-          _ = assertEquals(sq, 3.0)
-          _ = assertEquals(pw, 1024.0)
-          _ = assertEquals(ex, 1.0)
-          _ = assertEquals(ln, 0.0)
-          _ = assertEquals(lg, 2.0)
+          _ <- assertIO(empty.select(_ => Pg.sqrt(lit(9.0))).compile.unique(s), 3.0)
+          _ <- assertIO(empty.select(_ => Pg.power(lit(2.0), lit(10.0))).compile.unique(s), 1024.0)
+          _ <- assertIO(empty.select(_ => Pg.exp(lit(0.0))).compile.unique(s), 1.0)
+          _ <- assertIO(empty.select(_ => Pg.ln(lit(1.0))).compile.unique(s), 0.0)
+          _ <- assertIO(empty.select(_ => Pg.log(lit(100.0))).compile.unique(s), 2.0)
         } yield ()
       }
     }
@@ -100,10 +89,8 @@ class PgFunctionSuite extends PgFixture {
     withContainers { containers =>
       session(containers).use { s =>
         for {
-          eq  <- empty.select(_ => Pg.nullif(lit(5), 5)).compile.unique(s)
-          neq <- empty.select(_ => Pg.nullif(lit(5), 3)).compile.unique(s)
-          _ = assertEquals(eq, Option.empty[Int])
-          _ = assertEquals(neq, Option(5))
+          _ <- assertIO(empty.select(_ => Pg.nullif(lit(5), 5)).compile.unique(s), Option.empty[Int])
+          _ <- assertIO(empty.select(_ => Pg.nullif(lit(5), 3)).compile.unique(s), Option(5))
         } yield ()
       }
     }
@@ -115,10 +102,8 @@ class PgFunctionSuite extends PgFixture {
     withContainers { containers =>
       session(containers).use { s =>
         for {
-          lo <- empty.select(_ => Pg.lower(lit("HELLO"))).compile.unique(s)
-          up <- empty.select(_ => Pg.upper(lit("hello"))).compile.unique(s)
-          _ = assertEquals(lo, "hello")
-          _ = assertEquals(up, "HELLO")
+          _ <- assertIO(empty.select(_ => Pg.lower(lit("HELLO"))).compile.unique(s), "hello")
+          _ <- assertIO(empty.select(_ => Pg.upper(lit("hello"))).compile.unique(s), "HELLO")
         } yield ()
       }
     }
@@ -128,14 +113,10 @@ class PgFunctionSuite extends PgFixture {
     withContainers { containers =>
       session(containers).use { s =>
         for {
-          t  <- empty.select(_ => Pg.trim(lit("  hi  "))).compile.unique(s)
-          lt <- empty.select(_ => Pg.ltrim(lit("  hi  "))).compile.unique(s)
-          rt <- empty.select(_ => Pg.rtrim(lit("  hi  "))).compile.unique(s)
-          tc <- empty.select(_ => Pg.trim(lit("xxhiyy"), "xy")).compile.unique(s)
-          _ = assertEquals(t, "hi")
-          _ = assertEquals(lt, "hi  ")
-          _ = assertEquals(rt, "  hi")
-          _ = assertEquals(tc, "hi")
+          _ <- assertIO(empty.select(_ => Pg.trim(lit("  hi  "))).compile.unique(s), "hi")
+          _ <- assertIO(empty.select(_ => Pg.ltrim(lit("  hi  "))).compile.unique(s), "hi  ")
+          _ <- assertIO(empty.select(_ => Pg.rtrim(lit("  hi  "))).compile.unique(s), "  hi")
+          _ <- assertIO(empty.select(_ => Pg.trim(lit("xxhiyy"), "xy")).compile.unique(s), "hi")
         } yield ()
       }
     }
@@ -145,20 +126,13 @@ class PgFunctionSuite extends PgFixture {
     withContainers { containers =>
       session(containers).use { s =>
         for {
-          r  <- empty.select(_ => Pg.replace(lit("a-b-c"), "-", "/")).compile.unique(s)
-          s1 <- empty.select(_ => Pg.substring(lit("hello world"), 7)).compile.unique(s)
-          s2 <- empty.select(_ => Pg.substring(lit("hello world"), 1, 5)).compile.unique(s)
-          lf <- empty.select(_ => Pg.left(lit("hello"), 3)).compile.unique(s)
-          rg <- empty.select(_ => Pg.right(lit("hello"), 3)).compile.unique(s)
-          rp <- empty.select(_ => Pg.repeat(lit("ab"), 3)).compile.unique(s)
-          rv <- empty.select(_ => Pg.reverse(lit("abc"))).compile.unique(s)
-          _ = assertEquals(r, "a/b/c")
-          _ = assertEquals(s1, "world")
-          _ = assertEquals(s2, "hello")
-          _ = assertEquals(lf, "hel")
-          _ = assertEquals(rg, "llo")
-          _ = assertEquals(rp, "ababab")
-          _ = assertEquals(rv, "cba")
+          _ <- assertIO(empty.select(_ => Pg.replace(lit("a-b-c"), "-", "/")).compile.unique(s), "a/b/c")
+          _ <- assertIO(empty.select(_ => Pg.substring(lit("hello world"), 7)).compile.unique(s), "world")
+          _ <- assertIO(empty.select(_ => Pg.substring(lit("hello world"), 1, 5)).compile.unique(s), "hello")
+          _ <- assertIO(empty.select(_ => Pg.left(lit("hello"), 3)).compile.unique(s), "hel")
+          _ <- assertIO(empty.select(_ => Pg.right(lit("hello"), 3)).compile.unique(s), "llo")
+          _ <- assertIO(empty.select(_ => Pg.repeat(lit("ab"), 3)).compile.unique(s), "ababab")
+          _ <- assertIO(empty.select(_ => Pg.reverse(lit("abc"))).compile.unique(s), "cba")
         } yield ()
       }
     }
@@ -168,10 +142,9 @@ class PgFunctionSuite extends PgFixture {
     withContainers { containers =>
       session(containers).use { s =>
         for {
-          rr <- empty.select(_ => Pg.regexpReplace(lit("foo123bar"), "[0-9]+", "-")).compile.unique(s)
-          sp <- empty.select(_ => Pg.splitPart(lit("a-b-c"), "-", 2)).compile.unique(s)
-          _ = assertEquals(rr, "foo-bar")
-          _ = assertEquals(sp, "b")
+          _ <-
+            assertIO(empty.select(_ => Pg.regexpReplace(lit("foo123bar"), "[0-9]+", "-")).compile.unique(s), "foo-bar")
+          _ <- assertIO(empty.select(_ => Pg.splitPart(lit("a-b-c"), "-", 2)).compile.unique(s), "b")
         } yield ()
       }
     }
@@ -183,14 +156,10 @@ class PgFunctionSuite extends PgFixture {
     withContainers { containers =>
       session(containers).use { s =>
         for {
-          l   <- empty.select(_ => Pg.length(lit("abc"))).compile.unique(s)
-          cl  <- empty.select(_ => Pg.charLength(lit("abc"))).compile.unique(s)
-          ol  <- empty.select(_ => Pg.octetLength(lit("abc"))).compile.unique(s)
-          pos <- empty.select(_ => Pg.position("b", lit("abc"))).compile.unique(s)
-          _ = assertEquals(l, 3)
-          _ = assertEquals(cl, 3)
-          _ = assertEquals(ol, 3)
-          _ = assertEquals(pos, 2)
+          _ <- assertIO(empty.select(_ => Pg.length(lit("abc"))).compile.unique(s), 3)
+          _ <- assertIO(empty.select(_ => Pg.charLength(lit("abc"))).compile.unique(s), 3)
+          _ <- assertIO(empty.select(_ => Pg.octetLength(lit("abc"))).compile.unique(s), 3)
+          _ <- assertIO(empty.select(_ => Pg.position("b", lit("abc"))).compile.unique(s), 2)
         } yield ()
       }
     }
@@ -220,12 +189,13 @@ class PgFunctionSuite extends PgFixture {
     withContainers { containers =>
       session(containers).use { s =>
         for {
-          cc <- empty.select(_ => Pg.concat(lit("a"), lit("b"), lit("c"))).compile.unique(s)
-          co <- empty.select(_ =>
-            Pg.coalesce(lit[Option[String]](None), lit[Option[String]](Some("fallback")))
-          ).compile.unique(s)
-          _ = assertEquals(cc, "abc")
-          _ = assertEquals(co, Option("fallback"))
+          _ <- assertIO(empty.select(_ => Pg.concat(lit("a"), lit("b"), lit("c"))).compile.unique(s), "abc")
+          _ <- assertIO(
+            empty.select(_ =>
+              Pg.coalesce(lit[Option[String]](None), lit[Option[String]](Some("fallback")))
+            ).compile.unique(s),
+            Option("fallback")
+          )
         } yield ()
       }
     }

--- a/modules/tests/src/test/scala/skunk/sharp/tests/ProjectionsSuite.scala
+++ b/modules/tests/src/test/scala/skunk/sharp/tests/ProjectionsSuite.scala
@@ -1,6 +1,5 @@
 package skunk.sharp.tests
 
-import cats.effect.IO
 import skunk.sharp.dsl.*
 
 import java.time.OffsetDateTime
@@ -27,8 +26,10 @@ class ProjectionsSuite extends PgFixture {
             created_at = OffsetDateTime.now(),
             deleted_at = None
           )).compile.run(s)
-          emails <- users.select.where(u => u.id === id).apply(u => u.email).compile.run(s)
-          _ = assertEquals(emails, List("proj-single@example.com"))
+          _ <- assertIO(
+            users.select.where(u => u.id === id).apply(u => u.email).compile.run(s),
+            List("proj-single@example.com")
+          )
         } yield ()
       }
     }
@@ -46,8 +47,10 @@ class ProjectionsSuite extends PgFixture {
             created_at = OffsetDateTime.now(),
             deleted_at = None
           )).compile.run(s)
-          rows <- users.select.where(u => u.id === id).apply(u => (u.email, u.age)).compile.run(s)
-          _ = assertEquals(rows, List(("proj-tuple@example.com", 42)))
+          _ <- assertIO(
+            users.select.where(u => u.id === id).apply(u => (u.email, u.age)).compile.run(s),
+            List(("proj-tuple@example.com", 42))
+          )
         } yield ()
       }
     }
@@ -65,8 +68,10 @@ class ProjectionsSuite extends PgFixture {
             created_at = OffsetDateTime.now(),
             deleted_at = None
           )).compile.run(s)
-          lowered <- users.select.where(u => u.id === id).apply(u => Pg.lower(u.email)).compile.run(s)
-          _ = assertEquals(lowered, List("uppercase@example.com"))
+          _ <- assertIO(
+            users.select.where(u => u.id === id).apply(u => Pg.lower(u.email)).compile.run(s),
+            List("uppercase@example.com")
+          )
         } yield ()
       }
     }

--- a/modules/tests/src/test/scala/skunk/sharp/tests/SubquerySuite.scala
+++ b/modules/tests/src/test/scala/skunk/sharp/tests/SubquerySuite.scala
@@ -28,12 +28,14 @@ class SubquerySuite extends PgFixture {
           _ <- users
             .insert((id = uidB, email = "no-posts@x", age = 31, deleted_at = Option.empty[OffsetDateTime]))
             .compile.run(s)
-          _    <- posts.insert((id = UUID.randomUUID, user_id = uidA, title = "hello")).compile.run(s)
-          rows <- users
-            .select(u => u.email)
-            .where(u => u.id.in(posts.select(p => p.user_id)))
-            .compile.run(s)
-          _ = assertEquals(rows, List("has-posts@x"))
+          _ <- posts.insert((id = UUID.randomUUID, user_id = uidA, title = "hello")).compile.run(s)
+          _ <- assertIO(
+            users
+              .select(u => u.email)
+              .where(u => u.id.in(posts.select(p => p.user_id)))
+              .compile.run(s),
+            List("has-posts@x")
+          )
         } yield ()
       }
     }
@@ -54,12 +56,14 @@ class SubquerySuite extends PgFixture {
           _ <- posts.insert((id = UUID.randomUUID, user_id = uidWith, title = "ex")).compile.run(s)
           // Inner query built inside the outer lambda — references u.id (an outer column) by closure. The
           // outer alias makes u.id render as "u"."id" so Postgres correlates it to the outer source.
-          rows <- users
-            .alias("u")
-            .select(u => u.email)
-            .where(u => Pg.exists(posts.select(_ => lit(1)).where(p => p.user_id ==== u.id)))
-            .compile.run(s)
-          _ = assertEquals(rows.toSet, Set("has-posts@x", "exw@x"))
+          _ <- assertIO(
+            users
+              .alias("u")
+              .select(u => u.email)
+              .where(u => Pg.exists(posts.select(_ => lit(1)).where(p => p.user_id ==== u.id)))
+              .compile.run(s).map(_.toSet),
+            Set("has-posts@x", "exw@x")
+          )
         } yield ()
       }
     }
@@ -77,16 +81,18 @@ class SubquerySuite extends PgFixture {
           _ <- users
             .insert((id = uidWO, email = "nex-without@x", age = 51, deleted_at = Option.empty[OffsetDateTime]))
             .compile.run(s)
-          _    <- posts.insert((id = UUID.randomUUID, user_id = uidWith, title = "nex")).compile.run(s)
-          rows <- users
-            .alias("u")
-            .select(u => u.email)
-            .where(u =>
-              u.id.in(cats.data.NonEmptyList.of(uidWith, uidWO)) &&
-                Pg.notExists(posts.select(_ => lit(1)).where(p => p.user_id ==== u.id))
-            )
-            .compile.run(s)
-          _ = assertEquals(rows, List("nex-without@x"))
+          _ <- posts.insert((id = UUID.randomUUID, user_id = uidWith, title = "nex")).compile.run(s)
+          _ <- assertIO(
+            users
+              .alias("u")
+              .select(u => u.email)
+              .where(u =>
+                u.id.in(cats.data.NonEmptyList.of(uidWith, uidWO)) &&
+                  Pg.notExists(posts.select(_ => lit(1)).where(p => p.user_id ==== u.id))
+              )
+              .compile.run(s),
+            List("nex-without@x")
+          )
         } yield ()
       }
     }
@@ -100,19 +106,21 @@ class SubquerySuite extends PgFixture {
           _ <- users
             .insert((id = uid, email = "scalar@x", age = 22, deleted_at = Option.empty[OffsetDateTime]))
             .compile.run(s)
-          _    <- posts.insert((id = UUID.randomUUID, user_id = uid, title = "a")).compile.run(s)
-          _    <- posts.insert((id = UUID.randomUUID, user_id = uid, title = "b")).compile.run(s)
-          rows <- users
-            .alias("u")
-            .select(u =>
-              (
-                u.email,
-                posts.select(_ => Pg.countAll).where(p => p.user_id ==== u.id).asExpr
+          _ <- posts.insert((id = UUID.randomUUID, user_id = uid, title = "a")).compile.run(s)
+          _ <- posts.insert((id = UUID.randomUUID, user_id = uid, title = "b")).compile.run(s)
+          _ <- assertIO(
+            users
+              .alias("u")
+              .select(u =>
+                (
+                  u.email,
+                  posts.select(_ => Pg.countAll).where(p => p.user_id ==== u.id).asExpr
+                )
               )
-            )
-            .where(u => u.id === uid)
-            .compile.run(s)
-          _ = assertEquals(rows, List(("scalar@x", 2L)))
+              .where(u => u.id === uid)
+              .compile.run(s),
+            List(("scalar@x", 2L))
+          )
         } yield ()
       }
     }

--- a/modules/tests/src/test/scala/skunk/sharp/tests/SubsetInsertSuite.scala
+++ b/modules/tests/src/test/scala/skunk/sharp/tests/SubsetInsertSuite.scala
@@ -1,7 +1,6 @@
 package skunk.sharp.tests
 
 import cats.data.NonEmptyList
-import cats.effect.IO
 import skunk.sharp.dsl.*
 
 import java.time.OffsetDateTime
@@ -62,8 +61,7 @@ class SubsetInsertSuite extends PgFixture {
           (kind = "c", payload = "three")
         )
         for {
-          inserted <- events.insert.values(rows).returning(e => e.kind).compile.run(s)
-          _ = assertEquals(inserted, List("a", "b", "c"))
+          _ <- assertIO(events.insert.values(rows).returning(e => e.kind).compile.run(s), List("a", "b", "c"))
         } yield ()
       }
     }

--- a/modules/tests/src/test/scala/skunk/sharp/tests/UpdateDeleteReturningSuite.scala
+++ b/modules/tests/src/test/scala/skunk/sharp/tests/UpdateDeleteReturningSuite.scala
@@ -27,12 +27,14 @@ class UpdateDeleteReturningSuite extends PgFixture {
             created_at = OffsetDateTime.now(),
             deleted_at = None
           )).compile.run(s)
-          returned <- users.update
-            .set(u => u.email := "new@example.com")
-            .where(u => u.id === id)
-            .returning(u => u.email)
-            .compile.unique(s)
-          _ = assertEquals(returned, "new@example.com")
+          _ <- assertIO(
+            users.update
+              .set(u => u.email := "new@example.com")
+              .where(u => u.id === id)
+              .returning(u => u.email)
+              .compile.unique(s),
+            "new@example.com"
+          )
         } yield ()
       }
     }
@@ -50,12 +52,14 @@ class UpdateDeleteReturningSuite extends PgFixture {
             created_at = OffsetDateTime.now(),
             deleted_at = None
           )).compile.run(s)
-          tup <- users.update
-            .set(u => u.age := 99)
-            .where(u => u.id === id)
-            .returningTuple(u => (u.id, u.age))
-            .compile.unique(s)
-          _ = assertEquals(tup, (id, 99))
+          _ <- assertIO(
+            users.update
+              .set(u => u.age := 99)
+              .where(u => u.id === id)
+              .returningTuple(u => (u.id, u.age))
+              .compile.unique(s),
+            (id, 99)
+          )
         } yield ()
       }
     }
@@ -73,8 +77,10 @@ class UpdateDeleteReturningSuite extends PgFixture {
             created_at = OffsetDateTime.now(),
             deleted_at = None
           )).compile.run(s)
-          returned <- users.delete.where(u => u.id === id).returning(u => u.email).compile.unique(s)
-          _ = assertEquals(returned, "gone@example.com")
+          _ <- assertIO(
+            users.delete.where(u => u.id === id).returning(u => u.email).compile.unique(s),
+            "gone@example.com"
+          )
         } yield ()
       }
     }


### PR DESCRIPTION
Closes #45. Replace the `_ = assertEquals(...)` inside `for`-comprehensions with `_ <- assertIO(io, expected)` across 9 integration suites (~60 assert sites). 60 tests green.