### PR TITLE
Composite primary keys + composite unique constraints

### DIFF
--- a/modules/core/src/main/scala/skunk/sharp/Column.scala
+++ b/modules/core/src/main/scala/skunk/sharp/Column.scala
@@ -18,11 +18,25 @@ object ColumnAttr {
   /** The column has a database-side default (sequence PK, `DEFAULT now()`, …) — may be omitted from INSERT. */
   sealed trait Default extends ColumnAttr
 
-  /** The column is (part of) a declared primary key. */
-  sealed trait Primary extends ColumnAttr
+  /**
+   * Primary-key membership. `Members` is the tuple of all column-name singletons that make up the primary key; every
+   * column that is part of the PK carries the *same* `Pk[Members]` value. Single-column PKs use a one-element tuple
+   * (`Pk[("id")]`); composite PKs share the full member tuple (`Pk[("tenant_id", "event_id")]`).
+   *
+   * Using a shared members tuple lets composite `.onConflict(c => (c.a, c.b))` verify that the lambda's column set
+   * matches the declared PK exactly.
+   */
+  sealed trait Pk[Members <: Tuple] extends ColumnAttr
 
-  /** The column is backed by a single-column `UNIQUE` constraint. */
-  sealed trait Unique extends ColumnAttr
+  /**
+   * `UNIQUE` constraint membership. `Name` is the constraint's declared name (used for schema-validator diffs and for
+   * distinguishing multiple unique constraints on the same column). `Members` is the tuple of column names covered by
+   * this constraint; every column in the group carries the *same* `Uq[Name, Members]`.
+   *
+   * Single-column `.withUnique("email")` uses `Uq["email", ("email")]` (auto-names after the column). Composite
+   * `.withUniqueIndex("uq_tenant_slug", "tenant_id", "slug")` uses `Uq["uq_tenant_slug", ("tenant_id", "slug")]`.
+   */
+  sealed trait Uq[Name <: String & Singleton, Members <: Tuple] extends ColumnAttr
 
 }
 
