### PR TITLE
skunk-sharp-refined: eu.timepit.refined companion module

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -21,11 +21,12 @@ val catsEffectV      = "3.7.0"
 val munitV           = "1.2.4"
 val munitCatsEffectV = "2.1.0"
 val ironV            = "3.0.2"
+val refinedV         = "0.11.3"
 val testcontainersV  = "0.44.1"
 val dumboV           = "0.9.0-SNAPSHOT"
 val otel4sV          = "0.16.0"
 
-lazy val root = tlCrossRootProject.aggregate(core, iron, circe, tests)
+lazy val root = tlCrossRootProject.aggregate(core, iron, refined, circe, tests)
 
 lazy val core = project
   .in(file("modules/core"))
@@ -51,6 +52,18 @@ lazy val iron = project
     )
   )
 
+lazy val refined = project
+  .in(file("modules/refined"))
+  .dependsOn(core)
+  .settings(
+    name := "skunk-sharp-refined",
+    libraryDependencies ++= Seq(
+      "eu.timepit"    %% "refined"           % refinedV,
+      "org.scalameta" %% "munit"             % munitV           % Test,
+      "org.typelevel" %% "munit-cats-effect" % munitCatsEffectV % Test
+    )
+  )
+
 lazy val circe = project
   .in(file("modules/circe"))
   .dependsOn(core)
@@ -66,7 +79,7 @@ lazy val circe = project
 
 lazy val tests = project
   .in(file("modules/tests"))
