### PR TITLE
Schema validator: diff PRIMARY KEY and UNIQUE constraints against live DB

### DIFF
--- a/modules/core/src/main/scala/skunk/sharp/validation/SchemaValidator.scala
+++ b/modules/core/src/main/scala/skunk/sharp/validation/SchemaValidator.scala
@@ -60,6 +60,28 @@ object SchemaValidator {
         ColumnInfo(n, dt, nullableStr.equalsIgnoreCase("YES"), cml, np, ns)
     }
 
+  /**
+   * One `(constraint_type, constraint_name, column_name)` row per column participating in a constraint. We aggregate in
+   * Scala: constraints group by name, and multi-column keys become a set per constraint. Covers PRIMARY KEY and UNIQUE;
+   * FOREIGN KEY / CHECK aren't validated (not declarable in the Scala description today).
+   */
+  private case class ConstraintRow(kind: String, name: String, column: String)
+
+  private val constraintsQuery: Query[(String, String), ConstraintRow] =
+    sql"""
+      SELECT tc.constraint_type::text,
+             tc.constraint_name::text,
+             kcu.column_name::text
+      FROM information_schema.table_constraints tc
+      JOIN information_schema.key_column_usage kcu
+        ON tc.constraint_schema = kcu.constraint_schema
+       AND tc.constraint_name   = kcu.constraint_name
+      WHERE tc.table_schema = $varchar
+        AND tc.table_name   = $varchar
+        AND tc.constraint_type IN ('PRIMARY KEY', 'UNIQUE')
+      ORDER BY tc.constraint_name, kcu.ordinal_position
+    """.query(text *: text *: text).map((k, n, c) => ConstraintRow(k, n, c))
+
   /** Report-only primitive: returns every mismatch the declared relations have with the live database. */
   def validate[F[_]: Concurrent](session: Session[F], relations: Relation[?]*): F[ValidationReport] =
     relations.toList.traverse(validateOne(session, _)).map(reports => ValidationReport(reports.flatMap(_.mismatches)))
@@ -91,12 +113,63 @@ object SchemaValidator {
           ))): ValidationReport)
             .pure[F]
         case _ =>
-          session
-            .prepare(columnsQuery)
-            .flatMap(_.stream((schema, relation.name), 64).compile.toList)
-            .map(actualCols => diffColumns(label, relation, actualCols))
+          for {
+            actualCols <- session.prepare(columnsQuery).flatMap(_.stream((schema, relation.name), 64).compile.toList)
+            columnReport = diffColumns(label, relation, actualCols)
+            constraintReport <-
+              if (relation.expectedTableType == "VIEW") ValidationReport.empty.pure[F]
+              else
+                session
+                  .prepare(constraintsQuery)
+                  .flatMap(_.stream((schema, relation.name), 64).compile.toList)
+                  .map(rows => diffConstraints(label, relation, rows))
+          } yield columnReport ++ constraintReport
       }
     } yield report
