### PR TITLE
Compile-time GROUP BY coverage check

### DIFF
--- a/modules/core/src/main/scala/skunk/sharp/HasColumn.scala
+++ b/modules/core/src/main/scala/skunk/sharp/HasColumn.scala
@@ -154,3 +154,92 @@ type HasCompositeUniqueness[Cols <: Tuple, Ns <: Tuple] <: Boolean = Cols match 
     }
   case EmptyTuple => false
 }
+
+/**
+ * Extract column-name singletons from a tuple of GROUP BY expressions. Only bare [[TypedColumn]] references contribute
+ * a name — expressions, function calls, literals skip. Used by [[GroupCoverage]] to collect the set of column names a
+ * caller's GROUP BY provides.
+ */
+type GroupNames[G <: Tuple] <: Tuple = G match {
+  case EmptyTuple                    => EmptyTuple
+  case TypedColumn[t, nu, n] *: tail => n *: GroupNames[tail]
+  case h *: tail                     => GroupNames[tail]
+}
+
+/**
+ * Marker typeclass: evidence that `E` is a bare [[TypedColumn]] reference with singleton name `N`. Powers
+ * [[GroupCoverage]]'s typeclass-based dispatch — match-type dispatch can't distinguish `TypedColumn` from
+ * `TypedExpr` since the former extends the latter (match types require *provable* disjointness, which subtype
+ * relationships defeat).
+ */
+sealed trait IsTypedCol[E] {
+  type N <: String & Singleton
+}
+
+object IsTypedCol {
+
+  type Aux[E, N0 <: String & Singleton] = IsTypedCol[E] { type N = N0 }
+
+  given fromTypedColumn[T, Null <: Boolean, N_ <: String & Singleton]
+    : IsTypedCol.Aux[TypedColumn[T, Null, N_], N_] = new IsTypedCol[TypedColumn[T, Null, N_]] {
+    type N = N_
+  }
+
+}
+
+/**
+ * Coverage witness for a single projection element:
+ *   - If `E` is a `TypedColumn[_, _, N]` whose `N` is in `GNames` — covered.
+ *   - If `E` is *not* a column (aggregate, literal, aliased expression, …) — covered unconditionally.
+ *   - If `E` is a column whose name is NOT in `GNames` — no instance resolves → compile error.
+ */
+sealed trait ElemCoverage[E, GNames <: Tuple]
+
+object ElemCoverage {
+
+  given columnCovered[E, N <: String & Singleton, GNames <: Tuple](using
+    col: IsTypedCol.Aux[E, N],
+    ev: Contains[N, GNames] =:= true
+  ): ElemCoverage[E, GNames] = new ElemCoverage[E, GNames] {}
+
+  given nonColumn[E, GNames <: Tuple](using
+    nc: scala.util.NotGiven[IsTypedCol[E]]
+  ): ElemCoverage[E, GNames] = new ElemCoverage[E, GNames] {}
+
+}
+
+/**
+ * Every element of `Proj` has [[ElemCoverage]] under `GNames`. Walks the projection tuple inductively — given instance
+ * resolution handles each element individually.
+ */
+sealed trait AllCovered[Proj <: Tuple, GNames <: Tuple]
+
+object AllCovered {
+
+  given empty[GNames <: Tuple]: AllCovered[EmptyTuple, GNames] = new AllCovered[EmptyTuple, GNames] {}
+
+  given cons[H, Rest <: Tuple, GNames <: Tuple](using
+    h: ElemCoverage[H, GNames],
+    r: AllCovered[Rest, GNames]
+  ): AllCovered[H *: Rest, GNames] = new AllCovered[H *: Rest, GNames] {}
+
+}
+
+/**
+ * Compile-time GROUP BY coverage gate. Summons iff either no GROUP BY is declared (vacuous) or every bare column in
+ * the projection also appears in the GROUP BY. Aggregates, literals, function-call expressions, aliased expressions
+ * pass unconditionally. GROUP BY expressions that are not bare columns (e.g.
+ * `.groupBy(u => Pg.dateTrunc("day", u.created))`) don't contribute names; queries relying on that form aren't
+ * helped by this check and should drop to hand SQL.
+ */
+sealed trait GroupCoverage[Proj <: Tuple, G <: Tuple]
+
+object GroupCoverage {
+
+  given empty[Proj <: Tuple]: GroupCoverage[Proj, EmptyTuple] = new GroupCoverage[Proj, EmptyTuple] {}
+
+  given nonEmpty[Proj <: Tuple, G <: NonEmptyTuple](using
+    ev: AllCovered[Proj, GroupNames[G]]
+  ): GroupCoverage[Proj, G] = new GroupCoverage[Proj, G] {}
+
+}

--- a/modules/core/src/main/scala/skunk/sharp/dsl/Compiled.scala
+++ b/modules/core/src/main/scala/skunk/sharp/dsl/Compiled.scala
@@ -85,9 +85,11 @@ object AsSubquery {
     def toCompiled(q: CompiledQuery[T]): CompiledQuery[T] = q
   }
 
