### PR TITLE
Fix #54: Mirror derivation tolerates unbounded opaque types

### DIFF
--- a/modules/core/src/main/scala/skunk/sharp/Table.scala
+++ b/modules/core/src/main/scala/skunk/sharp/Table.scala
@@ -1,6 +1,6 @@
 package skunk.sharp
 
-import skunk.sharp.internal.{deriveColumns, ColumnsFromMirror, CompileChecks}
+import skunk.sharp.internal.{CompileChecks, DeriveColumns}
 
 import scala.annotation.unused
 import scala.compiletime.constValueTuple
@@ -197,15 +197,9 @@ object Table {
   final class OfCont[T <: Product] {
 
     inline def apply[Name <: String & Singleton](tableName: Name)(using
-      m: Mirror.ProductOf[T]
-    ): Table[ColumnsFromMirror[m.MirroredElemLabels, m.MirroredElemTypes], Name] = {
-      val cols = deriveColumns[m.MirroredElemLabels, m.MirroredElemTypes]
-      Table[ColumnsFromMirror[m.MirroredElemLabels, m.MirroredElemTypes], Name](
-        tableName,
-        None,
-        cols.asInstanceOf[ColumnsFromMirror[m.MirroredElemLabels, m.MirroredElemTypes]]
-      )
-    }
+      m: Mirror.ProductOf[T],
+      dc: DeriveColumns[m.MirroredElemLabels, m.MirroredElemTypes]
+    ): Table[dc.Out, Name] = Table[dc.Out, Name](tableName, None, dc.value)
 
   }
 

--- a/modules/core/src/main/scala/skunk/sharp/View.scala
+++ b/modules/core/src/main/scala/skunk/sharp/View.scala
@@ -1,7 +1,7 @@
 package skunk.sharp
 
 import skunk.Codec
-import skunk.sharp.internal.{deriveColumns, ColumnsFromMirror}
+import skunk.sharp.internal.DeriveColumns
 import skunk.sharp.pg.PgTypes
 
 import scala.deriving.Mirror
@@ -59,15 +59,9 @@ object View {
   final class OfCont[T <: Product] {
 
     inline def apply[Name <: String & Singleton](viewName: Name)(using
-      m: Mirror.ProductOf[T]
-    ): View[ColumnsFromMirror[m.MirroredElemLabels, m.MirroredElemTypes], Name] = {
-      val cols = deriveColumns[m.MirroredElemLabels, m.MirroredElemTypes]
-      View[ColumnsFromMirror[m.MirroredElemLabels, m.MirroredElemTypes], Name](
-        viewName,
-        None,
-        cols.asInstanceOf[ColumnsFromMirror[m.MirroredElemLabels, m.MirroredElemTypes]]
-      )
-    }
+      m: Mirror.ProductOf[T],
+      dc: DeriveColumns[m.MirroredElemLabels, m.MirroredElemTypes]
+    ): View[dc.Out, Name] = View[dc.Out, Name](viewName, None, dc.value)
 
   }
 

--- a/modules/core/src/main/scala/skunk/sharp/internal/Derive.scala
+++ b/modules/core/src/main/scala/skunk/sharp/internal/Derive.scala
@@ -3,60 +3,90 @@ package skunk.sharp.internal
 import skunk.sharp.Column
 import skunk.sharp.pg.{PgTypeFor, PgTypes}
 
-import scala.compiletime.{constValue, erasedValue, summonInline}
+import scala.util.NotGiven
 
 /**
- * Map a `Mirror.ProductOf[T]`'s label/type tuples to the type-level tuple of [[skunk.sharp.Column]]s.
+ * Typeclass dispatch for deriving column tuples from a `Mirror.ProductOf[T]`'s `(Labels, Types)` pair.
  *
- * Option-wrapped fields become nullable columns; everything else is non-null. The resulting columns carry an empty
- * `Attrs` tuple — defaults / primary / unique are declared explicitly via `withDefault("name")` /
- * `withPrimary("name")` / `withUnique("name")` on the resulting table.
+ * Why a typeclass instead of a match type? The natural match-type implementation dispatches on `Option[t]` head vs.
+ * non-`Option` head, and Scala 3 requires the non-`Option` branch's scrutinee to be **provably disjoint** from
+ * `Option`. That works for concrete types (`String`, `Int`), and for opaque subtypes with an explicit upper bound
+ * (iron's `opaque type IronType[A, T] <: A = A` — `IronType[String, C]` is provably `<: String`, disjoint from
+ * `Option`). It **fails** for unbounded opaque aliases like refined's `opaque type Refined[T, P] = T` (no upper bound
+ * visible outside the defining scope — Scala can't prove `Refined[String, C]` is not an `Option`, reduction stalls).
+ *
+ * Typeclass resolution uses `<:<` directly, which CAN see through opaque types correctly. `NotGiven[T <:< Option[?]]`
+ * fires for any `T` not provably an `Option`, which covers unbounded opaques, concrete classes, iron types, and so on.
+ * The four instances below form an induction over the label/type tuples.
  */