+  }
+
+  /**
+   * Compare declared `isPrimary` / `isUnique` flags against the database's `PRIMARY KEY` and single-column `UNIQUE`
+   * constraints.
+   *
+   * Scope: set-based comparison for composite PKs (ordering inside a composite PK isn't declarable today); only
+   * single-column `UNIQUE` constraints (composite uniques need a separate `.withUniqueIndex(name, cols*)` DSL, see the
+   * issues board).
+   */
+  private def diffConstraints(
+    label: String,
+    relation: Relation[?],
+    rows: List[ConstraintRow]
+  ): ValidationReport = {
+    val cols                          = relation.columns.toList.asInstanceOf[List[Column[?, ?, ?, ?]]]
+    val declaredPkCols: Set[String]   = cols.filter(_.isPrimary).map(_.name: String).toSet
+    val declaredUniqCols: Set[String] = cols.filter(c => c.isUnique && !c.isPrimary).map(_.name: String).toSet
+
+    // Group DB constraint rows by constraint name, then bucket by kind.
+    val byConstraint: Map[(String, String), Set[String]] =
+      rows.groupMap(r => (r.kind, r.name))(_.column).view.mapValues(_.toSet).toMap
+    val actualPkColsOpt: Option[Set[String]] =
+      byConstraint.collectFirst { case ((kind, _), cs) if kind == "PRIMARY KEY" => cs }
+    val actualSingleCol_UniqueCols: Set[String] =
+      byConstraint.iterator.collect {
+        case ((kind, _), cs) if kind == "UNIQUE" && cs.sizeIs == 1 => cs.head
+      }.toSet
+
+    val pkMismatches: List[Mismatch] = (declaredPkCols.isEmpty, actualPkColsOpt) match {
+      case (true, None)                                      => Nil
+      case (true, Some(actual))                              => List(Mismatch.ExtraPrimaryKey(label, actual))
+      case (false, None)                                     => List(Mismatch.PrimaryKeyMissing(label, declaredPkCols))
+      case (false, Some(actual)) if actual != declaredPkCols =>
+        List(Mismatch.PrimaryKeyColumnsDiffer(label, declaredPkCols, actual))
+      case _ => Nil
+    }
+
+    val missingUnique = (declaredUniqCols -- actualSingleCol_UniqueCols).toList.sorted
+      .map(Mismatch.UniqueConstraintMissing(label, _))
+    val extraUnique = (actualSingleCol_UniqueCols -- declaredUniqCols -- declaredPkCols).toList.sorted
+      .map(Mismatch.ExtraUniqueConstraint(label, _))
+
+    ValidationReport(pkMismatches ++ missingUnique ++ extraUnique)
   }
 
   private def diffColumns(label: String, relation: Relation[?], actual: List[ColumnInfo]): ValidationReport = {

--- a/modules/core/src/main/scala/skunk/sharp/validation/ValidationReport.scala
+++ b/modules/core/src/main/scala/skunk/sharp/validation/ValidationReport.scala
@@ -40,6 +40,51 @@ object Mismatch {
 
   }
 
+  /** Declared primary-key column(s) found, but the database has no primary key at all on this relation. */
+  final case class PrimaryKeyMissing(relation: String, expected: Set[String]) extends Mismatch {
+    def pretty = s"relation $relation: expected primary key on ${expected.mkString("(", ", ", ")")} but DB has none"
+  }
+
+  /**
+   * Declared primary-key column set differs from the database's. Matching is set-based — ordering inside a composite PK
+   * isn't tracked at declaration time today, so `(a, b)` declared vs `(b, a)` in DB is not reported.
+   */
+  final case class PrimaryKeyColumnsDiffer(
+    relation: String,
+    expected: Set[String],
+    actual: Set[String]
+  ) extends Mismatch {
+
+    def pretty =
+      s"relation $relation: expected primary key on ${expected.mkString("(", ", ", ")")} but DB has " +
+        actual.mkString("(", ", ", ")")
+
+  }
+
+  /**
+   * Database has a primary key but nothing in the Scala description flags one. Usually a declaration gap — reported so
+   * callers can decide whether to tighten the description.
+   */
+  final case class ExtraPrimaryKey(relation: String, actual: Set[String]) extends Mismatch {
+
+    def pretty =
+      s"relation $relation: DB has a primary key on ${actual.mkString("(", ", ", ")")} but nothing is declared"
+
+  }
+
+  /** Declared `.withUnique(column)` but no matching single-column `UNIQUE` constraint in the database. */
+  final case class UniqueConstraintMissing(relation: String, column: String) extends Mismatch {
+    def pretty = s"relation $relation: expected a unique constraint on $column but none found in the database"
+  }
+
+  /**
+   * Database has a single-column unique constraint on a column that isn't declared `.withUnique`. Usually informational
+   * (an index-backed unique that the Scala description doesn't know about); report so callers see it.
+   */
+  final case class ExtraUniqueConstraint(relation: String, column: String) extends Mismatch {
+    def pretty = s"relation $relation: DB has a unique constraint on $column that is not declared"
+  }
+
 }
 
 /** Result of comparing one-or-more declared relations to a live Postgres schema. */