@@ -33,12 +47,13 @@ object ColumnAttr {
  *   - `N` — a **singleton** string type carrying the column's name. Keeping the name in the type lets the DSL's match
  *     types (`HasColumn`, `ColumnAt`) look up columns by name at compile time.
  *   - `Null` — `true` iff the column is nullable.
- *   - `Attrs` — a tuple of [[ColumnAttr]] markers: `Default`, `Primary`, `Unique` (and any third-party additions).
- *     Checked by [[Contains]] / [[HasUniqueness]] / [[ColumnDefault]] to offer compile-time evidence for insert
- *     defaulting and `.onConflict(...)` targeting.
+ *   - `Attrs` — a tuple of [[ColumnAttr]] markers: `Default`, `Pk[Members]`, `Uq[Name, Members]` (and any third-party
+ *     additions). Checked by [[Contains]] / [[HasUniqueness]] / [[HasCompositeUniqueness]] / [[ColumnDefault]] for
+ *     compile-time evidence of insert defaulting and `.onConflict(...)` targeting.
  *
- * Term-level `hasDefault` / `isPrimary` / `isUnique` flags mirror the phantom markers and are what the schema
- * validator reads at runtime when diffing against `information_schema.table_constraints`.
+ * Term-level `hasDefault` / `isPrimary` / `isUnique` flags mirror the phantom markers for simple single-column checks;
+ * the table-level [[Table.pk]] / [[Table.uniques]] lists carry the full composite constraint shape for the schema
+ * validator to diff against `information_schema.table_constraints`.
  *
  * `tpe` is the skunk [[skunk.data.Type]] of the column — we store it rather than a custom enum so we inherit skunk's
  * full built-in type registry.
@@ -50,7 +65,8 @@ final case class Column[T, N <: String & Singleton, Null <: Boolean, Attrs <: Tu
   isNullable: Null,
   hasDefault: Boolean = false,
   isPrimary: Boolean = false,
-  isUnique: Boolean = false
+  isUnique: Boolean = false,
+  uniqueGroups: Set[String] = Set.empty
 ) {
 
   def qualifiedIdent: String = s""""$name""""

--- a/modules/core/src/main/scala/skunk/sharp/ColumnsView.scala
+++ b/modules/core/src/main/scala/skunk/sharp/ColumnsView.scala
@@ -11,6 +11,15 @@ type TypedColumnsOf[Cols <: Tuple] <: Tuple = Cols match {
 }
 
 /**
+ * Extract the column-name tuple from a tuple of `TypedColumn`s. Used by composite `.onConflict` to derive the set of
+ * target column names at the type level from what the user wrote in the lambda.
+ */
+type NamesOfTypedCols[T <: Tuple] <: Tuple = T match {
+  case EmptyTuple                    => EmptyTuple
+  case TypedColumn[t, nu, n] *: tail => n *: NamesOfTypedCols[tail]
+}
+
+/**
  * A named tuple carrying one [[TypedColumn]] per column, keyed by column name. This is the `cols` value that appears
  * inside WHERE/SELECT lambdas — `cols.email` resolves (via Scala 3.8 named-tuple Selectable support) to
  * `TypedColumn[String, false]` or whatever the declared types demand.

--- a/modules/core/src/main/scala/skunk/sharp/HasColumn.scala
+++ b/modules/core/src/main/scala/skunk/sharp/HasColumn.scala
@@ -58,6 +58,25 @@ type Or[A <: Boolean, B <: Boolean] <: Boolean = A match {
   case false => B
 }
 
+/** Reduces to `true` iff every element of `Xs` is present in `Ys`. */
+type AllInTuple[Xs <: Tuple, Ys <: Tuple] <: Boolean = Xs match {
+  case EmptyTuple => true
+  case h *: tail  => Contains[h, Ys] match {
+      case true  => AllInTuple[tail, Ys]
+      case false => false
+    }
+}
+
+/**
+ * Set-equality on tuples — `true` iff `A` and `B` contain the same elements (order-independent). Used by
+ * [[HasCompositeUniqueness]] to accept `.onConflict(c => (c.a, c.b))` against a declared
+ * `.withCompositePrimary(("b", "a"))` regardless of declaration order.
+ */
+type TupleSetEq[A <: Tuple, B <: Tuple] <: Boolean = AllInTuple[A, B] match {
+  case true  => AllInTuple[B, A]
+  case false => false
+}
+
 /** Reduces to `true` iff every name in `Ns` is a declared column name in `Cols`. */
 type AllNamesInCols[Ns <: Tuple, Cols <: Tuple] <: Boolean = Ns match {
   case EmptyTuple => true
@@ -83,13 +102,55 @@ type CoversRequired[Cols <: Tuple, Ns <: Tuple] <: Boolean = Cols match {
 }
 
 /**
- * Type-level predicate: reduces to `true` iff the column named `N` in `Cols` is declared `.withPrimary` or
- * `.withUnique` (or both). Powers compile-time evidence for `.onConflict(c => c.<n>)` — Postgres requires the conflict
- * target to be backed by a unique or exclusion constraint, and a PRIMARY KEY is implicitly unique.
+ * Scan a column's `Attrs` tuple for any `Pk[Members]` / `Uq[Name, Members]` marker whose `Members` is the singleton
+ * tuple `(N)` — i.e. the column itself is an entire primary-key or unique constraint group. Powers single-column
+ * `.onConflict(c => c.<N>)` evidence.
+ */
+type HasSingletonKey[Attrs <: Tuple, N <: String & Singleton] <: Boolean = Attrs match {
+  case EmptyTuple                                => false
+  case ColumnAttr.Pk[N *: EmptyTuple] *: tail    => true
+  case ColumnAttr.Uq[n, N *: EmptyTuple] *: tail => true
+  case h *: tail                                 => HasSingletonKey[tail, N]
+}
+
+/**
+ * Type-level predicate: reduces to `true` iff the column named `N` in `Cols` is a single-column primary-key or unique
+ * constraint target. A column that is only a *part* of a composite PK / unique does **not** satisfy this — Postgres
+ * won't accept a partial-constraint target in `ON CONFLICT`. Use [[HasCompositeUniqueness]] for the composite case.
  */
 type HasUniqueness[Cols <: Tuple, N <: String & Singleton] <: Boolean = Cols match {
-  case Column[t, N, nu, attrs] *: tail =>
-    Or[Contains[ColumnAttr.Primary, attrs], Contains[ColumnAttr.Unique, attrs]]
-  case h *: tail  => HasUniqueness[tail, N]
+  case Column[t, N, nu, attrs] *: tail => HasSingletonKey[attrs, N]
+  case h *: tail                       => HasUniqueness[tail, N]
+  case EmptyTuple                      => false
+}
+
+/** Scan a column's `Attrs` for a `Pk[Members]` or `Uq[_, Members]` marker whose `Members` is set-equal to `Ns`. */
+type HasGroupMatching[Attrs <: Tuple, Ns <: Tuple] <: Boolean = Attrs match {
+  case EmptyTuple                        => false
+  case ColumnAttr.Pk[members] *: tail    => TupleSetEq[members, Ns] match {
+      case true  => true
+      case false => HasGroupMatching[tail, Ns]
+    }
+  case ColumnAttr.Uq[n, members] *: tail => TupleSetEq[members, Ns] match {
+      case true  => true
+      case false => HasGroupMatching[tail, Ns]
+    }
+  case h *: tail                         => HasGroupMatching[tail, Ns]
+}
+
+/**
+ * Composite-target evidence: `true` iff any column in `Cols` carries a `Pk[Members]` or `Uq[_, Members]` marker whose
+ * `Members` is set-equal to `Ns`. Powers `.onConflict(c => (c.a, c.b, …))` — the full tuple of columns must exactly
+ * match a declared composite primary-key or unique constraint (Postgres rejects subsets / supersets).
+ *
+ * Because every column in a declared group carries the same `Members` tuple, finding it on *any* column proves the
+ * group was declared.
+ */
+type HasCompositeUniqueness[Cols <: Tuple, Ns <: Tuple] <: Boolean = Cols match {
+  case Column[t, n, nu, attrs] *: tail =>
+    HasGroupMatching[attrs, Ns] match {
+      case true  => true
+      case false => HasCompositeUniqueness[tail, Ns]
+    }
   case EmptyTuple => false
 }

--- a/modules/core/src/main/scala/skunk/sharp/Table.scala
+++ b/modules/core/src/main/scala/skunk/sharp/Table.scala
@@ -2,6 +2,8 @@ package skunk.sharp
 
 import skunk.sharp.internal.{deriveColumns, ColumnsFromMirror, CompileChecks}
 
+import scala.annotation.unused
+import scala.compiletime.constValueTuple
 import scala.deriving.Mirror
 
 /**
@@ -43,25 +45,91 @@ final case class Table[Cols <: Tuple, Name <: String & Singleton](
   }
 
   /**
-   * Mark a column as primary key. Adds the [[ColumnAttr.Primary]] marker to that column's `Attrs` tuple, making
-   * `.onConflict(c => c.<n>)` accepted at compile time.
+   * Mark a column as a single-column primary key. Appends a `ColumnAttr.Pk[(N)]` marker so
+   * `.onConflict(c => c.<N>)` is accepted at compile time via [[HasUniqueness]].
+   *
+   * For composite primary keys — where the PK spans multiple columns — use [[withCompositePrimary]] instead.
    */
-  inline def withPrimary[N <: String & Singleton](inline n: N): Table[Table.AddAttr[Cols, N, ColumnAttr.Primary], Name] = {
+  inline def withPrimary[N <: String & Singleton](inline n: N)
+    : Table[Table.AddAttr[Cols, N, ColumnAttr.Pk[N *: EmptyTuple]], Name] = {
     CompileChecks.requireColumn[Cols, N]
     val updated = Table.updateCol[Cols, N](columns, n, _.copy(isPrimary = true))
-    copy(columns = updated.asInstanceOf[Table.AddAttr[Cols, N, ColumnAttr.Primary]])
-      .asInstanceOf[Table[Table.AddAttr[Cols, N, ColumnAttr.Primary], Name]]
+    copy(columns = updated.asInstanceOf[Table.AddAttr[Cols, N, ColumnAttr.Pk[N *: EmptyTuple]]])
+      .asInstanceOf[Table[Table.AddAttr[Cols, N, ColumnAttr.Pk[N *: EmptyTuple]], Name]]
   }
 
   /**
-   * Mark a column as unique. Adds the [[ColumnAttr.Unique]] marker to that column's `Attrs` tuple, making
-   * `.onConflict(c => c.<n>)` accepted at compile time.
+   * Mark several columns as jointly making up a composite primary key. Each listed column receives
+   * `ColumnAttr.Pk[Ns]` (the full tuple of PK column names), so composite
+   * `.onConflictComposite(c => (c.a, c.b))` checks for exact set-equality against `Ns` via [[HasCompositeUniqueness]].
+   *
+   * Column names are passed as a **type argument** — a tuple type of string literals. Type arguments preserve literal
+   * singletons (value-level tuple literals would widen to `(String, String)` and break the match-type machinery).
+   *
+   * {{{
+   *   Table.of[Order]("orders").withCompositePrimary[("tenant_id", "order_id")]
+   * }}}
    */
-  inline def withUnique[N <: String & Singleton](inline n: N): Table[Table.AddAttr[Cols, N, ColumnAttr.Unique], Name] = {
+  inline def withCompositePrimary[Ns <: NonEmptyTuple](using
+    @unused ev: Tuple.Union[Ns] <:< (String & Singleton)
+  ): Table[Table.AddCompositePk[Cols, Ns], Name] = {
+    CompileChecks.requireAllNamesInCols[Cols, Ns]
+    val names   = constValueTuple[Ns].toList.asInstanceOf[List[String]]
+    val nameSet = names.toSet
+    val updated =
+      Table.mapCols(columns, (c: Column[Any, String & Singleton, Boolean, Tuple]) =>
+        if (nameSet.contains(c.name)) c.copy(isPrimary = true) else c
+      )
+    copy(columns = updated.asInstanceOf[Table.AddCompositePk[Cols, Ns]])
+      .asInstanceOf[Table[Table.AddCompositePk[Cols, Ns], Name]]
+  }
+
+  /**
+   * Mark a column as having a single-column `UNIQUE` constraint. Appends `ColumnAttr.Uq[N, (N)]` (the constraint's
+   * "name" is the column name itself, matching Postgres's default naming) so `.onConflict(c => c.<N>)` accepts this
+   * column.
+   *
+   * For composite unique indexes (one constraint spanning multiple columns), use [[withUniqueIndex]].
+   */
+  inline def withUnique[N <: String & Singleton](inline n: N)
+    : Table[Table.AddAttr[Cols, N, ColumnAttr.Uq[N, N *: EmptyTuple]], Name] = {
     CompileChecks.requireColumn[Cols, N]
-    val updated = Table.updateCol[Cols, N](columns, n, _.copy(isUnique = true))
-    copy(columns = updated.asInstanceOf[Table.AddAttr[Cols, N, ColumnAttr.Unique]])
-      .asInstanceOf[Table[Table.AddAttr[Cols, N, ColumnAttr.Unique], Name]]
+    val nameStr = compiletime.constValue[N]: String
+    val updated = Table.updateCol[Cols, N](
+      columns,
+      n,
+      c => c.copy(isUnique = true, uniqueGroups = c.uniqueGroups + nameStr)
+    )
+    copy(columns = updated.asInstanceOf[Table.AddAttr[Cols, N, ColumnAttr.Uq[N, N *: EmptyTuple]]])
+      .asInstanceOf[Table[Table.AddAttr[Cols, N, ColumnAttr.Uq[N, N *: EmptyTuple]], Name]]
+  }
+
+  /**
+   * Mark several columns as jointly making up a named `UNIQUE` constraint. Each listed column receives
+   * `ColumnAttr.Uq[ConstraintName, Ns]`, so composite `.onConflictComposite(c => (c.a, c.b))` is accepted as long as
+   * its column set is set-equal to `Ns`.
+   *
+   * Both arguments are **type arguments** — string literals as type parameters preserve their singleton types; the
+   * corresponding value-level literals would widen. `ConstraintName` is the SQL constraint name (surfaced by the
+   * schema validator in `Mismatch` messages).
+   *
+   * {{{
+   *   Table.of[Order]("orders").withUniqueIndex["uq_orders_tenant_slug", ("tenant_id", "slug")]
+   * }}}
+   */
+  inline def withUniqueIndex[ConstraintName <: String & Singleton, Ns <: NonEmptyTuple](using
+    @unused ev: Tuple.Union[Ns] <:< (String & Singleton)
+  ): Table[Table.AddCompositeUq[Cols, ConstraintName, Ns], Name] = {
+    CompileChecks.requireAllNamesInCols[Cols, Ns]
+    val cname   = compiletime.constValue[ConstraintName]: String
+    val names   = constValueTuple[Ns].toList.asInstanceOf[List[String]]
+    val nameSet = names.toSet
+    val updated =
+      Table.mapCols(columns, (c: Column[Any, String & Singleton, Boolean, Tuple]) =>
+        if (nameSet.contains(c.name)) c.copy(isUnique = true, uniqueGroups = c.uniqueGroups + cname) else c
+      )
+    copy(columns = updated.asInstanceOf[Table.AddCompositeUq[Cols, ConstraintName, Ns]])
+      .asInstanceOf[Table[Table.AddCompositeUq[Cols, ConstraintName, Ns], Name]]
   }
 
   /**
@@ -82,11 +150,29 @@ final case class Table[Cols <: Tuple, Name <: String & Singleton](
    * Mark a column as having a database-side default. Adds the [[ColumnAttr.Default]] marker to that column's `Attrs`
    * so INSERTs that omit the column become legal at the type level.
    */
-  inline def withDefault[N <: String & Singleton](inline n: N): Table[Table.AddAttr[Cols, N, ColumnAttr.Default], Name] = {
+  inline def withDefault[N <: String & Singleton](inline n: N)
+    : Table[Table.AddAttr[Cols, N, ColumnAttr.Default], Name] = {
     CompileChecks.requireColumn[Cols, N]
     val updated = Table.updateCol[Cols, N](columns, n, _.copy(hasDefault = true))
     copy(columns = updated.asInstanceOf[Table.AddAttr[Cols, N, ColumnAttr.Default]])
       .asInstanceOf[Table[Table.AddAttr[Cols, N, ColumnAttr.Default], Name]]
+  }
+
+  /**
+   * PK columns in declaration order. Derived from the per-column `isPrimary` flag. Used by [[skunk.sharp.validation]]
+   * to diff against `information_schema.table_constraints`.
+   */
+  def pkColumns: List[String] =
+    columns.toList.asInstanceOf[List[Column[?, ?, ?, ?]]].filter(_.isPrimary).map(_.name: String)
+
+  /**
+   * UNIQUE constraints as (name → column-list) pairs. Derived by inverting per-column `uniqueGroups`: two columns that
+   * share a group name belong to the same UNIQUE constraint.
+   */
+  def uniqueIndexes: Map[String, List[String]] = {
+    val cols = columns.toList.asInstanceOf[List[Column[?, ?, ?, ?]]]
+    cols.flatMap(c => c.uniqueGroups.toList.map(g => g -> (c.name: String)))
+      .groupMap(_._1)(_._2)
   }
 
 }
@@ -130,6 +216,30 @@ object Table {
     case EmptyTuple                      => EmptyTuple
   }
 
+  /**
+   * Type-level: append `ColumnAttr.Pk[Ns]` to every column whose name is in `Ns`. All listed columns end up with the
+   * same `Pk[Ns]` marker, which is what [[HasCompositeUniqueness]] matches against.
+   */
+  type AddCompositePk[Cols <: Tuple, Ns <: Tuple] <: Tuple = Cols match {
+    case Column[t, n, nu, attrs] *: tail => Contains[n, Ns] match {
+        case true  => Column[t, n, nu, Tuple.Append[attrs, ColumnAttr.Pk[Ns]]] *: AddCompositePk[tail, Ns]
+        case false => Column[t, n, nu, attrs] *: AddCompositePk[tail, Ns]
+      }
+    case EmptyTuple => EmptyTuple
+  }
+
+  /**
+   * Type-level: append `ColumnAttr.Uq[Name, Ns]` to every column whose name is in `Ns`. Parallels [[AddCompositePk]]
+   * but for named `UNIQUE` constraints.
+   */
+  type AddCompositeUq[Cols <: Tuple, Name <: String & Singleton, Ns <: Tuple] <: Tuple = Cols match {
+    case Column[t, n, nu, attrs] *: tail => Contains[n, Ns] match {
+        case true  => Column[t, n, nu, Tuple.Append[attrs, ColumnAttr.Uq[Name, Ns]]] *: AddCompositeUq[tail, Name, Ns]
+        case false => Column[t, n, nu, attrs] *: AddCompositeUq[tail, Name, Ns]
+      }
+    case EmptyTuple => EmptyTuple
+  }
+
   /** Runtime helper: walk the columns tuple, apply `f` to the column whose singleton-name matches `n`. */
   private[sharp] def updateCol[Cols <: Tuple, N <: String & Singleton](
     cols: Cols,
@@ -140,6 +250,18 @@ object Table {
       case c: Column[?, ?, ?, ?] if c.name == n =>
         f(c.asInstanceOf[Column[Any, N, Boolean, Tuple]])
       case other => other
+    }
+    Tuple.fromArray(updated.toArray[Any])
+  }
+
+  /** Runtime helper: apply `f` to every column in the tuple. */
+  private[sharp] def mapCols(
+    cols: Tuple,
+    f: Column[Any, String & Singleton, Boolean, Tuple] => Column[Any, String & Singleton, Boolean, Tuple]
+  ): Tuple = {
+    val updated = cols.toList.map {
+      case c: Column[?, ?, ?, ?] => f(c.asInstanceOf[Column[Any, String & Singleton, Boolean, Tuple]])
+      case other                 => other
     }
     Tuple.fromArray(updated.toArray[Any])
   }

--- a/modules/core/src/main/scala/skunk/sharp/dsl/Insert.scala
+++ b/modules/core/src/main/scala/skunk/sharp/dsl/Insert.scala
@@ -185,12 +185,22 @@ final class InsertCommand[Cols <: Tuple] private[sharp] (
   }
 
   /**
-   * Start a targeted `ON CONFLICT (c1, c2, …) …` clause on a *composite* target. No `HasUniqueness` check happens here:
-   * composite unique constraints aren't declarable on the Scala side yet — see the `.withUniqueIndex(name, cols*)`
-   * roadmap item. Postgres still raises at execution time if the declared set doesn't match a composite unique /
-   * exclusion constraint.
+   * Start a targeted `ON CONFLICT (c1, c2, …) …` clause on a *composite* target — the target must exactly match a
+   * declared `.withCompositePrimary(...)` or `.withUniqueIndex(...)` column set (set-equality, order-independent).
+   * Powered by [[HasCompositeUniqueness]] evidence.
+   *
+   * {{{
+   *   val orders = Table.of[Order]("orders").withCompositePrimary(("tenant_id", "order_id"))
+   *
+   *   orders.insert(row).onConflictComposite(o => (o.tenant_id, o.order_id)).doNothing.compile  // ✓
+   *   orders.insert(row).onConflictComposite(o => (o.tenant_id, o.slug)).doNothing.compile       // compile error
+   * }}}
    */
-  def onConflictComposite(f: ColumnsView[Cols] => Tuple): OnConflictBuilder[Cols] = {
+  def onConflictComposite[T <: NonEmptyTuple](
+    f: ColumnsView[Cols] => T
+  )(using
+    ev: HasCompositeUniqueness[Cols, NamesOfTypedCols[T]] =:= true
+  ): OnConflictBuilder[Cols] = {
     val view  = ColumnsView(table.columns)
     val names = f(view).toList.asInstanceOf[List[TypedColumn[?, ?, ?]]].map(_.name)
     new OnConflictBuilder[Cols](this, names)

--- a/modules/core/src/main/scala/skunk/sharp/internal/Derive.scala
+++ b/modules/core/src/main/scala/skunk/sharp/internal/Derive.scala
@@ -42,7 +42,8 @@ inline def deriveColumns[Labels <: Tuple, Types <: Tuple]: Tuple =
             isNullable = true,
             hasDefault = false,
             isPrimary = false,
-            isUnique = false
+            isUnique = false,
+            uniqueGroups = Set.empty[String]
           ) *: deriveColumns[ls, ts]
         case _: (t *: ts) =>
           val pf   = summonInline[PgTypeFor[t]]
@@ -54,7 +55,8 @@ inline def deriveColumns[Labels <: Tuple, Types <: Tuple]: Tuple =
             isNullable = false,
             hasDefault = false,
             isPrimary = false,
-            isUnique = false
+            isUnique = false,
+            uniqueGroups = Set.empty[String]
           ) *: deriveColumns[ls, ts]
       }
   }

--- a/modules/core/src/main/scala/skunk/sharp/validation/SchemaValidator.scala
+++ b/modules/core/src/main/scala/skunk/sharp/validation/SchemaValidator.scala
@@ -5,7 +5,7 @@ import cats.syntax.all.*
 import skunk.*
 import skunk.codec.all.*
 import skunk.implicits.*
-import skunk.sharp.{Column, Relation}
+import skunk.sharp.{Column, Relation, Table}
 import skunk.sharp.pg.PgTypes
 
 /**
@@ -129,31 +129,34 @@ object SchemaValidator {
   }
 
   /**
-   * Compare declared `isPrimary` / `isUnique` flags against the database's `PRIMARY KEY` and single-column `UNIQUE`
-   * constraints.
+   * Compare declared primary-key and unique-constraint data against the database. Handles both single-column and
+   * composite constraints:
    *
-   * Scope: set-based comparison for composite PKs (ordering inside a composite PK isn't declarable today); only
-   * single-column `UNIQUE` constraints (composite uniques need a separate `.withUniqueIndex(name, cols*)` DSL, see the
-   * issues board).
+   *   - PK: set-based comparison of columns (ordering inside a composite PK isn't declarable today).
+   *   - UNIQUE: keyed by constraint name on both sides, so a declared `.withUnique("email")` (auto-name `"email"`) and
+   *     a `.withUniqueIndex("uq_tenant_slug", ("tenant_id", "slug"))` are diffed separately and independently.
    */
   private def diffConstraints(
     label: String,
     relation: Relation[?],
     rows: List[ConstraintRow]
   ): ValidationReport = {
-    val cols                          = relation.columns.toList.asInstanceOf[List[Column[?, ?, ?, ?]]]
-    val declaredPkCols: Set[String]   = cols.filter(_.isPrimary).map(_.name: String).toSet
-    val declaredUniqCols: Set[String] = cols.filter(c => c.isUnique && !c.isPrimary).map(_.name: String).toSet
+    val cols                        = relation.columns.toList.asInstanceOf[List[Column[?, ?, ?, ?]]]
+    val declaredPkCols: Set[String] = cols.filter(_.isPrimary).map(_.name: String).toSet
+
+    // Declared unique constraints, keyed by constraint name.
+    val declaredUniques: Map[String, Set[String]] = relation match {
+      case t: Table[?, ?] => t.uniqueIndexes.view.mapValues(_.toSet).toMap
+      case _              => Map.empty
+    }
 
     // Group DB constraint rows by constraint name, then bucket by kind.
     val byConstraint: Map[(String, String), Set[String]] =
       rows.groupMap(r => (r.kind, r.name))(_.column).view.mapValues(_.toSet).toMap
     val actualPkColsOpt: Option[Set[String]] =
       byConstraint.collectFirst { case ((kind, _), cs) if kind == "PRIMARY KEY" => cs }
-    val actualSingleCol_UniqueCols: Set[String] =
-      byConstraint.iterator.collect {
-        case ((kind, _), cs) if kind == "UNIQUE" && cs.sizeIs == 1 => cs.head
-      }.toSet
+    val actualUniques: Map[String, Set[String]] =
+      byConstraint.iterator.collect { case ((kind, name), cs) if kind == "UNIQUE" => name -> cs }.toMap
 
     val pkMismatches: List[Mismatch] = (declaredPkCols.isEmpty, actualPkColsOpt) match {
       case (true, None)                                      => Nil
@@ -164,12 +167,27 @@ object SchemaValidator {
       case _ => Nil
     }
 
-    val missingUnique = (declaredUniqCols -- actualSingleCol_UniqueCols).toList.sorted
-      .map(Mismatch.UniqueConstraintMissing(label, _))
-    val extraUnique = (actualSingleCol_UniqueCols -- declaredUniqCols -- declaredPkCols).toList.sorted
-      .map(Mismatch.ExtraUniqueConstraint(label, _))
+    // Match UNIQUE constraints by their column set, not by name — Postgres auto-generates names for inline
+    // `UNIQUE` columns (`<table>_<col>_key`) while the DSL defaults to the user-facing column name for the
+    // `.withUnique(col)` shorthand. Matching by column set (which is unambiguous, since Postgres forbids two unique
+    // constraints on the same set of columns) gracefully handles both. We still carry the declared or DB name through
+    // so `Mismatch` messages are identifiable.
+    val declaredByCols: Map[Set[String], String] =
+      declaredUniques.iterator.map { case (n, cs) => cs -> n }.toMap
+    val actualByCols: Map[Set[String], String] =
+      actualUniques.iterator.map { case (n, cs) => cs -> n }.toMap
 
-    ValidationReport(pkMismatches ++ missingUnique ++ extraUnique)
+    val uniqueMismatches: List[Mismatch] = {
+      val missing = (declaredByCols.keySet -- actualByCols.keySet).toList
+        .sortBy(_.toList.sorted.mkString(","))
+        .map(cs => Mismatch.UniqueConstraintMissing(label, declaredByCols(cs), cs))
+      val extra = (actualByCols.keySet -- declaredByCols.keySet).toList
+        .sortBy(_.toList.sorted.mkString(","))
+        .map(cs => Mismatch.ExtraUniqueConstraint(label, actualByCols(cs), cs))
+      missing ++ extra
+    }
+
+    ValidationReport(pkMismatches ++ uniqueMismatches)
   }
 
   private def diffColumns(label: String, relation: Relation[?], actual: List[ColumnInfo]): ValidationReport = {

--- a/modules/core/src/main/scala/skunk/sharp/validation/ValidationReport.scala
+++ b/modules/core/src/main/scala/skunk/sharp/validation/ValidationReport.scala
@@ -72,17 +72,29 @@ object Mismatch {
 
   }
 
-  /** Declared `.withUnique(column)` but no matching single-column `UNIQUE` constraint in the database. */
-  final case class UniqueConstraintMissing(relation: String, column: String) extends Mismatch {
-    def pretty = s"relation $relation: expected a unique constraint on $column but none found in the database"
+  /**
+   * Declared `.withUnique(column)` / `.withUniqueIndex(name, cols)` but no matching `UNIQUE` constraint in the
+   * database. `name` is the constraint name (matches the DB's `constraint_name`); `columns` is the full column set.
+   * Single-column unique constraints use the column name as `name`, matching Postgres's default naming convention.
+   */
+  final case class UniqueConstraintMissing(relation: String, name: String, columns: Set[String]) extends Mismatch {
+
+    def pretty =
+      s"relation $relation: expected unique constraint \"$name\" on ${columns.mkString("(", ", ", ")")} but none found " +
+        "in the database"
+
   }
 
   /**
-   * Database has a single-column unique constraint on a column that isn't declared `.withUnique`. Usually informational
-   * (an index-backed unique that the Scala description doesn't know about); report so callers see it.
+   * Database has a `UNIQUE` constraint that the Scala description doesn't declare (by name). Usually informational;
+   * report so callers can tighten their declaration. `name` is the DB's `constraint_name`, `columns` its column set.
    */
-  final case class ExtraUniqueConstraint(relation: String, column: String) extends Mismatch {
-    def pretty = s"relation $relation: DB has a unique constraint on $column that is not declared"
+  final case class ExtraUniqueConstraint(relation: String, name: String, columns: Set[String]) extends Mismatch {
+
+    def pretty =
+      s"relation $relation: DB has unique constraint \"$name\" on ${columns.mkString("(", ", ", ")")} that is not " +
+        "declared"
+
   }
 
 }

--- a/modules/core/src/test/scala/skunk/sharp/NegativeTestsSuite.scala
+++ b/modules/core/src/test/scala/skunk/sharp/NegativeTestsSuite.scala
@@ -207,4 +207,120 @@ class NegativeTestsSuite extends munit.FunSuite {
     """)
     assert(errs.nonEmpty, "expected a compile error when the table has no declared constraints")
   }
+
+  // ---- Composite .onConflict evidence (HasCompositeUniqueness) -------------------------------
+
+  test(".onConflict rejects a single-column target when the column is part of a composite PK") {
+    // Being part of a composite PK doesn't qualify a column for single-column `.onConflict`. Postgres requires the
+    // target to match an entire constraint.
+    val errs = typeCheckErrors("""
+      import skunk.sharp.*
+      import skunk.sharp.dsl.*
+      import NegativeTestsSuite.User
+      import java.time.OffsetDateTime
+      val users = Table.of[User]("users").withCompositePrimary[("id", "email")]
+      users
+        .insert((
+          id = java.util.UUID.randomUUID,
+          email = "x",
+          age = 1,
+          created_at = OffsetDateTime.now(),
+          deleted_at = Option.empty[OffsetDateTime]
+        ))
+        .onConflict(u => u.id)   // partial PK — should be rejected
+        .doNothing
+        .compile
+    """)
+    assert(errs.nonEmpty, "expected rejection for single-col onConflict on a composite-PK column")
+  }
+
+  test(".onConflictComposite accepts the full composite-PK tuple") {
+    val errs = typeCheckErrors("""
+      import skunk.sharp.*
+      import skunk.sharp.dsl.*
+      import NegativeTestsSuite.User
+      import java.time.OffsetDateTime
+      val users = Table.of[User]("users").withCompositePrimary[("id", "email")]
+      users
+        .insert((
+          id = java.util.UUID.randomUUID,
+          email = "x",
+          age = 1,
+          created_at = OffsetDateTime.now(),
+          deleted_at = Option.empty[OffsetDateTime]
+        ))
+        .onConflictComposite(u => (u.id, u.email))
+        .doNothing
+        .compile
+    """)
+    assert(errs.isEmpty, s"expected no errors for full composite PK target; got: ${errs.map(_.message).mkString("\n")}")
+  }
+
+  test(".onConflictComposite accepts columns in any order (set-equality)") {
+    val errs = typeCheckErrors("""
+      import skunk.sharp.*
+      import skunk.sharp.dsl.*
+      import NegativeTestsSuite.User
+      import java.time.OffsetDateTime
+      val users = Table.of[User]("users").withCompositePrimary[("id", "email")]
+      users
+        .insert((
+          id = java.util.UUID.randomUUID,
+          email = "x",
+          age = 1,
+          created_at = OffsetDateTime.now(),
+          deleted_at = Option.empty[OffsetDateTime]
+        ))
+        .onConflictComposite(u => (u.email, u.id))   // reversed order — should still compile
+        .doNothing
+        .compile
+    """)
+    assert(errs.isEmpty, s"expected no errors for reversed composite PK target; got: ${errs.map(_.message).mkString("\n")}")
+  }
+
+  test(".onConflictComposite rejects a tuple that doesn't exactly match a declared composite group") {
+    val errs = typeCheckErrors("""
+      import skunk.sharp.*
+      import skunk.sharp.dsl.*
+      import NegativeTestsSuite.User
+      import java.time.OffsetDateTime
+      val users = Table.of[User]("users").withCompositePrimary[("id", "email")]
+      users
+        .insert((
+          id = java.util.UUID.randomUUID,
+          email = "x",
+          age = 1,
+          created_at = OffsetDateTime.now(),
+          deleted_at = Option.empty[OffsetDateTime]
+        ))
+        .onConflictComposite(u => (u.id, u.age))   // "age" is not part of any group
+        .doNothing
+        .compile
+    """)
+    assert(errs.nonEmpty, "expected rejection for onConflictComposite with a non-matching column set")
+  }
+
+  test(".onConflictComposite accepts a named composite unique index") {
+    val errs = typeCheckErrors("""
+      import skunk.sharp.*
+      import skunk.sharp.dsl.*
+      import NegativeTestsSuite.User
+      import java.time.OffsetDateTime
+      val users = Table.of[User]("users")
+        .withPrimary("id")
+        .withUniqueIndex["uq_email_age", ("email", "age")]
+      users
+        .insert((
+          id = java.util.UUID.randomUUID,
+          email = "x",
+          age = 1,
+          created_at = OffsetDateTime.now(),
+          deleted_at = Option.empty[OffsetDateTime]
+        ))
+        .onConflictComposite(u => (u.email, u.age))
+        .doNothing
+        .compile
+    """)
+    assert(errs.isEmpty, s"expected no errors for named composite unique target; got: ${errs.map(_.message).mkString("\n")}")
+  }
 }

--- a/modules/tests/src/test/resources/migrations/V7__orders.sql
+++ b/modules/tests/src/test/resources/migrations/V7__orders.sql
@@ -1,0 +1,11 @@
+-- Exercise composite primary keys and named composite unique constraints.
+CREATE TABLE orders (
+  tenant_id  uuid        NOT NULL,
+  order_id   bigint      NOT NULL,
+  slug       text        NOT NULL,
+  external_id text       NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (tenant_id, order_id),
+  CONSTRAINT uq_orders_tenant_slug UNIQUE (tenant_id, slug),
+  CONSTRAINT uq_orders_external_id UNIQUE (external_id)
+);

--- a/modules/tests/src/test/scala/skunk/sharp/tests/SchemaValidatorSuite.scala
+++ b/modules/tests/src/test/scala/skunk/sharp/tests/SchemaValidatorSuite.scala
@@ -13,6 +13,9 @@ object SchemaValidatorSuite {
   // Intentionally wrong: `emails` is not a column; `age` declared as String instead of Int; `created_at` nullability
   // claim is wrong.
   case class BrokenUser(id: UUID, emails: String, age: String, created_at: Option[OffsetDateTime])
+
+  // Exercises composite PK + named composite UNIQUE + single-column UNIQUE. Matches V7__orders.sql.
+  case class Order(tenant_id: UUID, order_id: Long, slug: String, external_id: String, created_at: OffsetDateTime)
 }
 
 class SchemaValidatorSuite extends PgFixture {
@@ -114,8 +117,8 @@ class SchemaValidatorSuite extends PgFixture {
         SchemaValidator.validate[IO](s, wrongUnique).map { report =>
           assert(
             report.mismatches.exists {
-              case Mismatch.UniqueConstraintMissing(_, "age") => true
-              case _                                          => false
+              case Mismatch.UniqueConstraintMissing(_, "age", cols) => cols == Set("age")
+              case _                                                => false
             },
             s"expected UniqueConstraintMissing(age), got: ${report.mismatches.map(_.pretty).mkString("; ")}"
           )
@@ -132,7 +135,7 @@ class SchemaValidatorSuite extends PgFixture {
         SchemaValidator.validate[IO](s, pkOnly).map { report =>
           assert(
             report.mismatches.exists {
-              case Mismatch.ExtraUniqueConstraint(_, "email") => true
+              case Mismatch.ExtraUniqueConstraint(_, _, cols) => cols == Set("email")
               case _                                          => false
             },
             s"expected ExtraUniqueConstraint(email), got: ${report.mismatches.map(_.pretty).mkString("; ")}"
@@ -153,6 +156,83 @@ class SchemaValidatorSuite extends PgFixture {
               case _                                   => false
             },
             s"expected ExtraPrimaryKey(id), got: ${report.mismatches.map(_.pretty).mkString("; ")}"
+          )
+        }
+      }
+    }
+  }
+
+  // ---- Composite constraints (PR: composite PK + composite UNIQUE) --------------------------------
+
+  test("validate accepts a composite PK + composite UNIQUE + single-column UNIQUE declaration") {
+    withContainers { containers =>
+      session(containers).use { s =>
+        val orders = Table.of[Order]("orders")
+          .withCompositePrimary[("tenant_id", "order_id")]
+          .withUniqueIndex["uq_orders_tenant_slug", ("tenant_id", "slug")]
+          .withUnique("external_id")
+          .withDefault("created_at")
+
+        SchemaValidator.validate[IO](s, orders).map { report =>
+          assert(report.isValid, s"expected valid, got: ${report.mismatches.map(_.pretty).mkString("; ")}")
+        }
+      }
+    }
+  }
+
+  test("validate flags a mis-declared composite PK (wrong column set)") {
+    withContainers { containers =>
+      session(containers).use { s =>
+        // DB PK is (tenant_id, order_id). Declare (tenant_id, slug) instead — expect PrimaryKeyColumnsDiffer.
+        val wrongPk = Table.of[Order]("orders").withCompositePrimary[("tenant_id", "slug")]
+        SchemaValidator.validate[IO](s, wrongPk).map { report =>
+          assert(
+            report.mismatches.exists {
+              case Mismatch.PrimaryKeyColumnsDiffer(_, exp, act) =>
+                exp == Set("tenant_id", "slug") && act == Set("tenant_id", "order_id")
+              case _ => false
+            },
+            s"expected PrimaryKeyColumnsDiffer, got: ${report.mismatches.map(_.pretty).mkString("; ")}"
+          )
+        }
+      }
+    }
+  }
+
+  test("validate flags a missing composite UNIQUE when declared but absent in DB") {
+    withContainers { containers =>
+      session(containers).use { s =>
+        // Declare a composite unique on (slug, external_id) — doesn't exist in DB.
+        val orders = Table.of[Order]("orders")
+          .withCompositePrimary[("tenant_id", "order_id")]
+          .withUniqueIndex["uq_bogus", ("slug", "external_id")]
+        SchemaValidator.validate[IO](s, orders).map { report =>
+          assert(
+            report.mismatches.exists {
+              case Mismatch.UniqueConstraintMissing(_, "uq_bogus", cols) => cols == Set("slug", "external_id")
+              case _                                                     => false
+            },
+            s"expected UniqueConstraintMissing(uq_bogus), got: ${report.mismatches.map(_.pretty).mkString("; ")}"
+          )
+        }
+      }
+    }
+  }
+
+  test("validate flags ExtraUniqueConstraint for a DB composite unique the declaration misses") {
+    withContainers { containers =>
+      session(containers).use { s =>
+        // Declare only PK + external_id unique — miss the (tenant_id, slug) composite. Expect ExtraUniqueConstraint.
+        val orders = Table.of[Order]("orders")
+          .withCompositePrimary[("tenant_id", "order_id")]
+          .withUnique("external_id")
+        SchemaValidator.validate[IO](s, orders).map { report =>
+          assert(
+            report.mismatches.exists {
+              case Mismatch.ExtraUniqueConstraint(_, _, cols) => cols == Set("tenant_id", "slug")
+              case _                                          => false
+            },
+            s"expected ExtraUniqueConstraint on (tenant_id, slug), got: ${report.mismatches.map(_.pretty).mkString("; ")}"
           )
         }
       }


### PR DESCRIPTION
## Summary

Builds on PR #49 (Attrs tuple infrastructure) to add **composite constraints** — primary keys and unique indexes spanning multiple columns — with the same compile-time \`.onConflict\` evidence that single-column constraints already get.

**Stacked on PR #49** — merge that one first, then retarget this to \`main\`.

## New DSL

    orders
      .withCompositePrimary[("tenant_id", "order_id")]
      .withUniqueIndex["uq_orders_tenant_slug", ("tenant_id", "slug")]
      .withUnique("external_id")   // single-column, unchanged

    // single-column onConflict on a composite-PK member = compile error
    orders.insert(row).onConflict(o => o.tenant_id).doNothing  // ✗

    // composite form accepts the full declared set (order-independent)
    orders.insert(row).onConflictComposite(o => (o.order_id, o.tenant_id)).doNothing  // ✓
    orders.insert(row).onConflictComposite(o => (o.tenant_id, o.slug)).doUpdate(…)    // ✓

Column names pass as **type arguments** to \`withCompositePrimary\` / \`withUniqueIndex\`: value-level tuple literals \`("a", "b")\` widen to \`(String, String)\` at the Scala level, stripping the singletons the match-type machinery needs. Type arguments preserve them.

## Marker evolution

\`ColumnAttr.Primary\` / \`ColumnAttr.Unique\` (parameterless) are now \`ColumnAttr.Pk[Members <: Tuple]\` / \`ColumnAttr.Uq[Name, Members]\`. Single-column calls produce a 1-element tuple; composite calls share the full tuple across every member column. Evidence match types (\`HasSingletonKey\`, \`HasGroupMatching\`) walk these.

## Schema validator — column-set matching

UNIQUE diffing now keys by **column set**, not by constraint name. Postgres auto-names inline \`UNIQUE\` columns (\`users_email_key\`); matching on name would produce spurious mismatches against \`.withUnique("email")\`. Column sets are unambiguous (PG forbids two uniques on the same set).

\`Mismatch.UniqueConstraintMissing\` / \`ExtraUniqueConstraint\` now carry \`(name, columns: Set[String])\`.

## Test plan

- [x] \`sbt core/test iron/test circe/test\` — all 163 unit tests pass, including 5 new compile-time negatives for composite \`.onConflict\`
- [x] \`sbt tests/test\` — 74 integration tests pass, including 4 new ones over a new \`V7__orders.sql\` migration
- [x] \`SBT_TPOLECAT_CI=1 sbt clean compile\` — clean under fatal warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)