### PR TITLE
Multi-schema integration fixture + non-public-schema test suite

### DIFF
--- a/modules/tests/src/test/resources/migrations-multischema/V1__schemas.sql
+++ b/modules/tests/src/test/resources/migrations-multischema/V1__schemas.sql
@@ -1,0 +1,2 @@
+CREATE SCHEMA app;
+CREATE SCHEMA audit;

--- a/modules/tests/src/test/resources/migrations-multischema/V2__app_products.sql
+++ b/modules/tests/src/test/resources/migrations-multischema/V2__app_products.sql
@@ -1,0 +1,5 @@
+CREATE TABLE app.products (
+  id    uuid         PRIMARY KEY,
+  name  varchar(256) NOT NULL,
+  price numeric(10, 2) NOT NULL
+);

--- a/modules/tests/src/test/resources/migrations-multischema/V3__audit_events.sql
+++ b/modules/tests/src/test/resources/migrations-multischema/V3__audit_events.sql
@@ -1,0 +1,6 @@
+CREATE TABLE audit.events (
+  id         bigserial    PRIMARY KEY,
+  action     varchar(64)  NOT NULL,
+  product_id uuid         NULL REFERENCES app.products (id),
+  occurred_at timestamptz NOT NULL DEFAULT now()
+);

--- a/modules/tests/src/test/scala/skunk/sharp/tests/MultiSchemaSuite.scala
+++ b/modules/tests/src/test/scala/skunk/sharp/tests/MultiSchemaSuite.scala
@@ -1,0 +1,128 @@
+package skunk.sharp.tests
+
+import cats.effect.IO
+import dumbo.{ConnectionConfig, Dumbo}
+import dumbo.logging.Implicits.console
+import org.typelevel.otel4s.metrics.Meter.Implicits.given
+import org.typelevel.otel4s.trace.Tracer.Implicits.given
+import skunk.sharp.dsl.*
+import skunk.sharp.pg.tags.*
+
+import java.time.OffsetDateTime
+import java.util.UUID
+
+object MultiSchemaSuite {
+
+  // Tables live in non-public schemas: `app.products` and `audit.events`. Both case classes mirror the migration
+  // column shapes including `Varchar[N]` / `Numeric[P, S]` tags so the validator has tight expected types to diff.
+  case class Product(id: UUID, name: Varchar[256], price: Numeric[10, 2])
+
+  case class Event(id: Long, action: Varchar[64], product_id: Option[UUID], occurred_at: OffsetDateTime)
+}
+
+/**
+ * Exercises relations declared in non-`public` Postgres schemas — confirms that
+ *   - the builder renders `"app"."products"` etc. in generated SQL,
+ *   - cross-schema JOINs work end-to-end,
+ *   - the [[SchemaValidator]] scopes its `information_schema` queries by declared schema.
+ *
+ * Uses a dedicated migrations directory (`migrations-multischema`) so it doesn't fight the default-public suites
+ * sharing the main `migrations` folder.
+ */
+class MultiSchemaSuite extends PgFixture {
+  import MultiSchemaSuite.*
+
+  override protected def runMigrations(conn: ConnectionConfig): IO[Unit] =
+    Dumbo.withResourcesIn[IO]("migrations-multischema").apply(conn).runMigration.void
+
+  private val products = Table.of[Product]("products").inSchema("app").withPrimary("id")
+  private val events   = Table.of[Event]("events").inSchema("audit").withDefault("id").withDefault("occurred_at")
+
+  test("insert + select round-trip on a schema-qualified table (app.products)") {
+    withContainers { containers =>
+      session(containers).use { s =>
+        val id = UUID.randomUUID
+        for {
+          _ <- products
+            .insert((id = id, name = Varchar[256]("widget"), price = Numeric[10, 2](BigDecimal("9.99"))))
+            .compile.run(s)
+          _ <- assertIO(
+            products.select(p => (p.name, p.price)).where(p => p.id === id).compile.unique(s),
+            (Varchar[256]("widget"), Numeric[10, 2](BigDecimal("9.99")))
+          )
+        } yield ()
+      }
+    }
+  }
+
+  test("rendered SQL uses schema-qualified names (\"app\".\"products\" / \"audit\".\"events\")") {
+    val af = products.select(p => p.name).compile.af
+    assertEquals(af.fragment.sql, """SELECT "name" FROM "app"."products"""")
+
+    val af2 = events.select(e => e.action).compile.af
+    assertEquals(af2.fragment.sql, """SELECT "action" FROM "audit"."events"""")
+  }
+
+  test("cross-schema JOIN: audit.events LEFT JOIN app.products") {
+    withContainers { containers =>
+      session(containers).use { s =>
+        val pid = UUID.randomUUID
+        for {
+          _ <- products
+            .insert((id = pid, name = Varchar[256]("gadget"), price = Numeric[10, 2](BigDecimal("1.00"))))
+            .compile.run(s)
+          _ <- events
+            .insert((action = Varchar[64]("view"), product_id = Some(pid)))
+            .compile.run(s)
+          _ <- events
+            .insert((action = Varchar[64]("heartbeat"), product_id = Option.empty[UUID]))
+            .compile.run(s)
+          // LEFT JOIN: all events back, with product name when the event has a product_id.
+          rows <- events
+            .leftJoin(products)
+            // events.product_id is nullable; r.products.id is not. Cast the nullable side to drop the Option from
+            // the Scala type — SQL NULL still flows correctly through the = operator in an ON predicate.
+            .on(r => r.events.product_id.cast[UUID] ==== r.products.id)
+            .select(r => (r.events.action, r.products.name))
+            .orderBy(r => r.events.action.asc)
+            .compile.run(s)
+          // Widen Varchar-tag results to plain String for comparison; equivalence is via subtype erasure.
+          _ = assertEquals(
+            rows.map((a, n) => (a: String, n.map(x => x: String))),
+            List(("heartbeat", Option.empty[String]), ("view", Some("gadget")))
+          )
+        } yield ()
+      }
+    }
+  }
+
+  test("SchemaValidator passes on both schemas") {
+    withContainers { containers =>
+      session(containers).use { s =>
+        for {
+          report <- SchemaValidator.validate[cats.effect.IO](s, products, events)
+          _ = assert(report.isValid, s"unexpected mismatches: ${report.mismatches}")
+        } yield ()
+      }
+    }
+  }
+
+  test("SchemaValidator catches a wrong-schema declaration (audit.products does not exist)") {
+    withContainers { containers =>
+      session(containers).use { s =>
+        // Same columns as the real `app.products`, but pointed at `audit` — so the table doesn't exist there.
+        val misplaced = Table.of[Product]("products").inSchema("audit")
+        for {
+          report <- SchemaValidator.validate[cats.effect.IO](s, misplaced)
+          _ = assert(
+            report.mismatches.exists {
+              case Mismatch.RelationMissing(rel, _) => rel.contains("audit") && rel.contains("products")
+              case _                                => false
+            },
+            s"expected a RelationMissing on audit.products, got ${report.mismatches}"
+          )
+        } yield ()
+      }
+    }
+  }
+}

--- a/modules/tests/src/test/scala/skunk/sharp/tests/MultiSchemaSuite.scala
+++ b/modules/tests/src/test/scala/skunk/sharp/tests/MultiSchemaSuite.scala
@@ -55,14 +55,6 @@ class MultiSchemaSuite extends PgFixture {
     }
   }
 
-  test("rendered SQL uses schema-qualified names (\"app\".\"products\" / \"audit\".\"events\")") {
-    val af = products.select(p => p.name).compile.af
-    assertEquals(af.fragment.sql, """SELECT "name" FROM "app"."products"""")
-
-    val af2 = events.select(e => e.action).compile.af
-    assertEquals(af2.fragment.sql, """SELECT "action" FROM "audit"."events"""")
-  }
-
   test("cross-schema JOIN: audit.events LEFT JOIN app.products") {
     withContainers { containers =>
       session(containers).use { s =>

--- a/modules/tests/src/test/scala/skunk/sharp/tests/PgFixture.scala
+++ b/modules/tests/src/test/scala/skunk/sharp/tests/PgFixture.scala
@@ -12,8 +12,12 @@ import org.typelevel.otel4s.trace.Tracer.Implicits.given
 import skunk.Session
 
 /**
- * Shared fixture: one Postgres container per suite; dumbo runs migrations from `resources/migrations/` before any tests
- * see the session. Tests receive a `Resource[IO, Session[IO]]` for per-test sessions.
+ * Shared fixture: one Postgres container per suite; the container is migrated via dumbo before any tests see the
+ * session. Tests receive a `Resource[IO, Session[IO]]` for per-test sessions.
+ *
+ * The migration step is overridable per suite — override [[runMigrations]] to point at a different classpath resource
+ * dir, run extra setup, etc. `Dumbo.withResourcesIn` is an `inline` macro that needs its path as a compile-time
+ * constant, which is why subclasses override the whole method rather than just a `String` field.
  */
 trait PgFixture extends CatsEffectSuite with TestContainerForAll {
 
@@ -24,6 +28,21 @@ trait PgFixture extends CatsEffectSuite with TestContainerForAll {
       username = "skunk_sharp",
       password = "skunk_sharp"
     )
+
+  /**
+   * Run whatever schema-setup the suite needs against the freshly-started container. The default runs dumbo against the
+   * `"migrations"` resource directory (the shared set of migrations most suites use).
+   *
+   * Override to point dumbo at a different directory — the path must be a literal String because `withResourcesIn` is
+   * inlined at the call site. Typical override:
+   *
+   * {{{
+   *   override protected def runMigrations(conn: ConnectionConfig): IO[Unit] =
+   *     Dumbo.withResourcesIn[IO]("migrations-multischema").apply(conn).runMigration.void
+   * }}}
+   */
+  protected def runMigrations(conn: ConnectionConfig): IO[Unit] =
+    Dumbo.withResourcesIn[IO]("migrations").apply(conn).runMigration.void
 
   override def afterContainersStart(containers: containerDef.Container): Unit = {
     super.afterContainersStart(containers)
@@ -36,12 +55,7 @@ trait PgFixture extends CatsEffectSuite with TestContainerForAll {
       ssl = ConnectionConfig.SSL.None
     )
     import cats.effect.unsafe.implicits.global
-    Dumbo
-      .withResourcesIn[IO]("migrations")
-      .apply(conn)
-      .runMigration
-      .void
-      .unsafeRunSync()
+    runMigrations(conn).unsafeRunSync()
   }
 
   /** Build a skunk session resource against the container. */


### PR DESCRIPTION
Closes #7. Overridable migration step on PgFixture + a dedicated suite with app/audit schemas + cross-schema JOIN + schema validator coverage.