-type ColumnsFromMirror[Labels <: Tuple, Types <: Tuple] <: Tuple = (Labels, Types) match {
-  case (EmptyTuple, EmptyTuple)   => EmptyTuple
-  case (l *: lt, Option[t] *: tt) =>
-    Column[Option[t], l & String & Singleton, true, EmptyTuple] *: ColumnsFromMirror[lt, tt]
-  case (l *: lt, t *: tt) =>
-    Column[t, l & String & Singleton, false, EmptyTuple] *: ColumnsFromMirror[lt, tt]
+sealed trait DeriveColumns[Labels <: Tuple, Types <: Tuple] {
+  type Out <: Tuple
+  def value: Out
 }
 
-/**
- * Runtime counterpart to [[ColumnsFromMirror]]: builds the tuple of [[Column]] values by summoning a [[PgTypeFor]] for
- * each field type. The column's skunk `Type` is read from the codec (`codec.types.head`) so no separate type registry
- * is needed.
- */
-inline def deriveColumns[Labels <: Tuple, Types <: Tuple]: Tuple =
-  inline erasedValue[Labels] match {
-    case _: EmptyTuple =>
-      EmptyTuple
-    case _: (l *: ls) =>
-      inline erasedValue[Types] match {
-        case _: (Option[t] *: ts) =>
-          val pf    = summonInline[PgTypeFor[t]]
-          val name  = constValue[l].asInstanceOf[String & Singleton]
-          val codec = pf.codec.opt
-          Column(
-            name = name,
-            tpe = PgTypes.typeOf(pf.codec),
-            codec = codec,
-            isNullable = true,
-            hasDefault = false,
-            isPrimary = false,
-            isUnique = false,
-            uniqueGroups = Set.empty[String]
-          ) *: deriveColumns[ls, ts]
-        case _: (t *: ts) =>
-          val pf   = summonInline[PgTypeFor[t]]
-          val name = constValue[l].asInstanceOf[String & Singleton]
-          Column(
-            name = name,
-            tpe = PgTypes.typeOf(pf.codec),
-            codec = pf.codec,
-            isNullable = false,
-            hasDefault = false,
-            isPrimary = false,
-            isUnique = false,
-            uniqueGroups = Set.empty[String]
-          ) *: deriveColumns[ls, ts]
-      }
+object DeriveColumns {
+
+  type Aux[Labels <: Tuple, Types <: Tuple, Out0 <: Tuple] = DeriveColumns[Labels, Types] { type Out = Out0 }
+
+  given empty: DeriveColumns.Aux[EmptyTuple, EmptyTuple, EmptyTuple] = new DeriveColumns[EmptyTuple, EmptyTuple] {
+    type Out = EmptyTuple
+    def value: EmptyTuple = EmptyTuple
   }
+
+  /**
+   * Head element is `Option[T]` → the column is nullable, carries `Option[T]` at the Scala level, codec wrapped with
+   * `.opt`. Higher priority than [[nonOptionCase]] because its bound on the head is more specific.
+   */
+  given optionCase[L <: String & Singleton, T, Ls <: Tuple, Ts <: Tuple, Rest <: Tuple](using
+    label: ValueOf[L],
+    pf: PgTypeFor[T],
+    rest: DeriveColumns.Aux[Ls, Ts, Rest]
+  ): DeriveColumns.Aux[L *: Ls, Option[T] *: Ts, Column[Option[T], L, true, EmptyTuple] *: Rest] =
+    new DeriveColumns[L *: Ls, Option[T] *: Ts] {
+      type Out = Column[Option[T], L, true, EmptyTuple] *: Rest
+
+      def value: Out = {
+        val col = Column[Option[T], L, true, EmptyTuple](
+          name = label.value,
+          tpe = PgTypes.typeOf(pf.codec),
+          codec = pf.codec.opt,
+          isNullable = true,
+          hasDefault = false,
+          isPrimary = false,
+          isUnique = false,
+          uniqueGroups = Set.empty
+        )
+        (col *: rest.value).asInstanceOf[Out]
+      }
+    }
+
+  /**
+   * Head element is *not* `Option[_]` — non-nullable column. `NotGiven[T <:< Option[?]]` guards resolution. Unbounded
+   * opaque types pass this guard (no `<:<` exists), concrete non-Option classes pass, iron's subtype-bounded opaque
+   * types pass.
+   */
+  given nonOptionCase[L <: String & Singleton, T, Ls <: Tuple, Ts <: Tuple, Rest <: Tuple](using
+    label: ValueOf[L],
+    pf: PgTypeFor[T],
+    notOption: NotGiven[T <:< Option[?]],
+    rest: DeriveColumns.Aux[Ls, Ts, Rest]
+  ): DeriveColumns.Aux[L *: Ls, T *: Ts, Column[T, L, false, EmptyTuple] *: Rest] =
+    new DeriveColumns[L *: Ls, T *: Ts] {
+      type Out = Column[T, L, false, EmptyTuple] *: Rest
+
+      def value: Out = {
+        val col = Column[T, L, false, EmptyTuple](
+          name = label.value,
+          tpe = PgTypes.typeOf(pf.codec),
+          codec = pf.codec,
+          isNullable = false,
+          hasDefault = false,
+          isPrimary = false,
+          isUnique = false,
+          uniqueGroups = Set.empty
+        )
+        (col *: rest.value).asInstanceOf[Out]
+      }
+    }
+
+}

--- a/modules/core/src/test/scala/skunk/sharp/TableOfSuite.scala
+++ b/modules/core/src/test/scala/skunk/sharp/TableOfSuite.scala
@@ -7,6 +7,22 @@ import java.util.UUID
 
 object TableOfSuite {
   case class User(id: UUID, email: String, createdAt: OffsetDateTime, deletedAt: Option[OffsetDateTime])
+
+  /**
+   * Unbounded opaque alias — the shape that refined 0.11.x uses for `Refined[T, P]`. No `<: T` upper bound visible
+   * outside this object, so match types can't prove disjointness from `Option[_]`. The typeclass-based
+   * [[skunk.sharp.internal.DeriveColumns]] tolerates this; locking in #54.
+   */
+  opaque type Opaque[+T] = T
+  object Opaque {
+    def apply[T](t: T): Opaque[T] = t
+
+    // Fallback PgTypeFor — mirrors refined's `refinedPgTypeFor` / iron's `refinedPgTypeFor` pattern.
+    given opaquePgTypeFor[T](using base: skunk.sharp.pg.PgTypeFor[T]): skunk.sharp.pg.PgTypeFor[Opaque[T]] =
+      skunk.sharp.pg.PgTypeFor.instance(base.codec.asInstanceOf[skunk.Codec[Opaque[T]]])
+  }
+
+  case class Person(id: Int, email: Opaque[String], age: Opaque[Int])
 }
 
 class TableOfSuite extends munit.FunSuite {
@@ -34,6 +50,17 @@ class TableOfSuite extends munit.FunSuite {
       cols.map(_.name).zip(cols.map(_.isUnique)),
       List("id" -> false, "email" -> true, "createdAt" -> false, "deletedAt" -> false)
     )
+  }
+
+  test("Table.of handles unbounded opaque aliases (regression for #54)") {
+    // Without typeclass dispatch, `Person.email: Opaque[String]` would stall ColumnsFromMirror's Option[_] check
+    // because an unbounded opaque isn't provably disjoint from `Option`. The typeclass-based DeriveColumns resolves
+    // cleanly via `NotGiven[T <:< Option[?]]`.
+    val people = Table.of[TableOfSuite.Person]("people")
+
+    val cols = people.columns.toList.asInstanceOf[List[Column[?, ?, ?, ?]]]
+    assertEquals(cols.map(_.name), List("id", "email", "age"))
+    assertEquals(cols.map(_.isNullable), List(false, false, false))
   }
 
   test("withDefault flips runtime hasDefault flag and advances the Default phantom") {

--- a/modules/refined/src/test/scala/skunk/sharp/refined/RefinedSuite.scala
+++ b/modules/refined/src/test/scala/skunk/sharp/refined/RefinedSuite.scala
@@ -12,65 +12,44 @@ object RefinedSuite {
   type Email = String Refined MatchesRegex["^[^@]+@[^@]+$"]
   type Age   = Int Refined Positive
 
+  case class Person(id: Int, email: Email, age: Age)
+
   // Bridge cases: refined constraints that have a DB-type counterpart.
   type Name   = String Refined MaxSize[64]
   type Postal = String Refined Size[Equal[5]]
+  case class Party(name: Name, postalCode: Postal)
 }
 
 class RefinedSuite extends munit.FunSuite {
   import RefinedSuite.*
 
-  // Refined's `Refined[T, P]` is an unbounded opaque alias (`opaque type Refined[T, P] = T`), which defeats Scala 3
-  // match-type disjointness in `ColumnsFromMirror` — so `Table.of[T]` can't derive columns for case classes
-  // containing refined fields. Users with refined should use the column-by-column `Table.builder` path, which picks
-  // the right codec via the `PgTypeFor[Refined[A, P]]` givens defined in this module. (Tracked as a core follow-up:
-  // make `ColumnsFromMirror` dispatch via typeclasses that tolerate unbounded opaque types.)
-
-  test("fallback: refined refinement keeps the underlying type's codec") {
-    val people = Table
-      .builder("people")
-      .column[Int]("id")
-      .column[Email]("email")
-      .column[Age]("age")
-      .build
+  test("refined refinements participate in Table.of derivation") {
+    val people = Table.of[Person]("people").withPrimary("id")
 
     val cols = people.columns.toList.asInstanceOf[List[Column[?, ?, ?, ?]]]
     assertEquals(cols.map(_.name), List("id", "email", "age"))
     assertEquals(cols.map(_.tpe), List(Type.int4, Type.text, Type.int4))
   }
 
-  test("refined bridge: String Refined MaxSize[N] picks varchar(n)") {
-    val parties = Table
-      .builder("parties")
-      .column[Name]("name")
-      .build
+  test("refined-based columns participate in the DSL") {
+    val people = Table.of[Person]("people")
+    val cv     = ColumnsView(people.columns)
 
-    val cols = parties.columns.toList.asInstanceOf[List[Column[?, ?, ?, ?]]]
-    val name = cols.find(_.name == "name").get
+    val emailCol: TypedColumn[Email, false, "email"] = cv.email
+    assertEquals(emailCol.name, "email")
+  }
+
+  test("refined bridge: String Refined MaxSize[N] picks varchar(n)") {
+    val parties = Table.of[Party]("parties")
+    val cols    = parties.columns.toList.asInstanceOf[List[Column[?, ?, ?, ?]]]
+    val name    = cols.find(_.name == "name").get
     assertEquals(name.tpe, Type.varchar(64))
   }
 
   test("refined bridge: String Refined Size[Equal[N]] picks bpchar(n)") {
-    val parties = Table
-      .builder("parties")
-      .column[Postal]("postalCode")
-      .build
-
-    val cols   = parties.columns.toList.asInstanceOf[List[Column[?, ?, ?, ?]]]
-    val postal = cols.find(_.name == "postalCode").get
+    val parties = Table.of[Party]("parties")
+    val cols    = parties.columns.toList.asInstanceOf[List[Column[?, ?, ?, ?]]]
+    val postal  = cols.find(_.name == "postalCode").get
     assertEquals(postal.tpe, Type.bpchar(5))
-  }
-
-  test("refined columns participate in the DSL (ColumnsView selector access)") {
-    val people = Table
-      .builder("people")
-      .column[Int]("id")
-      .column[Email]("email")
-      .column[Age]("age")
-      .build
-
-    val cv = ColumnsView(people.columns)
-    val emailCol: TypedColumn[Email, false, "email"] = cv.email
-    assertEquals(emailCol.name, "email")
   }
 }


### PR DESCRIPTION
Closes #54. Stacked on #55 (refined module) — merge that first; GitHub will retarget this to main.

## Summary

Replace \`ColumnsFromMirror\` match-type + \`deriveColumns\` inline helper with a typeclass \`DeriveColumns[Labels, Types]\`.

The match-type dispatch stalls for unbounded opaque types (refined's \`opaque type Refined[T, P] = T\`) because Scala 3 requires the non-\`Option\` branch to be **provably disjoint** from \`Option[_]\` — and from outside an unbounded opaque's defining scope, disjointness can't be proved.

The typeclass uses \`NotGiven[T <:< Option[?]]\` to gate the non-\`Option\` instance. Subtype evidence works correctly with unbounded opaques (no \`<:<\` exists, so \`NotGiven\` succeeds), concrete classes (\`String\` clearly isn't \`<:<\` \`Option[?]\`), and upper-bounded opaques like iron's \`IronType\`.

## Downstream effect

- RefinedSuite reverts from the \`.builder\` workaround to the natural \`Table.of[T]\` form.
- No other call-site changes; \`Table.of\` / \`View.of\` summon the typeclass and use \`dc.Out\` / \`dc.value\` instead of the match-type + inline-helper duo.

## Regression test

A bespoke unbounded opaque alias in \`TableOfSuite\` exercises the exact shape refined uses, locking the behaviour so future regressions fail loudly in core rather than downstream modules.

## Test plan

- [x] \`sbt core/test iron/test refined/test circe/test\` — 180 unit tests pass
- [x] \`sbt tests/test\` — 74 integration tests pass
- [x] \`SBT_TPOLECAT_CI=1 sbt clean compile\` — clean under fatal warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)