### PR TITLE
Values: literal VALUES as both subquery and joinable Relation

### DIFF
--- a/modules/core/src/main/scala/skunk/sharp/dsl/Compiled.scala
+++ b/modules/core/src/main/scala/skunk/sharp/dsl/Compiled.scala
@@ -128,6 +128,17 @@ object AsSubquery {
     def render(q: SetOpQuery[T]): () => AppliedFragment = q.renderFn
   }
 
+  /**
+   * A literal [[Values]] fragment is also a subquery: embed it wherever a sub-select would go (INSERT…FROM, set-op
+   * operand, scalar `.asExpr`). Declared here because `AsSubquery` is sealed — subclasses / instances that widen
+   * through `new` must live with the declaration.
+   */
+  given fromValues[Cols <: Tuple, Row <: scala.NamedTuple.AnyNamedTuple]: AsSubquery[Values[Cols, Row], Row] =
+    new AsSubquery[Values[Cols, Row], Row] {
+      def codec(v: Values[Cols, Row]): Codec[Row]             = v.codec
+      def render(v: Values[Cols, Row]): () => AppliedFragment = () => v.render
+    }
+
 }
 
 /**

--- a/modules/core/src/main/scala/skunk/sharp/dsl/Join.scala
+++ b/modules/core/src/main/scala/skunk/sharp/dsl/Join.scala
@@ -110,6 +110,40 @@ extension [Ss <: Tuple](sb: SelectBuilder[Ss])(using ev: IsSingleSource[Ss]) {
 
 }
 
+/**
+ * `.alias("v")` on a [[Values]] — promote the literal row source to a joinable [[Relation]]. Every relation extension
+ * (`.innerJoin` / `.leftJoin` / `.select` / …) works on the result. The rendered FROM fragment is
+ * `(VALUES (…), (…)) AS "alias" ("col1", "col2", …)` — Postgres requires a derived `VALUES` to declare both its alias
+ * and its column list.
+ *
+ * Lives here (not in `Values.scala`) because Scala 3 requires overloaded extensions to share a single top-level
+ * definition group; this `alias` sits alongside the `Relation` and `SelectBuilder` overloads.
+ */
+extension [Cols <: Tuple, Row <: scala.NamedTuple.AnyNamedTuple](v: Values[Cols, Row]) {
+
+  def alias[A <: String & Singleton](a: A): Relation[Cols] {
+    type Alias = A
+    type Mode  = AliasMode.Explicit
+  } = {
+    val newAlias                           = a
+    val colsVal                            = v.columns
+    val colsList                           = v.columnListSql
+    val renderInner: () => AppliedFragment = () => v.render
+    new Relation[Cols] {
+      type Alias = A
+      type Mode  = AliasMode.Explicit
+      val currentAlias: A                                       = newAlias
+      val name: String                                          = newAlias
+      val schema: Option[String]                                = None
+      val columns: Cols                                         = colsVal
+      val expectedTableType: String                             = ""
+      override def fromFragmentWith(x: String): AppliedFragment =
+        TypedExpr.raw("(") |+| renderInner() |+| TypedExpr.raw(s""") AS "$x" ($colsList)""")
+    }
+  }
+
+}
+
 // ---- JoinKind + NullableCols -------------------------------------------------------------------
 
 /** Kind of join — drives the rendered keyword and whether the right-side cols are nullabilified. */