--- a/modules/tests/src/test/scala/skunk/sharp/tests/MultiSchemaSuite.scala
+++ b/modules/tests/src/test/scala/skunk/sharp/tests/MultiSchemaSuite.scala
@@ -36,7 +36,9 @@ class MultiSchemaSuite extends PgFixture {
     Dumbo.withResourcesIn[IO]("migrations-multischema").apply(conn).runMigration.void
 
   private val products = Table.of[Product]("products").inSchema("app").withPrimary("id")
-  private val events   = Table.of[Event]("events").inSchema("audit").withDefault("id").withDefault("occurred_at")
+
+  private val events =
+    Table.of[Event]("events").inSchema("audit").withPrimary("id").withDefault("id").withDefault("occurred_at")
 
   test("insert + select round-trip on a schema-qualified table (app.products)") {
     withContainers { containers =>

--- a/modules/tests/src/test/scala/skunk/sharp/tests/SchemaValidatorSuite.scala
+++ b/modules/tests/src/test/scala/skunk/sharp/tests/SchemaValidatorSuite.scala
@@ -18,7 +18,7 @@ object SchemaValidatorSuite {
 class SchemaValidatorSuite extends PgFixture {
   import SchemaValidatorSuite.*
 
-  private val users  = Table.of[User]("users")
+  private val users  = Table.of[User]("users").withPrimary("id").withUnique("email")
   private val active = View.of[ActiveUser]("active_users")
   private val broken = Table.of[BrokenUser]("users")
 
@@ -72,6 +72,108 @@ class SchemaValidatorSuite extends PgFixture {
         SchemaValidator.validate[IO](s, usersAsView).map { report =>
           val kinds = report.mismatches.map(_.getClass.getSimpleName).toSet
           assert(kinds.contains("RelationKindMismatch"), s"expected RelationKindMismatch, got: $kinds")
+        }
+      }
+    }
+  }
+
+  // ---- PK / UNIQUE constraint diffs -------------------------------------------------------------
+
+  test("validate accepts matching PRIMARY KEY + UNIQUE declarations (users has PK id + UNIQUE email)") {
+    withContainers { containers =>
+      session(containers).use { s =>
+        val usersWithConstraints = Table.of[User]("users").withPrimary("id").withUnique("email")
+        SchemaValidator.validate[IO](s, usersWithConstraints).map { report =>
+          assert(report.isValid, s"expected valid, got: ${report.mismatches.map(_.pretty).mkString("; ")}")
+        }
+      }
+    }
+  }
+
+  test("validate flags PrimaryKeyColumnsDiffer when the declared PK column is wrong") {
+    withContainers { containers =>
+      session(containers).use { s =>
+        val wrongPk = Table.of[User]("users").withPrimary("email") // DB's PK is "id"
+        SchemaValidator.validate[IO](s, wrongPk).map { report =>
+          assert(
+            report.mismatches.exists {
+              case Mismatch.PrimaryKeyColumnsDiffer(_, exp, act) => exp == Set("email") && act == Set("id")
+              case _                                             => false
+            },
+            s"expected PrimaryKeyColumnsDiffer, got: ${report.mismatches.map(_.pretty).mkString("; ")}"
+          )
+        }
+      }
+    }
+  }
+
+  test("validate flags UniqueConstraintMissing when .withUnique points at a non-unique column") {
+    withContainers { containers =>
+      session(containers).use { s =>
+        val wrongUnique = Table.of[User]("users").withPrimary("id").withUnique("age") // "age" has no unique
+        SchemaValidator.validate[IO](s, wrongUnique).map { report =>
+          assert(
+            report.mismatches.exists {
+              case Mismatch.UniqueConstraintMissing(_, "age") => true
+              case _                                          => false
+            },
+            s"expected UniqueConstraintMissing(age), got: ${report.mismatches.map(_.pretty).mkString("; ")}"
+          )
+        }
+      }
+    }
+  }
+
+  test("validate flags ExtraUniqueConstraint when DB has a unique the declaration misses") {
+    withContainers { containers =>
+      session(containers).use { s =>
+        // Declare PK only; DB also has UNIQUE on email. Expect ExtraUniqueConstraint(email).
+        val pkOnly = Table.of[User]("users").withPrimary("id")
+        SchemaValidator.validate[IO](s, pkOnly).map { report =>
+          assert(
+            report.mismatches.exists {
+              case Mismatch.ExtraUniqueConstraint(_, "email") => true
+              case _                                          => false
+            },
+            s"expected ExtraUniqueConstraint(email), got: ${report.mismatches.map(_.pretty).mkString("; ")}"
+          )
+        }
+      }
+    }
+  }
+
+  test("validate flags ExtraPrimaryKey when DB has a PK but nothing is declared") {
+    withContainers { containers =>
+      session(containers).use { s =>
+        val noPkDecl = Table.of[User]("users").withUnique("email") // PK "id" undeclared
+        SchemaValidator.validate[IO](s, noPkDecl).map { report =>
+          assert(
+            report.mismatches.exists {
+              case Mismatch.ExtraPrimaryKey(_, actual) => actual == Set("id")
+              case _                                   => false
+            },
+            s"expected ExtraPrimaryKey(id), got: ${report.mismatches.map(_.pretty).mkString("; ")}"
+          )
+        }
+      }
+    }
+  }
+
+  test("constraints aren't checked on views (Postgres doesn't allow PK / UNIQUE on views)") {
+    withContainers { containers =>
+      session(containers).use { s =>
+        // `active_users` is a VIEW — even if we declared .withPrimary on it, the validator shouldn't produce
+        // any constraint-related mismatches for it (the constraint query is skipped for views entirely).
+        SchemaValidator.validate[IO](s, active).map { report =>
+          val constraintKinds = Set(
+            "PrimaryKeyMissing",
+            "PrimaryKeyColumnsDiffer",
+            "ExtraPrimaryKey",
+            "UniqueConstraintMissing",
+            "ExtraUniqueConstraint"
+          )
+          val constraintMismatches = report.mismatches.filter(m => constraintKinds.contains(m.getClass.getSimpleName))
+          assert(constraintMismatches.isEmpty, s"unexpected constraint mismatches on view: $constraintMismatches")
         }
       }
     }

--- a/modules/tests/src/test/scala/skunk/sharp/tests/TagValidationSuite.scala
+++ b/modules/tests/src/test/scala/skunk/sharp/tests/TagValidationSuite.scala
@@ -17,7 +17,7 @@ object TagValidationSuite {
 class TagValidationSuite extends PgFixture {
   import TagValidationSuite.*
 
-  private val parties      = Table.of[Party]("parties").withDefault("id").withDefault("balance")
+  private val parties      = Table.of[Party]("parties").withPrimary("id").withDefault("id").withDefault("balance")
   private val wrongVarchar = Table.of[PartyWrongVarchar]("parties").withDefault("id").withDefault("balance")
   private val wrongNumeric = Table.of[PartyWrongNumeric]("parties").withDefault("id").withDefault("balance")
 


### PR DESCRIPTION
Closes #36. 5 new Mismatch cases, one extra query per Table (skipped for Views), 7 new integration tests. Baseline Table declarations updated across the integration suite to include their real PKs / uniques.