-  .dependsOn(core, iron, circe)
+  .dependsOn(core, iron, refined, circe)
   .enablePlugins(NoPublishPlugin)
   .settings(
     name := "skunk-sharp-tests",

--- a/modules/refined/src/main/scala/skunk/sharp/refined/package.scala
+++ b/modules/refined/src/main/scala/skunk/sharp/refined/package.scala
@@ -1,0 +1,47 @@
+package skunk.sharp.refined
+
+import eu.timepit.refined.api.Refined
+import eu.timepit.refined.collection.{MaxSize, Size}
+import eu.timepit.refined.generic.Equal
+import skunk.Codec
+import skunk.sharp.pg.PgTypeFor
+import skunk.sharp.pg.tags.{Bpchar, Varchar}
+
+/**
+ * Integration with [refined](https://github.com/fthomas/refined).
+ *
+ * Parallel to the Iron module ([[skunk.sharp.iron]]) — same two-level support:
+ *
+ *   - The **fallback** `refinedPgTypeFor[A, C]` reuses the base `PgTypeFor[A]` — the constraint is Scala-only, the
+ *     codec and Postgres type mirror the underlying unrefined type. This kicks in for constraints that have no DB
+ *     counterpart (`Positive`, `MatchesRegex[…]`, `Greater[N]`, etc.).
+ *   - **Bridges** from common refined constraints to skunk-sharp's tag types in core (see `skunk.sharp.pg.tags`).
+ *     Example: `String Refined MaxSize[256]` picks the `varchar(256)` codec by routing to `PgTypeFor[Varchar[256]]`.
+ *     Bridges are more specific than the fallback, so given-resolution prefers them automatically.
+ *
+ * Decoding does NOT re-validate the refined constraint — we trust what Postgres returns. Wrap with `Codec.emap` +
+ * `refineV` if you want strict validation on decode.
+ */
+given refinedPgTypeFor[A, C](using base: PgTypeFor[A]): PgTypeFor[A Refined C] =
+  PgTypeFor.instance(
+    base.codec.imap[A Refined C](Refined.unsafeApply[A, C](_))(_.value)
+  )
+
+/** `String Refined MaxSize[N]` ⇒ `varchar(n)`. More specific than the fallback; implicit resolution prefers it. */
+given varcharFromMaxSize[N <: Int](using pf: PgTypeFor[Varchar[N]]): PgTypeFor[String Refined MaxSize[N]] =
+  PgTypeFor.instance(pf.codec.asInstanceOf[Codec[String Refined MaxSize[N]]])
+
+/** `String Refined Size[Equal[N]]` ⇒ `bpchar(n)`. Mirrors Iron's `FixedLength[N]` bridge. */
+given bpcharFromSizeEqual[N <: Int](using pf: PgTypeFor[Bpchar[N]])
+  : PgTypeFor[String Refined Size[Equal[N]]] =
+  PgTypeFor.instance(pf.codec.asInstanceOf[Codec[String Refined Size[Equal[N]]]])
+
+object syntax {
+
+  /**
+   * Given a refined `Codec[A Refined C]`, downcast to a `Codec[A]` for interop with legacy code that needs the plain
+   * base type.
+   */
+  extension [A, C](c: Codec[A Refined C]) def toBaseCodec: Codec[A] = c.asInstanceOf[Codec[A]]
+
+}

--- a/modules/refined/src/test/scala/skunk/sharp/refined/RefinedSuite.scala
+++ b/modules/refined/src/test/scala/skunk/sharp/refined/RefinedSuite.scala
@@ -1,0 +1,76 @@
+package skunk.sharp.refined
+
+import eu.timepit.refined.api.Refined
+import eu.timepit.refined.collection.{MaxSize, Size}
+import eu.timepit.refined.generic.Equal
+import eu.timepit.refined.numeric.Positive
+import eu.timepit.refined.string.MatchesRegex
+import skunk.data.Type
+import skunk.sharp.*
+
+object RefinedSuite {
+  type Email = String Refined MatchesRegex["^[^@]+@[^@]+$"]
+  type Age   = Int Refined Positive
+
+  // Bridge cases: refined constraints that have a DB-type counterpart.
+  type Name   = String Refined MaxSize[64]
+  type Postal = String Refined Size[Equal[5]]
+}
+
+class RefinedSuite extends munit.FunSuite {
+  import RefinedSuite.*
+
+  // Refined's `Refined[T, P]` is an unbounded opaque alias (`opaque type Refined[T, P] = T`), which defeats Scala 3
+  // match-type disjointness in `ColumnsFromMirror` — so `Table.of[T]` can't derive columns for case classes
+  // containing refined fields. Users with refined should use the column-by-column `Table.builder` path, which picks
+  // the right codec via the `PgTypeFor[Refined[A, P]]` givens defined in this module. (Tracked as a core follow-up:
+  // make `ColumnsFromMirror` dispatch via typeclasses that tolerate unbounded opaque types.)
+
+  test("fallback: refined refinement keeps the underlying type's codec") {
+    val people = Table
+      .builder("people")
+      .column[Int]("id")
+      .column[Email]("email")
+      .column[Age]("age")
+      .build
+
+    val cols = people.columns.toList.asInstanceOf[List[Column[?, ?, ?, ?]]]
+    assertEquals(cols.map(_.name), List("id", "email", "age"))
+    assertEquals(cols.map(_.tpe), List(Type.int4, Type.text, Type.int4))
+  }
+
+  test("refined bridge: String Refined MaxSize[N] picks varchar(n)") {
+    val parties = Table
+      .builder("parties")
+      .column[Name]("name")
+      .build
+
+    val cols = parties.columns.toList.asInstanceOf[List[Column[?, ?, ?, ?]]]
+    val name = cols.find(_.name == "name").get
+    assertEquals(name.tpe, Type.varchar(64))
+  }
+
+  test("refined bridge: String Refined Size[Equal[N]] picks bpchar(n)") {
+    val parties = Table
+      .builder("parties")
+      .column[Postal]("postalCode")
+      .build
+
+    val cols   = parties.columns.toList.asInstanceOf[List[Column[?, ?, ?, ?]]]
+    val postal = cols.find(_.name == "postalCode").get
+    assertEquals(postal.tpe, Type.bpchar(5))
+  }
+
+  test("refined columns participate in the DSL (ColumnsView selector access)") {
+    val people = Table
+      .builder("people")
+      .column[Int]("id")
+      .column[Email]("email")
+      .column[Age]("age")
+      .build
+
+    val cv = ColumnsView(people.columns)
+    val emailCol: TypedColumn[Email, false, "email"] = cv.email
+    assertEquals(emailCol.name, "email")
+  }
+}


### PR DESCRIPTION
Closes #11.

## Summary

Ships a new module \`skunk-sharp-refined\` that mirrors \`skunk-sharp-iron\` for users on the refined stack.

Two levels of \`PgTypeFor\` support:

- **Fallback** \`refinedPgTypeFor[A, C]\` reuses the base \`PgTypeFor[A]\` — any refined constraint without a DB counterpart (e.g. \`Positive\`, \`MatchesRegex[…]\`) uses the underlying type's codec.
- **Bridges** route common refined constraints to core tag codecs:
  - \`String Refined MaxSize[N]\` → \`Varchar[N]\` (\`varcharFromMaxSize\`)
  - \`String Refined Size[Equal[N]]\` → \`Bpchar[N]\` (\`bpcharFromSizeEqual\`)

## Known limitation (filed as #54)

refined 0.11.3 defines \`Refined\` as \`infix opaque type Refined[T, P] = T\` — an **unbounded** opaque alias, unlike iron's \`opaque type IronType[A, T] <: A = A\`. The lack of a \`<: T\` upper bound breaks Scala 3 match-type disjointness in \`ColumnsFromMirror\` — \`Table.of[T]\` can't derive columns for case classes containing \`Refined\` fields.

Users with refined should use the column-by-column \`Table.builder.column[T]\` path; \`PgTypeFor[Refined[A, P]]\` resolution works fine there. The test suite demonstrates this pattern. Fix will replace match-type dispatch with typeclass dispatch in a follow-up (#54).

## Test plan

- [x] \`sbt refined/test\` — 4 tests pass (fallback + \`varchar\` bridge + \`bpchar\` bridge + ColumnsView selector round-trip)
- [x] \`sbt core/test iron/test circe/test\` — 175 other unit tests unaffected
- [x] \`SBT_TPOLECAT_CI=1 sbt clean compile\` — clean under fatal warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)