-  given fromProjected[Ss <: Tuple, T]: AsSubquery[ProjectedSelect[Ss, T], T] =
-    new AsSubquery[ProjectedSelect[Ss, T], T] {
-      def toCompiled(q: ProjectedSelect[Ss, T]): CompiledQuery[T] = q.compile
+  given fromProjected[Ss <: Tuple, Proj <: Tuple, Groups <: Tuple, T](using
+    ev: skunk.sharp.GroupCoverage[Proj, Groups]
+  ): AsSubquery[ProjectedSelect[Ss, Proj, Groups, T], T] =
+    new AsSubquery[ProjectedSelect[Ss, Proj, Groups, T], T] {
+      def toCompiled(q: ProjectedSelect[Ss, Proj, Groups, T]): CompiledQuery[T] = q.compile(using ev)
     }
 
   /** Whole-row SelectBuilder → subquery of NamedRow. Relies on the same IsSingleSource evidence `.compile` uses. */

--- a/modules/core/src/main/scala/skunk/sharp/dsl/Select.scala
+++ b/modules/core/src/main/scala/skunk/sharp/dsl/Select.scala
@@ -54,7 +54,11 @@ final class SelectBuilder[Ss <: Tuple] private[sharp] (
     copy(orderBys = orderBys ++ fresh)
   }
 
-  /** `GROUP BY …`. Coverage is not type-checked (Postgres raises runtime on misalignment). */
+  /**
+   * `GROUP BY …` on a pre-projection builder — runtime-only. Coverage of the later projection isn't type-checked here
+   * because we don't know the projection yet; use the `.select(...).groupBy(...)` order (or the whole-row
+   * [[compile]]) to get the compile-time check via [[GroupCoverage]].
+   */
   def groupBy(f: SelectView[Ss] => TypedExpr[?] | Tuple): SelectBuilder[Ss] = {
     val fresh = f(view) match {
       case e: TypedExpr[?] => List(e)
@@ -149,13 +153,16 @@ final class SelectBuilder[Ss <: Tuple] private[sharp] (
 
   /**
    * Projection — pick the columns / expressions to return. Single `TypedExpr[T]` → row is `T`; tuple (named or
-   * positional) → row is the tuple of expression output types.
+   * positional) → row is the tuple of expression output types. `X` is threaded as the projection phantom (`Proj`) on
+   * the resulting [[ProjectedSelect]] so downstream [[ProjectedSelect.groupBy]] / [[ProjectedSelect.compile]] can
+   * check GROUP BY coverage.
    */
-  transparent inline def select[X](inline f: SelectView[Ss] => X): ProjectedSelect[Ss, ProjResult[X]] = {
+  transparent inline def select[X](inline f: SelectView[Ss] => X)
+    : ProjectedSelect[Ss, NormProj[X], EmptyTuple, ProjResult[X]] = {
     val v = view
     f(v) match {
       case expr: TypedExpr[?] =>
-        new ProjectedSelect[Ss, ProjResult[X]](
+        new ProjectedSelect[Ss, NormProj[X], EmptyTuple, ProjResult[X]](
           sources,
           distinct,
           List(expr),
@@ -171,7 +178,7 @@ final class SelectBuilder[Ss <: Tuple] private[sharp] (
       case tup: NonEmptyTuple =>
         val exprs = tup.toList.asInstanceOf[List[TypedExpr[?]]]
         val codec = tupleCodec(exprs.map(_.codec)).asInstanceOf[Codec[ProjResult[X]]]
-        new ProjectedSelect[Ss, ProjResult[X]](
+        new ProjectedSelect[Ss, NormProj[X], EmptyTuple, ProjResult[X]](
           sources,
           distinct,
           exprs,
@@ -187,7 +194,8 @@ final class SelectBuilder[Ss <: Tuple] private[sharp] (
     }
   }
 
-  transparent inline def apply[X](inline f: SelectView[Ss] => X): ProjectedSelect[Ss, ProjResult[X]] = select[X](f)
+  transparent inline def apply[X](inline f: SelectView[Ss] => X)
+    : ProjectedSelect[Ss, NormProj[X], EmptyTuple, ProjResult[X]] = select[X](f)
 
   /**
    * Whole-row `.compile` — only available on single-source builders. Multi-source builders must project first via
@@ -213,8 +221,12 @@ final class SelectBuilder[Ss <: Tuple] private[sharp] (
 /**
  * A SELECT with an explicit projection list — rows have shape `Row` instead of the relation's default named tuple.
  * Shared between single-source and multi-source queries; the `Ss` parameter carries the full shape.
+ *
+ *   - `Proj` is the tuple-normalised projection (`X *: EmptyTuple` for single-expr, the tuple itself for multi-expr).
+ *     Threaded from `.select[X](f)` so downstream `.groupBy` / `.compile` can check coverage.
+ *   - `Groups` is the tuple of GROUP BY expressions; starts `EmptyTuple`, extended by `.groupBy[G]`.
  */
-final class ProjectedSelect[Ss <: Tuple, Row](
+final class ProjectedSelect[Ss <: Tuple, Proj <: Tuple, Groups <: Tuple, Row](
   private[sharp] val sources: Ss,
   private[sharp] val distinct: Boolean,
   private[sharp] val projections: List[TypedExpr[?]],
@@ -239,8 +251,8 @@ final class ProjectedSelect[Ss <: Tuple, Row](
     limitOpt: Option[Int] = limitOpt,
     offsetOpt: Option[Int] = offsetOpt,
     lockingOpt: Option[Locking] = lockingOpt
-  ): ProjectedSelect[Ss, Row] =
-    new ProjectedSelect[Ss, Row](
+  ): ProjectedSelect[Ss, Proj, Groups, Row] =
+    new ProjectedSelect[Ss, Proj, Groups, Row](
       sources,
       distinct,
       projections,
@@ -256,12 +268,12 @@ final class ProjectedSelect[Ss <: Tuple, Row](
 
   private def view: SelectView[Ss] = buildSelectView[Ss](sources)
 
-  def where(f: SelectView[Ss] => Where): ProjectedSelect[Ss, Row] = {
+  def where(f: SelectView[Ss] => Where): ProjectedSelect[Ss, Proj, Groups, Row] = {
     val next = whereOpt.fold(f(view))(_ && f(view))
     copy(whereOpt = Some(next))
   }
 
-  def orderBy(f: SelectView[Ss] => OrderBy | Tuple): ProjectedSelect[Ss, Row] = {
+  def orderBy(f: SelectView[Ss] => OrderBy | Tuple): ProjectedSelect[Ss, Proj, Groups, Row] = {
     val fresh = f(view) match {
       case ob: OrderBy => List(ob)
       case t: Tuple    => t.toList.asInstanceOf[List[OrderBy]]
@@ -269,40 +281,58 @@ final class ProjectedSelect[Ss <: Tuple, Row](
     copy(orderBys = orderBys ++ fresh)
   }
 
-  def groupBy(f: SelectView[Ss] => TypedExpr[?] | Tuple): ProjectedSelect[Ss, Row] = {
-    val fresh = f(view) match {
+  /**
+   * `GROUP BY …`. `G` is captured as a phantom — bare-column elements contribute their names to [[Groups]] for the
+   * eventual coverage check at `.compile` time. Accumulates across multiple calls via `Tuple.Concat`.
+   */
+  transparent inline def groupBy[G](inline f: SelectView[Ss] => G)
+    : ProjectedSelect[Ss, Proj, Tuple.Concat[Groups, NormProj[G]], Row] = {
+    val v     = view
+    val fresh = f(v) match {
       case e: TypedExpr[?] => List(e)
       case t: Tuple        => t.toList.asInstanceOf[List[TypedExpr[?]]]
     }
-    copy(groupBys = groupBys ++ fresh)
+    new ProjectedSelect[Ss, Proj, Tuple.Concat[Groups, NormProj[G]], Row](
+      sources,
+      distinct,
+      projections,
+      codec,
+      whereOpt,
+      groupBys ++ fresh,
+      havingOpt,
+      orderBys,
+      limitOpt,
+      offsetOpt,
+      lockingOpt
+    )
   }
 
-  def having(f: SelectView[Ss] => Where): ProjectedSelect[Ss, Row] = {
+  def having(f: SelectView[Ss] => Where): ProjectedSelect[Ss, Proj, Groups, Row] = {
     val next = havingOpt.fold(f(view))(_ && f(view))
     copy(havingOpt = Some(next))
   }
 
-  def limit(n: Int): ProjectedSelect[Ss, Row]  = copy(limitOpt = Some(n))
-  def offset(n: Int): ProjectedSelect[Ss, Row] = copy(offsetOpt = Some(n))
+  def limit(n: Int): ProjectedSelect[Ss, Proj, Groups, Row]  = copy(limitOpt = Some(n))
+  def offset(n: Int): ProjectedSelect[Ss, Proj, Groups, Row] = copy(offsetOpt = Some(n))
 
-  def distinctRows: ProjectedSelect[Ss, Row] = copy(distinct = true)
+  def distinctRows: ProjectedSelect[Ss, Proj, Groups, Row] = copy(distinct = true)
 
-  def forUpdate(using ev: IsSingleTable[Ss]): ProjectedSelect[Ss, Row] =
+  def forUpdate(using ev: IsSingleTable[Ss]): ProjectedSelect[Ss, Proj, Groups, Row] =
     copy(lockingOpt = Some(Locking(LockMode.ForUpdate)))
 
-  def forNoKeyUpdate(using ev: IsSingleTable[Ss]): ProjectedSelect[Ss, Row] =
+  def forNoKeyUpdate(using ev: IsSingleTable[Ss]): ProjectedSelect[Ss, Proj, Groups, Row] =
     copy(lockingOpt = Some(Locking(LockMode.ForNoKeyUpdate)))
 
-  def forShare(using ev: IsSingleTable[Ss]): ProjectedSelect[Ss, Row] =
+  def forShare(using ev: IsSingleTable[Ss]): ProjectedSelect[Ss, Proj, Groups, Row] =
     copy(lockingOpt = Some(Locking(LockMode.ForShare)))
 
-  def forKeyShare(using ev: IsSingleTable[Ss]): ProjectedSelect[Ss, Row] =
+  def forKeyShare(using ev: IsSingleTable[Ss]): ProjectedSelect[Ss, Proj, Groups, Row] =
     copy(lockingOpt = Some(Locking(LockMode.ForKeyShare)))
 
-  def skipLocked(using ev: IsSingleTable[Ss]): ProjectedSelect[Ss, Row] =
+  def skipLocked(using ev: IsSingleTable[Ss]): ProjectedSelect[Ss, Proj, Groups, Row] =
     copy(lockingOpt = lockingOpt.map(_.copy(waitPolicy = WaitPolicy.SkipLocked)))
 
-  def noWait(using ev: IsSingleTable[Ss]): ProjectedSelect[Ss, Row] =
+  def noWait(using ev: IsSingleTable[Ss]): ProjectedSelect[Ss, Proj, Groups, Row] =
     copy(lockingOpt = lockingOpt.map(_.copy(waitPolicy = WaitPolicy.NoWait)))
 
   /**
@@ -311,11 +341,11 @@ final class ProjectedSelect[Ss <: Tuple, Row](
    */
   def to[T <: Product](using
     m: scala.deriving.Mirror.ProductOf[T] { type MirroredElemTypes = Row & Tuple }
-  ): ProjectedSelect[Ss, T] = {
+  ): ProjectedSelect[Ss, Proj, Groups, T] = {
     val newCodec: Codec[T] = codec.imap[T](r => m.fromProduct(r.asInstanceOf[Product]))(t =>
       Tuple.fromProductTyped[T](t)(using m).asInstanceOf[Row]
     )
-    new ProjectedSelect[Ss, T](
+    new ProjectedSelect[Ss, Proj, Groups, T](
       sources,
       distinct,
       projections,
@@ -330,7 +360,12 @@ final class ProjectedSelect[Ss <: Tuple, Row](
     )
   }
 
-  def compile: CompiledQuery[Row] = {
+  /**
+   * Compile into an [[CompiledQuery]]. Enforces [[GroupCoverage]] — if GROUP BY is declared, every bare-column element
+   * in the projection must appear in the GROUP BY; aggregates, literals, aliased expressions are free. When no GROUP
+   * BY is declared, the check is vacuous.
+   */
+  def compile(using @scala.annotation.unused ev: GroupCoverage[Proj, Groups]): CompiledQuery[Row] = {
     val entries  = sources.toList.asInstanceOf[List[SourceEntry[?, ?, ?, ?]]]
     val projList = TypedExpr.joined(projections.map(_.render), ", ")
     val keyword  = if (distinct) "SELECT DISTINCT " else "SELECT "
@@ -401,11 +436,11 @@ extension [L, RL <: Relation[CL], CL <: Tuple, AL <: String & Singleton](left: L
 extension (rel: skunk.sharp.empty.type) {
 
   transparent inline def select[X](inline f: ColumnsView[EmptyTuple] => X)
-    : ProjectedSelect[EmptyTuple, ProjResult[X]] = {
+    : ProjectedSelect[EmptyTuple, NormProj[X], EmptyTuple, ProjResult[X]] = {
     val v = ColumnsView(EmptyTuple)
     f(v) match {
       case expr: TypedExpr[?] =>
-        new ProjectedSelect[EmptyTuple, ProjResult[X]](
+        new ProjectedSelect[EmptyTuple, NormProj[X], EmptyTuple, ProjResult[X]](
           EmptyTuple,
           false,
           List(expr),
@@ -421,7 +456,7 @@ extension (rel: skunk.sharp.empty.type) {
       case tup: NonEmptyTuple =>
         val exprs = tup.toList.asInstanceOf[List[TypedExpr[?]]]
         val codec = tupleCodec(exprs.map(_.codec)).asInstanceOf[Codec[ProjResult[X]]]
-        new ProjectedSelect[EmptyTuple, ProjResult[X]](
+        new ProjectedSelect[EmptyTuple, NormProj[X], EmptyTuple, ProjResult[X]](
           EmptyTuple,
           false,
           exprs,
@@ -532,6 +567,15 @@ type ExprOutputs[T <: Tuple] <: Tuple = T match {
 type ProjResult[X] = X match {
   case TypedExpr[t]  => t
   case NonEmptyTuple => ExprOutputs[X & NonEmptyTuple]
+}
+
+/**
+ * Normalise a projection / GROUP BY lambda return type into a tuple: a single `TypedExpr[_]` becomes a one-element
+ * tuple; a tuple stays as-is. Feeds the [[GroupCoverage]] check uniformly regardless of single-vs-multi form.
+ */
+type NormProj[X] <: Tuple = X match {
+  case NonEmptyTuple => X & Tuple
+  case _             => X *: EmptyTuple
 }
 
 /** Type-level lookup: tuple of column names → tuple of value types. */

--- a/modules/core/src/test/scala/skunk/sharp/NegativeTestsSuite.scala
+++ b/modules/core/src/test/scala/skunk/sharp/NegativeTestsSuite.scala
@@ -323,4 +323,88 @@ class NegativeTestsSuite extends munit.FunSuite {
     """)
     assert(errs.isEmpty, s"expected no errors for named composite unique target; got: ${errs.map(_.message).mkString("\n")}")
   }
+
+  // ---- GROUP BY coverage (GroupCoverage) -----------------------------------------------------
+
+  test("GROUP BY coverage — projection with only aggregates compiles without GROUP BY") {
+    val errs = typeCheckErrors("""
+      import skunk.sharp.dsl.*
+      import NegativeTestsSuite.User
+      val users = Table.of[User]("users")
+      users.select(_ => Pg.countAll).compile
+    """)
+    assert(errs.isEmpty, s"pure-aggregate projection should compile; got: ${errs.map(_.message).mkString("\n")}")
+  }
+
+  test("GROUP BY coverage — bare column in projection with matching GROUP BY compiles") {
+    val errs = typeCheckErrors("""
+      import skunk.sharp.dsl.*
+      import NegativeTestsSuite.User
+      val users = Table.of[User]("users")
+      users.select(u => (u.age, Pg.count(u.id))).groupBy(u => u.age).compile
+    """)
+    assert(errs.isEmpty, s"covered projection should compile; got: ${errs.map(_.message).mkString("\n")}")
+  }
+
+  test("GROUP BY coverage — bare column in projection WITHOUT GROUP BY rejects") {
+    val errs = typeCheckErrors("""
+      import skunk.sharp.dsl.*
+      import NegativeTestsSuite.User
+      val users = Table.of[User]("users")
+      users.select(u => (u.age, Pg.count(u.id))).groupBy(u => u.email).compile
+    """)
+    assert(errs.nonEmpty, "projecting a bare column not in GROUP BY should be a compile error")
+  }
+
+  test("GROUP BY coverage — multi-column GROUP BY covers multi-column projection") {
+    val errs = typeCheckErrors("""
+      import skunk.sharp.dsl.*
+      import NegativeTestsSuite.User
+      val users = Table.of[User]("users")
+      users
+        .select(u => (u.age, u.email, Pg.count(u.id)))
+        .groupBy(u => (u.age, u.email))
+        .compile
+    """)
+    assert(errs.isEmpty, s"multi-col GROUP BY should cover multi-col projection; got: ${errs.map(_.message).mkString("\n")}")
+  }
+
+  test("GROUP BY coverage — partial coverage (GROUP BY misses one projection column) rejects") {
+    val errs = typeCheckErrors("""
+      import skunk.sharp.dsl.*
+      import NegativeTestsSuite.User
+      val users = Table.of[User]("users")
+      users
+        .select(u => (u.age, u.email, Pg.count(u.id)))
+        .groupBy(u => u.age)
+        .compile
+    """)
+    assert(errs.nonEmpty, "GROUP BY that covers only some of the bare columns should fail")
+  }
+
+  test("GROUP BY coverage — aggregates (Pg.count, Pg.sum) skip coverage requirement") {
+    val errs = typeCheckErrors("""
+      import skunk.sharp.dsl.*
+      import NegativeTestsSuite.User
+      val users = Table.of[User]("users")
+      users
+        .select(u => (u.age, Pg.count(u.id), Pg.sum(u.age), Pg.max(u.email)))
+        .groupBy(u => u.age)
+        .compile
+    """)
+    assert(errs.isEmpty, s"aggregates should be free of coverage requirement; got: ${errs.map(_.message).mkString("\n")}")
+  }
+
+  test("GROUP BY coverage — aliased expressions are free of coverage") {
+    val errs = typeCheckErrors("""
+      import skunk.sharp.dsl.*
+      import NegativeTestsSuite.User
+      val users = Table.of[User]("users")
+      users
+        .select(u => (u.age, Pg.count(u.id).as("cnt")))
+        .groupBy(u => u.age)
+        .compile
+    """)
+    assert(errs.isEmpty, s"aliased aggregates should compile; got: ${errs.map(_.message).mkString("\n")}")
+  }
 }

--- a/modules/tests/src/test/scala/skunk/sharp/tests/DslRoundTripSuite.scala
+++ b/modules/tests/src/test/scala/skunk/sharp/tests/DslRoundTripSuite.scala
@@ -23,21 +23,10 @@ class DslRoundTripSuite extends PgFixture {
         val bobId   = UUID.fromString("22222222-2222-2222-2222-222222222222")
         val now     = OffsetDateTime.now()
         for {
-          _ <- users.insert((
-            id = aliceId,
-            email = "alice@example.com",
-            age = 30,
-            created_at = now,
-            deleted_at = None
-          )).compile.run(s)
-          _ <-
-            users.insert((
-              id = bobId,
-              email = "bob@example.com",
-              age = 45,
-              created_at = now,
-              deleted_at = None
-            )).compile.run(s)
+          _ <- users.insert.values(
+            (id = aliceId, email = "alice@example.com", age = 30, created_at = now, deleted_at = Option.empty[OffsetDateTime]),
+            (id = bobId, email = "bob@example.com", age = 45, created_at = now, deleted_at = Option.empty[OffsetDateTime])
+          ).compile.run(s)
           _ <- assertIO(users.select.compile.run(s).map(_.size), 2)
           _ <- assertIO(users.select.where(u => u.age >= 18).compile.run(s).map(_.size), 2)
           _ <- users.update.set(u => u.age := 31).where(u => u.id === aliceId).compile.run(s)
@@ -57,9 +46,11 @@ class DslRoundTripSuite extends PgFixture {
         val c   = UUID.fromString("40000000-0000-0000-0000-000000000003")
         val now = OffsetDateTime.now()
         for {
-          _ <- users.insert((id = a, email = "aaa@x", age = 30, created_at = now, deleted_at = None)).compile.run(s)
-          _ <- users.insert((id = b, email = "bbb@x", age = 10, created_at = now, deleted_at = None)).compile.run(s)
-          _ <- users.insert((id = c, email = "ccc@x", age = 20, created_at = now, deleted_at = None)).compile.run(s)
+          _ <- users.insert.values(
+            (id = a, email = "aaa@x", age = 30, created_at = now, deleted_at = Option.empty[OffsetDateTime]),
+            (id = b, email = "bbb@x", age = 10, created_at = now, deleted_at = Option.empty[OffsetDateTime]),
+            (id = c, email = "ccc@x", age = 20, created_at = now, deleted_at = Option.empty[OffsetDateTime])
+          ).compile.run(s)
           _ <- assertIO(
             users.select.where(u => u.email.like("%@x")).orderBy(u => u.age.asc).apply(u => u.email).compile.run(s),
             List("bbb@x", "ccc@x", "aaa@x")

--- a/modules/tests/src/test/scala/skunk/sharp/tests/GroupBySuite.scala
+++ b/modules/tests/src/test/scala/skunk/sharp/tests/GroupBySuite.scala
@@ -1,6 +1,6 @@
 package skunk.sharp.tests
 
-import cats.syntax.all.*
+import cats.data.NonEmptyList
 import skunk.sharp.dsl.*
 
 import java.time.OffsetDateTime
@@ -18,18 +18,13 @@ class GroupBySuite extends PgFixture {
   test("aggregate count(*) and count(col) return the row count") {
     withContainers { containers =>
       session(containers).use { s =>
-        val rows = List(
-          (email = "g1@x", age = 20, deleted_at = Option.empty[OffsetDateTime]),
-          (email = "g2@x", age = 25, deleted_at = Option.empty[OffsetDateTime]),
-          (email = "g3@x", age = 30, deleted_at = Option.empty[OffsetDateTime])
+        val rows = NonEmptyList.of(
+          (id = UUID.randomUUID, email = "g1@x", age = 20, deleted_at = Option.empty[OffsetDateTime]),
+          (id = UUID.randomUUID, email = "g2@x", age = 25, deleted_at = Option.empty[OffsetDateTime]),
+          (id = UUID.randomUUID, email = "g3@x", age = 30, deleted_at = Option.empty[OffsetDateTime])
         )
         for {
-          _ <- rows.traverse_(r =>
-            users
-              .insert((id = UUID.randomUUID, email = r.email, age = r.age, deleted_at = r.deleted_at))
-              .compile
-              .run(s)
-          )
+          _     <- users.insert.values(rows).compile.run(s)
           total <- users.select(_ => Pg.countAll).compile.unique(s)
           _ = assert(total >= 3L, s"expected at least 3 rows, got $total")
           _ <- assertIO(users.select(u => Pg.count(u.age)).compile.unique(s), total)
@@ -41,18 +36,13 @@ class GroupBySuite extends PgFixture {
   test("GROUP BY age with count + having") {
     withContainers { containers =>
       session(containers).use { s =>
-        val seed = List(
-          (email = "gb1@x", age = 21),
-          (email = "gb2@x", age = 21),
-          (email = "gb3@x", age = 22)
+        val seed = NonEmptyList.of(
+          (id = UUID.randomUUID, email = "gb1@x", age = 21, deleted_at = Option.empty[OffsetDateTime]),
+          (id = UUID.randomUUID, email = "gb2@x", age = 21, deleted_at = Option.empty[OffsetDateTime]),
+          (id = UUID.randomUUID, email = "gb3@x", age = 22, deleted_at = Option.empty[OffsetDateTime])
         )
         for {
-          _ <- seed.traverse_(r =>
-            users
-              .insert((id = UUID.randomUUID, email = r.email, age = r.age, deleted_at = None))
-              .compile
-              .run(s)
-          )
+          _    <- users.insert.values(seed).compile.run(s)
           rows <- users
             .select(u => (u.age, Pg.count(u.id)))
             .groupBy(u => u.age)
@@ -71,12 +61,10 @@ class GroupBySuite extends PgFixture {
     withContainers { containers =>
       session(containers).use { s =>
         for {
-          _ <- users
-            .insert((id = UUID.randomUUID, email = "m1@x", age = 10, deleted_at = None))
-            .compile.run(s)
-          _ <- users
-            .insert((id = UUID.randomUUID, email = "m2@x", age = 30, deleted_at = None))
-            .compile.run(s)
+          _ <- users.insert.values(
+            (id = UUID.randomUUID, email = "m1@x", age = 10, deleted_at = Option.empty[OffsetDateTime]),
+            (id = UUID.randomUUID, email = "m2@x", age = 30, deleted_at = Option.empty[OffsetDateTime])
+          ).compile.run(s)
           stats <- users
             .select(u => (Pg.sum(u.age), Pg.avg(u.age), Pg.min(u.age), Pg.max(u.age)))
             .compile
@@ -105,18 +93,13 @@ class GroupBySuite extends PgFixture {
   test("aliased column + aliased aggregate with GROUP BY: SELECT age AS a, count(id) AS n") {
     withContainers { containers =>
       session(containers).use { s =>
-        val seed = List(
-          (email = "al1@x", age = 41),
-          (email = "al2@x", age = 41),
-          (email = "al3@x", age = 42)
+        val seed = NonEmptyList.of(
+          (id = UUID.randomUUID, email = "al1@x", age = 41, deleted_at = Option.empty[OffsetDateTime]),
+          (id = UUID.randomUUID, email = "al2@x", age = 41, deleted_at = Option.empty[OffsetDateTime]),
+          (id = UUID.randomUUID, email = "al3@x", age = 42, deleted_at = Option.empty[OffsetDateTime])
         )
         for {
-          _ <- seed.traverse_(r =>
-            users
-              .insert((id = UUID.randomUUID, email = r.email, age = r.age, deleted_at = None))
-              .compile
-              .run(s)
-          )
+          _    <- users.insert.values(seed).compile.run(s)
           rows <- users
             .select(u => (u.age.as("a"), Pg.count(u.id).as("n")))
             .groupBy(u => u.age)
@@ -135,9 +118,11 @@ class GroupBySuite extends PgFixture {
     withContainers { containers =>
       session(containers).use { s =>
         for {
-          _ <- users.insert((id = UUID.randomUUID, email = "cd1@x", age = 99, deleted_at = None)).compile.run(s)
-          _ <- users.insert((id = UUID.randomUUID, email = "cd2@x", age = 99, deleted_at = None)).compile.run(s)
-          _ <- users.insert((id = UUID.randomUUID, email = "cd3@x", age = 100, deleted_at = None)).compile.run(s)
+          _ <- users.insert.values(
+            (id = UUID.randomUUID, email = "cd1@x", age = 99, deleted_at = Option.empty[OffsetDateTime]),
+            (id = UUID.randomUUID, email = "cd2@x", age = 99, deleted_at = Option.empty[OffsetDateTime]),
+            (id = UUID.randomUUID, email = "cd3@x", age = 100, deleted_at = Option.empty[OffsetDateTime])
+          ).compile.run(s)
           n <- users.select(u => Pg.countDistinct(u.age)).where(u => u.age >= 99).compile.unique(s)
           _ = assert(n >= 2L, s"distinct ages ≥ 99 should be ≥ 2, got $n")
         } yield ()
@@ -150,8 +135,10 @@ class GroupBySuite extends PgFixture {
       session(containers).use { s =>
         val bucket = 77
         for {
-          _ <- users.insert((id = UUID.randomUUID, email = "sa1@x", age = bucket, deleted_at = None)).compile.run(s)
-          _ <- users.insert((id = UUID.randomUUID, email = "sa2@x", age = bucket, deleted_at = None)).compile.run(s)
+          _ <- users.insert.values(
+            (id = UUID.randomUUID, email = "sa1@x", age = bucket, deleted_at = Option.empty[OffsetDateTime]),
+            (id = UUID.randomUUID, email = "sa2@x", age = bucket, deleted_at = Option.empty[OffsetDateTime])
+          ).compile.run(s)
           concat <- users.select(u => Pg.stringAgg(u.email, ", ")).where(u => u.age === bucket).compile.unique(s)
           _ = assert(concat.contains("sa1@x") && concat.contains("sa2@x"), s"got '$concat'")
           _ = assert(concat.contains(", "), s"separator missing: '$concat'")
@@ -165,8 +152,10 @@ class GroupBySuite extends PgFixture {
       session(containers).use { s =>
         val bucket = 55
         for {
-          _ <- users.insert((id = UUID.randomUUID, email = "ba1@x", age = bucket, deleted_at = None)).compile.run(s)
-          _ <- users.insert((id = UUID.randomUUID, email = "ba2@x", age = bucket, deleted_at = None)).compile.run(s)
+          _ <- users.insert.values(
+            (id = UUID.randomUUID, email = "ba1@x", age = bucket, deleted_at = Option.empty[OffsetDateTime]),
+            (id = UUID.randomUUID, email = "ba2@x", age = bucket, deleted_at = Option.empty[OffsetDateTime])
+          ).compile.run(s)
           // All rows in this bucket have age >= 10 — boolAnd should be true.
           _ <- assertIO(
             users

--- a/modules/tests/src/test/scala/skunk/sharp/tests/JoinSuite.scala
+++ b/modules/tests/src/test/scala/skunk/sharp/tests/JoinSuite.scala
@@ -74,9 +74,11 @@ class JoinSuite extends PgFixture {
           _ <- users
             .insert((id = uid, email = "many@x", age = 28, deleted_at = Option.empty[OffsetDateTime]))
             .compile.run(s)
-          _ <- posts.insert((id = UUID.randomUUID, user_id = uid, title = "a")).compile.run(s)
-          _ <- posts.insert((id = UUID.randomUUID, user_id = uid, title = "b")).compile.run(s)
-          _ <- posts.insert((id = UUID.randomUUID, user_id = uid, title = "c")).compile.run(s)
+          _ <- posts.insert.values(
+            (id = UUID.randomUUID, user_id = uid, title = "a"),
+            (id = UUID.randomUUID, user_id = uid, title = "b"),
+            (id = UUID.randomUUID, user_id = uid, title = "c")
+          ).compile.run(s)
           _ <- assertIO(
             users
               .leftJoin(posts)
@@ -103,8 +105,10 @@ class JoinSuite extends PgFixture {
             .insert((id = uid, email = "chain@x", age = 33, deleted_at = Option.empty[OffsetDateTime]))
             .compile.run(s)
           _ <- posts.insert((id = pid, user_id = uid, title = "chain-post")).compile.run(s)
-          _ <- tags.insert((id = UUID.randomUUID, post_id = pid, name = "alpha")).compile.run(s)
-          _ <- tags.insert((id = UUID.randomUUID, post_id = pid, name = "beta")).compile.run(s)
+          _ <- tags.insert.values(
+            (id = UUID.randomUUID, post_id = pid, name = "alpha"),
+            (id = UUID.randomUUID, post_id = pid, name = "beta")
+          ).compile.run(s)
           _ <- assertIO(
             users
               .innerJoin(posts).on(r => r.users.id ==== r.posts.user_id)

--- a/modules/tests/src/test/scala/skunk/sharp/tests/JsonbSuite.scala
+++ b/modules/tests/src/test/scala/skunk/sharp/tests/JsonbSuite.scala
@@ -49,8 +49,10 @@ class JsonbSuite extends PgFixture {
         val inactive = CirceJson.obj("status" -> CirceJson.fromString("inactive"), "n" -> CirceJson.fromInt(2))
         val probe    = CirceJson.obj("status" -> CirceJson.fromString("active"))
         for {
-          _ <- docs.insert((id = matches, body = Jsonb(active))).compile.run(s)
-          _ <- docs.insert((id = misses, body = Jsonb(inactive))).compile.run(s)
+          _ <- docs.insert.values(
+            (id = matches, body = Jsonb(active)),
+            (id = misses, body = Jsonb(inactive))
+          ).compile.run(s)
           _ <- assertIO(
             docs
               .select(d => d.id)
@@ -71,8 +73,10 @@ class JsonbSuite extends PgFixture {
         val withEmail    = CirceJson.obj("email" -> CirceJson.fromString("a@x"), "tag" -> CirceJson.fromString("t"))
         val withoutEmail = CirceJson.obj("phone" -> CirceJson.fromString("555"))
         for {
-          _ <- docs.insert((id = a, body = Jsonb(withEmail))).compile.run(s)
-          _ <- docs.insert((id = b, body = Jsonb(withoutEmail))).compile.run(s)
+          _ <- docs.insert.values(
+            (id = a, body = Jsonb(withEmail)),
+            (id = b, body = Jsonb(withoutEmail))
+          ).compile.run(s)
           _ <- assertIO(docs.select(d => d.id).where(d => d.body.hasKey("email")).compile.run(s).map(_.toSet), Set(a))
           _ <- assertIO(
             docs.select(d => d.id).where(d => d.body.hasAnyKey("email", "phone")).compile.run(s).map(_.toSet),
@@ -129,8 +133,10 @@ class JsonbSuite extends PgFixture {
         val idA   = UUID.randomUUID
         val idB   = UUID.randomUUID
         for {
-          _ <- pdocs.insert((id = idA, body = Jsonb(alice))).compile.run(s)
-          _ <- pdocs.insert((id = idB, body = Jsonb(bob))).compile.run(s)
+          _ <- pdocs.insert.values(
+            (id = idA, body = Jsonb(alice)),
+            (id = idB, body = Jsonb(bob))
+          ).compile.run(s)
 
           // Filter via .getText — jsonb ->> 'name' = 'alice'. The IO returns `List[Jsonb[Profile]]`; opaque-type
           // direction (`Jsonb[A] <: A`) means we need to widen explicitly to match the expected `List[Profile]`.

--- a/modules/tests/src/test/scala/skunk/sharp/tests/MultiSchemaSuite.scala
+++ b/modules/tests/src/test/scala/skunk/sharp/tests/MultiSchemaSuite.scala
@@ -65,12 +65,10 @@ class MultiSchemaSuite extends PgFixture {
           _ <- products
             .insert((id = pid, name = Varchar[256]("gadget"), price = Numeric[10, 2](BigDecimal("1.00"))))
             .compile.run(s)
-          _ <- events
-            .insert((action = Varchar[64]("view"), product_id = Some(pid)))
-            .compile.run(s)
-          _ <- events
-            .insert((action = Varchar[64]("heartbeat"), product_id = Option.empty[UUID]))
-            .compile.run(s)
+          _ <- events.insert.values(
+            (action = Varchar[64]("view"), product_id = Some(pid)),
+            (action = Varchar[64]("heartbeat"), product_id = Option.empty[UUID])
+          ).compile.run(s)
           // LEFT JOIN: all events back, with product name when the event has a product_id.
           rows <- events
             .leftJoin(products)

--- a/modules/tests/src/test/scala/skunk/sharp/tests/SubquerySuite.scala
+++ b/modules/tests/src/test/scala/skunk/sharp/tests/SubquerySuite.scala
@@ -22,12 +22,10 @@ class SubquerySuite extends PgFixture {
         val uidA = UUID.randomUUID
         val uidB = UUID.randomUUID
         for {
-          _ <- users
-            .insert((id = uidA, email = "has-posts@x", age = 30, deleted_at = Option.empty[OffsetDateTime]))
-            .compile.run(s)
-          _ <- users
-            .insert((id = uidB, email = "no-posts@x", age = 31, deleted_at = Option.empty[OffsetDateTime]))
-            .compile.run(s)
+          _ <- users.insert.values(
+            (id = uidA, email = "has-posts@x", age = 30, deleted_at = Option.empty[OffsetDateTime]),
+            (id = uidB, email = "no-posts@x", age = 31, deleted_at = Option.empty[OffsetDateTime])
+          ).compile.run(s)
           _ <- posts.insert((id = UUID.randomUUID, user_id = uidA, title = "hello")).compile.run(s)
           _ <- assertIO(
             users
@@ -47,12 +45,10 @@ class SubquerySuite extends PgFixture {
         val uidWith = UUID.randomUUID
         val uidWO   = UUID.randomUUID
         for {
-          _ <- users
-            .insert((id = uidWith, email = "exw@x", age = 40, deleted_at = Option.empty[OffsetDateTime]))
-            .compile.run(s)
-          _ <- users
-            .insert((id = uidWO, email = "exo@x", age = 41, deleted_at = Option.empty[OffsetDateTime]))
-            .compile.run(s)
+          _ <- users.insert.values(
+            (id = uidWith, email = "exw@x", age = 40, deleted_at = Option.empty[OffsetDateTime]),
+            (id = uidWO, email = "exo@x", age = 41, deleted_at = Option.empty[OffsetDateTime])
+          ).compile.run(s)
           _ <- posts.insert((id = UUID.randomUUID, user_id = uidWith, title = "ex")).compile.run(s)
           // Inner query built inside the outer lambda — references u.id (an outer column) by closure. The
           // outer alias makes u.id render as "u"."id" so Postgres correlates it to the outer source.
@@ -75,12 +71,10 @@ class SubquerySuite extends PgFixture {
         val uidWith = UUID.randomUUID
         val uidWO   = UUID.randomUUID
         for {
-          _ <- users
-            .insert((id = uidWith, email = "nex-with@x", age = 50, deleted_at = Option.empty[OffsetDateTime]))
-            .compile.run(s)
-          _ <- users
-            .insert((id = uidWO, email = "nex-without@x", age = 51, deleted_at = Option.empty[OffsetDateTime]))
-            .compile.run(s)
+          _ <- users.insert.values(
+            (id = uidWith, email = "nex-with@x", age = 50, deleted_at = Option.empty[OffsetDateTime]),
+            (id = uidWO, email = "nex-without@x", age = 51, deleted_at = Option.empty[OffsetDateTime])
+          ).compile.run(s)
           _ <- posts.insert((id = UUID.randomUUID, user_id = uidWith, title = "nex")).compile.run(s)
           _ <- assertIO(
             users
@@ -106,8 +100,10 @@ class SubquerySuite extends PgFixture {
           _ <- users
             .insert((id = uid, email = "scalar@x", age = 22, deleted_at = Option.empty[OffsetDateTime]))
             .compile.run(s)
-          _ <- posts.insert((id = UUID.randomUUID, user_id = uid, title = "a")).compile.run(s)
-          _ <- posts.insert((id = UUID.randomUUID, user_id = uid, title = "b")).compile.run(s)
+          _ <- posts.insert.values(
+            (id = UUID.randomUUID, user_id = uid, title = "a"),
+            (id = UUID.randomUUID, user_id = uid, title = "b")
+          ).compile.run(s)
           _ <- assertIO(
             users
               .alias("u")


### PR DESCRIPTION
Closes #6.

## Summary

Move the GROUP BY / projection alignment check from Postgres runtime error to Scala compile-time. Every bare column in the projection must appear in the GROUP BY (or GROUP BY must be empty); aggregates, literals, aliased expressions are free.

    // ✓ compiles
    users.select(u => (u.age, Pg.count(u.id))).groupBy(u => u.age).compile

    // ✗ compile error — \`u.email\` projected but not grouped
    users.select(u => (u.age, u.email, Pg.count(u.id))).groupBy(u => u.age).compile

## Design

\`ProjectedSelect[Ss, Proj, Groups, Row]\` gains two phantom params carrying the projection and the accumulated GROUP BY expressions. \`.compile\` requires \`GroupCoverage[Proj, Groups]\` evidence.

**Typeclass-based** rather than match-type-based because \`TypedColumn <: TypedExpr\` breaks Scala 3's match-type disjointness requirement (Scala can't prove a \`TypedExpr[T]\` is *not* a \`TypedColumn\`, so the usual \`case TypedColumn ... case TypedExpr ...\` pattern refuses to reduce). \`ElemCoverage\` uses \`IsTypedCol\` + \`NotGiven\` — standard implicit-search subtype rules sidestep the issue.

## Scope

Only the \`.select(f).groupBy(g).compile\` flow is checked. The reverse \`.groupBy(g).select(f)\` path passes through \`SelectBuilder\` untouched and stays runtime-checked — documented.

## Test plan

- [x] \`sbt core/test\` — 154 tests pass, including 7 new compile-time tests (rejection for missing coverage, acceptance for aggregates / aliased expressions / composite GROUP BY / pure-aggregate projection)
- [x] \`sbt iron/test circe/test\` — 14 tests pass
- [x] \`sbt tests/test\` — 74 integration tests pass
- [x] \`SBT_TPOLECAT_CI=1 sbt clean compile\` — clean under fatal warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)