--- a/modules/core/src/main/scala/skunk/sharp/dsl/Values.scala
+++ b/modules/core/src/main/scala/skunk/sharp/dsl/Values.scala
@@ -1,0 +1,95 @@
+package skunk.sharp.dsl
+
+import cats.Reducible
+import skunk.{AppliedFragment, Codec, Fragment}
+import skunk.sharp.*
+import skunk.sharp.internal.{rowCodec, tupleCodec, DeriveColumns}
+import skunk.util.Origin
+
+import scala.NamedTuple
+
+/**
+ * A literal `VALUES` table — one or more rows given as named tuples. A single concept unifies two use cases:
+ *
+ *   - **As a subquery**: supplied to `.insert.from(…)`, `.asExpr`, `col.in(…)`, set-op operands, etc. Satisfies
+ *     [[AsSubquery]] so any position accepting a query accepts a `Values[Cols, Row]` with zero ceremony.
+ *   - **As a joinable [[Relation]]**: `Values.of(...).alias("v")` is a `Relation[Cols] { type Alias = "v" }` and flows
+ *     into `.innerJoin` / `.leftJoin` / `.crossJoin` / `.select` through the same `AsRelation` typeclass as Tables and
+ *     Views. The rendered FROM is `(VALUES (…), (…)) AS "v" ("col1", "col2", …)`, including the column list after the
+ *     alias — Postgres requires it and the `DeriveColumns`-derived `Cols` gives us the names for free.
+ *
+ * Codecs come from [[DeriveColumns]] (the same machinery `Table.of[T]` uses) — each named-tuple field is resolved to
+ * its [[skunk.sharp.pg.PgTypeFor]] instance. Fields with `Option[T]` values become nullable columns; everything else is
+ * non-nullable. Users can override per-field codecs by using the tag subtype aliases in [[skunk.sharp.pg.tags]]
+ * (`Varchar[256]`, `Numeric[10, 2]`, …) in the named-tuple field types.
+ */
+final class Values[Cols <: Tuple, Row <: NamedTuple.AnyNamedTuple] @scala.annotation.publicInBinary private[sharp] (
+  private[sharp] val columns: Cols,
+  private[sharp] val rowData: List[List[Any]]
+) {
+
+  /**
+   * Render the parameterised `VALUES (…), (…), …` fragment. Each field of every row flows through its column's codec,
+   * so parameters end up bound to the outer query's argument list when this value is embedded (subquery, FROM position,
+   * INSERT…FROM source).
+   */
+  private[sharp] def render: AppliedFragment = {
+    val cs          = columns.toList.asInstanceOf[List[Column[?, ?, ?, ?]]]
+    val perRow      = tupleCodec(cs.map(_.codec))
+    val rowEnc      = perRow.values
+    val rowFrag     = Fragment(List(Right(rowEnc.sql)), rowEnc, Origin.unknown)
+    val appliedRows = rowData.map(r => rowFrag(Tuple.fromArray(r.toArray[Any])))
+    TypedExpr.raw("VALUES ") |+| TypedExpr.joined(appliedRows, ", ")
+  }
+
+  /** Codec for decoding the produced rows when `Values` is consumed as a subquery that returns rows. */
+  private[sharp] def codec: Codec[Row] = rowCodec(columns).asInstanceOf[Codec[Row]]
+
+  /** Comma-joined, quoted column list — used after the alias when `Values` sits in FROM position. */
+  private[sharp] def columnListSql: String =
+    columns.toList.asInstanceOf[List[Column[?, ?, ?, ?]]].map(c => s""""${c.name}"""").mkString(", ")
+
+}
+
+object Values {
+
+  /**
+   * Build a `Values` from one or more named-tuple rows. Every row shares the same named-tuple shape — field names and
+   * types are taken from the first row's `Row` type parameter and the compile-time `DeriveColumns` resolution derives
+   * codecs for each field. Rows widening to positional tuples (if the caller drops named-tuple syntax) is rejected —
+   * the `Row <: NamedTuple.AnyNamedTuple` bound fires.
+   *
+   * {{{
+   *   val lookup = Values.of(
+   *     (id = 1, label = "alpha"),
+   *     (id = 2, label = "beta")
+   *   )
+   *
+   *   // As a subquery:
+   *   users.insert.from(lookup)                      // (rejected: different shapes — illustrative)
+   *
+   *   // As a joinable relation:
+   *   users.innerJoin(lookup.alias("l")).on(r => r.users.age ==== r.l.id).compile
+   * }}}
+   */
+  def of[Row <: NamedTuple.AnyNamedTuple](row: Row, more: Row*)(using
+    dc: DeriveColumns[NamedTuple.Names[Row], NamedTuple.DropNames[Row]]
+  ): Values[dc.Out, Row] = {
+    val cols = dc.value.asInstanceOf[dc.Out]
+    val rs   = (row :: more.toList).map(_.asInstanceOf[Tuple].toList)
+    new Values[dc.Out, Row](cols, rs)
+  }
+
+  /**
+   * Build from any cats-`Reducible` non-empty container. Parallel to `InsertBuilder.values(rows: F[R])` — lets callers
+   * feed a `NonEmptyList` / `NonEmptyVector` / `NonEmptyChain` directly without splatting.
+   */
+  def of[F[_]: Reducible, Row <: NamedTuple.AnyNamedTuple](rows: F[Row])(using
+    dc: DeriveColumns[NamedTuple.Names[Row], NamedTuple.DropNames[Row]]
+  ): Values[dc.Out, Row] = {
+    val cols = dc.value.asInstanceOf[dc.Out]
+    val rs   = Reducible[F].toNonEmptyList(rows).toList.map(_.asInstanceOf[Tuple].toList)
+    new Values[dc.Out, Row](cols, rs)
+  }
+
+}

--- a/modules/core/src/test/scala/skunk/sharp/dsl/ValuesSuite.scala
+++ b/modules/core/src/test/scala/skunk/sharp/dsl/ValuesSuite.scala
@@ -1,0 +1,92 @@
+package skunk.sharp.dsl
+
+import skunk.sharp.dsl.*
+
+import java.util.UUID
+
+object ValuesSuite {
+  case class User(id: UUID, email: String, age: Int)
+}
+
+class ValuesSuite extends munit.FunSuite {
+  import ValuesSuite.*
+
+  private val users = Table.of[User]("users")
+
+  test("Values.of + .alias renders `(VALUES (…), (…)) AS \"alias\" (col, …)` in FROM") {
+    val lookup = Values.of(
+      (id = 1, label = "alpha"),
+      (id = 2, label = "beta")
+    ).alias("lookup")
+
+    val af = lookup.select.compile.af
+
+    assertEquals(
+      af.fragment.sql,
+      """SELECT "id", "label" FROM (VALUES ($1, $2), ($3, $4)) AS "lookup" ("id", "label")"""
+    )
+  }
+
+  test("Values-as-subquery used as insert source via .from — no `.alias` needed in this position") {
+    val af = users.insert.from(
+      Values.of(
+        (id = UUID.randomUUID, email = "a@x", age = 20),
+        (id = UUID.randomUUID, email = "b@x", age = 30)
+      )
+    ).compile.af
+
+    // The INSERT's column list comes from the named-tuple field names; the body is the VALUES fragment itself
+    // (no wrapping SELECT — we're inserting literal rows).
+    assertEquals(
+      af.fragment.sql,
+      """INSERT INTO "users" ("id", "email", "age") VALUES ($1, $2, $3), ($4, $5, $6)"""
+    )
+  }
+
+  test("join a Table against a literal VALUES — matches your typical lookup-table pattern") {
+    val labels = Values.of(
+      (uid = UUID.randomUUID, label = "a"),
+      (uid = UUID.randomUUID, label = "b")
+    ).alias("labels")
+
+    val af = users
+      .innerJoin(labels)
+      .on(r => r.users.id ==== r.labels.uid)
+      .select(r => (r.users.email, r.labels.label))
+      .compile
+      .af
+
+    // The INNER JOIN picks up the derived relation's `fromFragmentWith` override — parens + alias + column list.
+    assertEquals(
+      af.fragment.sql,
+      """SELECT "users"."email", "labels"."label" FROM "users" INNER JOIN (VALUES ($1, $2), ($3, $4)) AS "labels" ("uid", "label") ON "users"."id" = "labels"."uid""""
+    )
+  }
+
+  test("Values.of keeps parameters in declared order across multiple rows") {
+    // Three rows × two fields = six $N placeholders in declaration order.
+    val af = Values.of(
+      (id = 1, label = "a"),
+      (id = 2, label = "b"),
+      (id = 3, label = "c")
+    ).alias("t").select.compile.af
+
+    assertEquals(
+      af.fragment.sql,
+      """SELECT "id", "label" FROM (VALUES ($1, $2), ($3, $4), ($5, $6)) AS "t" ("id", "label")"""
+    )
+  }
+
+  test("Option fields in the named tuple become nullable columns (codec `.opt`'d)") {
+    // The presence of Option[String] makes the derived column nullable — its codec decodes `Option[String]` rows.
+    val af = Values.of(
+      (id = 1, nickname = Option("robby")),
+      (id = 2, nickname = Option.empty[String])
+    ).alias("t").select.compile.af
+
+    assertEquals(
+      af.fragment.sql,
+      """SELECT "id", "nickname" FROM (VALUES ($1, $2), ($3, $4)) AS "t" ("id", "nickname")"""
+    )
+  }
+}

--- a/modules/tests/src/test/scala/skunk/sharp/tests/ValuesSuite.scala
+++ b/modules/tests/src/test/scala/skunk/sharp/tests/ValuesSuite.scala
@@ -1,0 +1,80 @@
+package skunk.sharp.tests
+
+import skunk.sharp.dsl.*
+
+import java.time.OffsetDateTime
+import java.util.UUID
+
+object ValuesSuite {
+  case class User(id: UUID, email: String, age: Int, created_at: OffsetDateTime, deleted_at: Option[OffsetDateTime])
+}
+
+/**
+ * Round-trip `Values.of(…)` against Postgres — both ways the unified shape shows up in SQL:
+ *   - As the row source of `INSERT INTO … SELECT` (users have a literal set of rows to promote).
+ *   - As a joinable [[Relation]] in `INNER JOIN` — the typical static-lookup table pattern.
+ */
+class ValuesSuite extends PgFixture {
+  import ValuesSuite.*
+
+  private val users = Table.of[User]("users").withPrimary("id").withUnique("email").withDefault("created_at")
+
+  test("insert.from Values.of — literal rows land in the table") {
+    withContainers { containers =>
+      session(containers).use { s =>
+        val tag = "values-insert"
+        val u1  = UUID.randomUUID
+        val u2  = UUID.randomUUID
+        val no  = Option.empty[OffsetDateTime]
+        for {
+          _ <- users.insert.from(
+            Values.of(
+              (id = u1, email = s"a-$tag@x", age = 22, deleted_at = no),
+              (id = u2, email = s"b-$tag@x", age = 33, deleted_at = no)
+            )
+          ).compile.run(s)
+          _ <- assertIO(
+            users
+              .select(u => u.email)
+              .where(u => u.email.like(s"%-$tag@x"))
+              .compile.run(s).map(_.toSet),
+            Set(s"a-$tag@x", s"b-$tag@x")
+          )
+        } yield ()
+      }
+    }
+  }
+
+  test("INNER JOIN on a literal Values relation — label users by their age bucket") {
+    withContainers { containers =>
+      session(containers).use { s =>
+        val tag = "values-join"
+        val u1  = UUID.randomUUID
+        val u2  = UUID.randomUUID
+        val no  = Option.empty[OffsetDateTime]
+        for {
+          _ <- users.insert.values(
+            (id = u1, email = s"young-$tag@x", age = 22, deleted_at = no),
+            (id = u2, email = s"old-$tag@x", age = 70, deleted_at = no)
+          ).compile.run(s)
+          // Literal (age, bucket) lookup. Not a table — just rows.
+          buckets = Values.of(
+            (age = 22, bucket = "young"),
+            (age = 70, bucket = "senior")
+          ).alias("buckets")
+          labelled <- users
+            .alias("u")
+            .innerJoin(buckets)
+            .on(r => r.u.age ==== r.buckets.age)
+            .select(r => (r.u.email, r.buckets.bucket))
+            .where(r => r.u.email.like(s"%-$tag@x"))
+            .compile.run(s).map(_.toSet)
+          _ = assertEquals(
+            labelled,
+            Set((s"young-$tag@x", "young"), (s"old-$tag@x", "senior"))
+          )
+        } yield ()
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

One \`Values[Cols, Row]\` concept replaces the previous split between "insert values" and "subquery":

- **As a subquery** — \`users.insert.from(Values.of((id = 1, email = \"x\"), …))\` renders \`INSERT INTO … VALUES (\$1,\$2), (\$3,\$4)\`. Satisfies \`AsSubquery[Values[Cols, Row], Row]\`.
- **As a joinable Relation** — \`Values.of(…).alias(\"v\")\` returns a \`Relation[Cols] { type Alias = \"v\"; type Mode = Explicit }\` that flows into \`.innerJoin\` / \`.leftJoin\` / \`.crossJoin\` / \`.select\` like Tables and Views. In FROM position: \`(VALUES (…)) AS \"v\" (\"c1\", \"c2\", …)\`.

Codecs come from \`DeriveColumns\` (the \`Table.of[T]\` machinery) — \`Option[T]\` fields become nullable columns; tag types (\`Varchar[N]\`, \`Numeric[P, S]\`, …) are respected.

The \`.alias\` extension for \`Values\` lives in \`Join.scala\` next to the \`Relation\` and \`SelectBuilder\` overloads because Scala 3 requires overloaded extensions to share a top-level group; the \`AsSubquery\` given lives in \`Compiled.scala\` because the trait is sealed.

## Test plan

- [x] \`sbt core/test\` — 208 pass (+5 new \`ValuesSuite\`: rendering, \`.from\` subquery position, JOIN-against-VALUES, multi-row parameter order, \`Option[T]\` nullability)
- [x] \`sbt tests/test\` — 95 pass (+2 new integration tests: INSERT from Values round-trip, users × literal-lookup INNER JOIN)
- [x] \`SBT_TPOLECAT_CI=1 sbt compile\` — clean
- [x] \`sbt scalafmtCheckAll\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)