### PR TITLE
LATERAL joins + inline Pg constants (TRUE / FALSE / NULL / session)

### DIFF
--- a/modules/core/src/main/scala/skunk/sharp/Pg.scala
+++ b/modules/core/src/main/scala/skunk/sharp/Pg.scala
@@ -24,9 +24,11 @@ import skunk.sharp.pg.functions.*
  * }}}
  */
 object Pg
-    extends PgNumeric
+    extends PgConstants
+    with PgNumeric
     with PgString
     with PgTime
+    with PgSession
     with PgAggregate
     with PgNull
     with PgSubquery

--- a/modules/core/src/main/scala/skunk/sharp/dsl/Join.scala
+++ b/modules/core/src/main/scala/skunk/sharp/dsl/Join.scala
@@ -337,8 +337,9 @@ final class SourceEntry[
   val alias: Alias,
   val originalCols: Cols0,
   val effectiveCols: Cols,
-  val kind: JoinKind,          // for the base source this is `Inner` (cosmetic — not rendered for index 0)
-  val onPredOpt: Option[Where] // `None` for the base source and CROSS joins; `Some` for INNER/LEFT
+  val kind: JoinKind,           // for the base source this is `Inner` (cosmetic — not rendered for index 0)
+  val onPredOpt: Option[Where], // `None` for the base source and CROSS joins; `Some` for INNER/LEFT/RIGHT/FULL
+  val isLateral: Boolean = false
 )
 
 /**
@@ -428,7 +429,8 @@ final class IncompleteJoin[
   pendingAlias: AR,
   pendingOriginalCols: CR0,
   pendingEffectiveCols: CR,
-  kind: JoinKind
+  kind: JoinKind,
+  isLateral: Boolean = false
 ) {
 
   /**
@@ -446,7 +448,8 @@ final class IncompleteJoin[
       pendingOriginalCols,
       pendingEffectiveCols,
       kind,
-      Some(pred)
+      Some(pred),
+      isLateral
     )
     // Nullabilify committed sources' effective cols for RIGHT / FULL. INNER / LEFT pass through unchanged.
     val finalCommitted: Tuple = kind match {
@@ -572,6 +575,102 @@ extension [L, RL <: Relation[CL], CL <: Tuple, AL <: String & Singleton, ML <: A
     val rCols     = rel.columns.asInstanceOf[CR]
     val rEntry    =
       new SourceEntry[RR, CR, CR, AR](rel, aR.aliasValue(right), rCols, rCols, JoinKind.Cross, None)
+    new SelectBuilder[(SourceEntry[RL, CL, CL, AL], SourceEntry[RR, CR, CR, AR])]((baseEntry, rEntry))
+  }
+
+  // ---- LATERAL joins ---------------------------------------------------------------------------
+  //
+  // `LATERAL` unlocks left-to-right correlation in FROM: the subquery on the right of a LATERAL join can reference
+  // the outer source's columns. The user's lambda receives the outer's qualified `ColumnsView`, which means
+  // correlated predicates in the inner `.where` — `p.user_id ==== outer.id` — type-check and render as
+  // alias-qualified SQL that Postgres resolves against the outer FROM-clause entry.
+
+  /**
+   * `INNER JOIN LATERAL (subquery) AS "x" ON <predicate>` — correlated inner join. The lambda receives the outer
+   * source's columns so the inner query's `.where` / `.limit` can reference them.
+   */
+  def innerJoinLateral[T, RR <: Relation[CR], CR <: Tuple, AR <: String & Singleton, MR <: AliasMode](
+    fn: ColumnsView[CL] => T
+  )(using
+    aR: AsRelation.Aux[T, RR, CR, AR, MR],
+    aliasCheck: AliasNotUsed[AR, AL *: EmptyTuple]
+  ): IncompleteJoin[
+    SourceEntry[RL, CL, CL, AL] *: EmptyTuple,
+    RR,
+    CR,
+    CR,
+    AR,
+    SourceEntry[RL, CL, CL, AL] *: EmptyTuple
+  ] = {
+    val baseEntry = makeBaseEntry[L, RL, CL, AL, ML](aL, left)
+    val outer     = ColumnsView.qualified(baseEntry.effectiveCols, baseEntry.alias)
+    val t         = fn(outer)
+    val rel       = aR(t)
+    val rCols     = rel.columns.asInstanceOf[CR]
+    new IncompleteJoin(baseEntry *: EmptyTuple, rel, aR.aliasValue(t), rCols, rCols, JoinKind.Inner, isLateral = true)
+  }
+
+  /**
+   * `LEFT JOIN LATERAL (subquery) AS "x" ON <predicate>` — correlated left join. When the inner subquery produces no
+   * rows for an outer row, the outer row still surfaces with the lateral side NULL-padded (so inner cols decode as
+   * `Option[_]`).
+   */
+  def leftJoinLateral[T, RR <: Relation[CR], CR <: Tuple, AR <: String & Singleton, MR <: AliasMode](
+    fn: ColumnsView[CL] => T
+  )(using
+    aR: AsRelation.Aux[T, RR, CR, AR, MR],
+    aliasCheck: AliasNotUsed[AR, AL *: EmptyTuple]
+  ): IncompleteJoin[
+    SourceEntry[RL, CL, CL, AL] *: EmptyTuple,
+    RR,
+    CR,
+    NullableCols[CR],
+    AR,
+    SourceEntry[RL, CL, CL, AL] *: EmptyTuple
+  ] = {
+    val baseEntry    = makeBaseEntry[L, RL, CL, AL, ML](aL, left)
+    val outer        = ColumnsView.qualified(baseEntry.effectiveCols, baseEntry.alias)
+    val t            = fn(outer)
+    val rel          = aR(t)
+    val origCols     = rel.columns.asInstanceOf[CR]
+    val effectiveCls = nullabilifyCols(origCols).asInstanceOf[NullableCols[CR]]
+    new IncompleteJoin(
+      baseEntry *: EmptyTuple,
+      rel,
+      aR.aliasValue(t),
+      origCols,
+      effectiveCls,
+      JoinKind.Left,
+      isLateral = true
+    )
+  }
+
+  /**
+   * `CROSS JOIN LATERAL (subquery) AS "x"` — correlated cross join, no ON required. Typical shape for "expand each
+   * outer row by the rows of a per-row-parameterised subquery". Outer rows whose inner produces zero rows are dropped
+   * (same semantics as a regular CROSS JOIN).
+   */
+  def crossJoinLateral[T, RR <: Relation[CR], CR <: Tuple, AR <: String & Singleton, MR <: AliasMode](
+    fn: ColumnsView[CL] => T
+  )(using
+    aR: AsRelation.Aux[T, RR, CR, AR, MR],
+    aliasCheck: AliasNotUsed[AR, AL *: EmptyTuple]
+  ): SelectBuilder[(SourceEntry[RL, CL, CL, AL], SourceEntry[RR, CR, CR, AR])] = {
+    val baseEntry = makeBaseEntry[L, RL, CL, AL, ML](aL, left)
+    val outer     = ColumnsView.qualified(baseEntry.effectiveCols, baseEntry.alias)
+    val t         = fn(outer)
+    val rel       = aR(t)
+    val rCols     = rel.columns.asInstanceOf[CR]
+    val rEntry    =
+      new SourceEntry[RR, CR, CR, AR](
+        rel,
+        aR.aliasValue(t),
+        rCols,
+        rCols,
+        JoinKind.Cross,
+        None,
+        isLateral = true
+      )
     new SelectBuilder[(SourceEntry[RL, CL, CL, AL], SourceEntry[RR, CR, CR, AR])]((baseEntry, rEntry))
   }
 

--- a/modules/core/src/main/scala/skunk/sharp/dsl/Select.scala
+++ b/modules/core/src/main/scala/skunk/sharp/dsl/Select.scala
@@ -182,6 +182,83 @@ final class SelectBuilder[Ss <: Tuple] private[sharp] (
     )
   }
 
+  // ---- LATERAL joins ---------------------------------------------------------------------------
+  //
+  // Same shape as the non-lateral methods but the source builder receives the outer view so its `.where` / `.limit`
+  // can reference already-committed sources' columns — Postgres resolves those as correlated references against the
+  // outer FROM-clause entry.
+
+  /**
+   * `INNER JOIN LATERAL (subquery) AS alias ON <predicate>`. The `fn` lambda receives the full outer view (committed
+   * sources keyed by alias) and returns the lateral source — typically
+   * `someTable.select(...).where(p => p.x ==== r.outer.y).limit(N).alias("x")`.
+   */
+  def innerJoinLateral[T, RR <: Relation[CR], CR <: Tuple, AR <: String & Singleton, MR <: AliasMode](
+    fn: SelectView[Ss] => T
+  )(using
+    a: AsRelation.Aux[T, RR, CR, AR, MR],
+    aliasCheck: AliasNotUsed[AR, AliasesOf[Ss]]
+  ): IncompleteJoin[Ss, RR, CR, CR, AR, Ss] = {
+    val t    = fn(view)
+    val rel  = a(t)
+    val cols = rel.columns.asInstanceOf[CR]
+    new IncompleteJoin(sources, rel, a.aliasValue(t), cols, cols, JoinKind.Inner, isLateral = true)
+  }
+
+  /**
+   * `LEFT JOIN LATERAL (subquery) AS alias ON <predicate>`. Every outer row surfaces; when the lateral produces no
+   * rows, the outer row is NULL-padded on the lateral side (lateral cols decode as `Option[_]`).
+   */
+  def leftJoinLateral[T, RR <: Relation[CR], CR <: Tuple, AR <: String & Singleton, MR <: AliasMode](
+    fn: SelectView[Ss] => T
+  )(using
+    a: AsRelation.Aux[T, RR, CR, AR, MR],
+    aliasCheck: AliasNotUsed[AR, AliasesOf[Ss]]
+  ): IncompleteJoin[Ss, RR, CR, NullableCols[CR], AR, Ss] = {
+    val t            = fn(view)
+    val rel          = a(t)
+    val origCols     = rel.columns.asInstanceOf[CR]
+    val effectiveCls = nullabilifyCols(origCols).asInstanceOf[NullableCols[CR]]
+    new IncompleteJoin(sources, rel, a.aliasValue(t), origCols, effectiveCls, JoinKind.Left, isLateral = true)
+  }
+
+  /**
+   * `CROSS JOIN LATERAL (subquery) AS alias` — no `.on(...)` required. Typical shape for "per-row expansion via a
+   * subquery parameterised by the outer row" (top-N per group, row-wise unnest, etc.). Outer rows whose lateral
+   * produces zero rows are dropped.
+   */
+  def crossJoinLateral[T, RR <: Relation[CR], CR <: Tuple, AR <: String & Singleton, MR <: AliasMode](
+    fn: SelectView[Ss] => T
+  )(using
+    a: AsRelation.Aux[T, RR, CR, AR, MR],
+    aliasCheck: AliasNotUsed[AR, AliasesOf[Ss]]
+  ): SelectBuilder[Tuple.Append[Ss, SourceEntry[RR, CR, CR, AR]]] = {
+    val t     = fn(view)
+    val rel   = a(t)
+    val cols  = rel.columns.asInstanceOf[CR]
+    val entry = new SourceEntry[RR, CR, CR, AR](
+      rel,
+      a.aliasValue(t),
+      cols,
+      cols,
+      JoinKind.Cross,
+      None,
+      isLateral = true
+    )
+    val next2 = (sources :* entry).asInstanceOf[Tuple.Append[Ss, SourceEntry[RR, CR, CR, AR]]]
+    new SelectBuilder[Tuple.Append[Ss, SourceEntry[RR, CR, CR, AR]]](
+      next2,
+      distinct,
+      whereOpt,
+      groupBys,
+      havingOpt,
+      orderBys,
+      limitOpt,
+      offsetOpt,
+      lockingOpt
+    )
+  }
+
   // ---- Projection -------------------------------------------------------------------------------
 
   /**
@@ -409,7 +486,8 @@ final class ProjectedSelect[Ss <: Tuple, Proj <: Tuple, Groups <: Tuple, Row](
         val head     = entries.head
         val headFrag = TypedExpr.raw(keyword) |+| projList |+| TypedExpr.raw(" FROM ") |+| aliasedFromEntry(head)
         entries.tail.foldLeft(headFrag) { (acc, s) =>
-          val fromFrag = TypedExpr.raw(s" ${s.kind.sql} ") |+| aliasedFromEntry(s)
+          val lateralKw = if (s.isLateral) " LATERAL" else ""
+          val fromFrag  = TypedExpr.raw(s" ${s.kind.sql}$lateralKw ") |+| aliasedFromEntry(s)
           s.onPredOpt.fold(acc |+| fromFrag)(p => acc |+| fromFrag |+| TypedExpr.raw(" ON ") |+| p.render)
         }
       }

--- a/modules/core/src/main/scala/skunk/sharp/pg/functions/PgConstants.scala
+++ b/modules/core/src/main/scala/skunk/sharp/pg/functions/PgConstants.scala
@@ -1,0 +1,34 @@
+package skunk.sharp.pg.functions
+
+import skunk.sharp.TypedExpr
+import skunk.sharp.pg.PgTypeFor
+
+/**
+ * Postgres literal constants. Rendered **inline** (no bound parameter) because there's no escape concern, no security
+ * benefit, and no semantic gain to parameterising a compile-time-known literal — `ON TRUE` is just a no-op join
+ * predicate, not a user-variable value.
+ *
+ * Intended surface: anywhere a `TypedExpr[Boolean]` / `TypedExpr[Option[T]]` would go. Typical use is a LATERAL JOIN's
+ * `.on(_ => Pg.True)` (standard SQL idiom for "JOIN needs an ON but the correlation lives in the inner WHERE");
+ * elsewhere users mostly want `col === value`, which goes through `lit` and the usual parameter path.
+ */
+trait PgConstants {
+
+  /** SQL `TRUE` — rendered inline, not as `$N`. */
+  val True: TypedExpr[Boolean] =
+    TypedExpr(TypedExpr.raw("TRUE"), skunk.codec.all.bool)
+
+  /** SQL `FALSE` — rendered inline, not as `$N`. */
+  val False: TypedExpr[Boolean] =
+    TypedExpr(TypedExpr.raw("FALSE"), skunk.codec.all.bool)
+
+  /**
+   * SQL `NULL` typed as `Option[T]` via the resolved `PgTypeFor[T]`. The codec uses `.opt` so the decoder expects an
+   * `Option`. Inline rendering.
+   *
+   * Not named `Null` to avoid colliding with Scala's `Null` type.
+   */
+  def nullOf[T](using pf: PgTypeFor[T]): TypedExpr[Option[T]] =
+    TypedExpr(TypedExpr.raw("NULL"), pf.codec.opt)
+
+}

--- a/modules/core/src/main/scala/skunk/sharp/pg/functions/PgSession.scala
+++ b/modules/core/src/main/scala/skunk/sharp/pg/functions/PgSession.scala
@@ -1,0 +1,38 @@
+package skunk.sharp.pg.functions
+
+import skunk.sharp.TypedExpr
+
+/**
+ * Session / connection introspection keywords — SQL-standard value functions that take no parentheses (`CURRENT_USER`,
+ * `SESSION_USER`, …) plus Postgres's `current_database()` (parenthesised, despite naming).
+ *
+ * All render inline as the keyword itself; decoders are `text` / `varchar`. Useful for audit columns, RLS predicates
+ * (`created_by = current_user`), diagnostic SELECTs, and multi-tenant defaults.
+ */
+trait PgSession {
+
+  /** `current_user` — the effective role id in force for the session. */
+  val currentUser: TypedExpr[String] =
+    TypedExpr(TypedExpr.raw("current_user"), skunk.codec.all.text)
+
+  /** `session_user` — the login role, unaffected by `SET ROLE`. */
+  val sessionUser: TypedExpr[String] =
+    TypedExpr(TypedExpr.raw("session_user"), skunk.codec.all.text)
+
+  /** `user` — SQL-standard alias of `current_user`. */
+  val user: TypedExpr[String] =
+    TypedExpr(TypedExpr.raw("user"), skunk.codec.all.text)
+
+  /** `current_schema` — first schema in the current `search_path`. */
+  val currentSchema: TypedExpr[String] =
+    TypedExpr(TypedExpr.raw("current_schema"), skunk.codec.all.text)
+
+  /** `current_catalog` — SQL-standard synonym for the current database name (Postgres extension). */
+  val currentCatalog: TypedExpr[String] =
+    TypedExpr(TypedExpr.raw("current_catalog"), skunk.codec.all.text)
+
+  /** `current_database()` — the current database name. Parenthesised despite the naming. */
+  val currentDatabase: TypedExpr[String] =
+    TypedExpr(TypedExpr.raw("current_database()"), skunk.codec.all.text)
+
+}

--- a/modules/core/src/main/scala/skunk/sharp/pg/functions/PgTime.scala
+++ b/modules/core/src/main/scala/skunk/sharp/pg/functions/PgTime.scala
@@ -2,9 +2,9 @@ package skunk.sharp.pg.functions
 
 import skunk.sharp.{PgFunction, TypedExpr}
 
-import java.time.{LocalDate, LocalDateTime, OffsetDateTime}
+import java.time.{LocalDate, LocalDateTime, LocalTime, OffsetDateTime, OffsetTime}
 
-/** Date / time accessor functions. Mixed into [[skunk.sharp.Pg]]. */
+/** Date / time accessor functions and keyword constants. Mixed into [[skunk.sharp.Pg]]. */
 trait PgTime {
 
   /** `now()` — current transaction timestamp with timezone. */
@@ -18,8 +18,16 @@ trait PgTime {
   val currentDate: TypedExpr[LocalDate] =
     TypedExpr(TypedExpr.raw("current_date"), skunk.codec.all.date)
 
-  /** `localtimestamp`. */
+  /** `current_time` — current time with timezone. */
+  val currentTime: TypedExpr[OffsetTime] =
+    TypedExpr(TypedExpr.raw("current_time"), skunk.codec.all.timetz)
+
+  /** `localtimestamp` — current timestamp without timezone. */
   val localTimestamp: TypedExpr[LocalDateTime] =
     TypedExpr(TypedExpr.raw("localtimestamp"), skunk.codec.all.timestamp)
+
+  /** `localtime` — current time without timezone. */
+  val localTime: TypedExpr[LocalTime] =
+    TypedExpr(TypedExpr.raw("localtime"), skunk.codec.all.time)
 
 }

--- a/modules/core/src/test/scala/skunk/sharp/dsl/JoinSuite.scala
+++ b/modules/core/src/test/scala/skunk/sharp/dsl/JoinSuite.scala
@@ -239,6 +239,63 @@ class JoinSuite extends munit.FunSuite {
     )
   }
 
+  // ---- LATERAL joins --------------------------------------------------------------------------
+  //
+  // LATERAL unlocks correlation in FROM — the inner subquery can reference the outer source's columns directly in
+  // its own `.where` / `.limit`. Today's `.alias` only works on whole-row SelectBuilder (projected `.select(f)`
+  // doesn't yet support `.alias`), so the inner shape is always `base.select.where(…).limit(N).alias("x")` — the
+  // outer query can still project just what it wants from the resulting relation.
+
+  test("INNER JOIN LATERAL renders LATERAL keyword; inner WHERE correlates against outer cols") {
+    val af = users
+      .innerJoinLateral(u => posts.select.where(p => p.user_id ==== u.id).limit(3).alias("recent"))
+      .on(_ => Pg.True)
+      .select(r => (r.users.email, r.recent.title))
+      .compile
+      .af
+
+    assertEquals(
+      af.fragment.sql,
+      """SELECT "users"."email", "recent"."title" FROM "users" INNER JOIN LATERAL (SELECT "id", "user_id", "title", "created_at" FROM "posts" WHERE "user_id" = "users"."id" LIMIT 3) AS "recent" ON TRUE"""
+    )
+  }
+
+  test("CROSS JOIN LATERAL — no .on required, transitions straight to SelectBuilder") {
+    val af = users
+      .crossJoinLateral(u => posts.select.where(p => p.user_id ==== u.id).limit(1).alias("top"))
+      .select(r => (r.users.email, r.top.title))
+      .compile
+      .af
+
+    assertEquals(
+      af.fragment.sql,
+      """SELECT "users"."email", "top"."title" FROM "users" CROSS JOIN LATERAL (SELECT "id", "user_id", "title", "created_at" FROM "posts" WHERE "user_id" = "users"."id" LIMIT 1) AS "top""""
+    )
+  }
+
+  test("LEFT JOIN LATERAL — lateral cols decode as Option when the inner produces zero rows") {
+    val q: CompiledQuery[(String, Option[String])] = users
+      .leftJoinLateral(u => posts.select.where(p => p.user_id ==== u.id).limit(1).alias("top"))
+      .on(_ => Pg.True)
+      .select(r => (r.users.email, r.top.title))
+      .compile
+
+    assert(q.af.fragment.sql.contains("LEFT JOIN LATERAL"), q.af.fragment.sql)
+  }
+
+  test("chained LATERAL after an INNER JOIN — multi-source outer view reaches inner WHERE") {
+    val af = users
+      .innerJoin(posts).on(r => r.users.id ==== r.posts.user_id)
+      .innerJoinLateral(r => tags.select.where(t => t.post_id ==== r.posts.id).limit(2).alias("top_tags"))
+      .on(_ => Pg.True)
+      .select(r => (r.users.email, r.posts.title, r.top_tags.name))
+      .compile
+      .af
+
+    assert(af.fragment.sql.contains("INNER JOIN LATERAL"), af.fragment.sql)
+    assert(af.fragment.sql.contains("""WHERE "post_id" = "posts"."id""""), af.fragment.sql)
+  }
+
   test("LEFT then FULL — LEFT-nullabilified cols stay Option (no double-wrapping) under FULL") {
     // posts was already Option[_] from LEFT. FULL also nullabilifies users. The Scala type must NOT go to
     // Option[Option[_]] for posts — NullableCol is idempotent on already-nullable columns. In the inner ON of the
@@ -246,7 +303,7 @@ class JoinSuite extends munit.FunSuite {
     // raw comparisons there by round-tripping through literals that match both sides at the bare types.
     val q: CompiledQuery[(Option[String], Option[String], Option[String])] = users
       .leftJoin(posts).on(r => r.users.id ==== r.posts.user_id)
-      .fullJoin(tags).on(_ => lit(true))
+      .fullJoin(tags).on(_ => Pg.True)
       .select(r => (r.users.email, r.posts.title, r.tags.name))
       .compile
 

--- a/modules/tests/src/test/scala/skunk/sharp/tests/JoinSuite.scala
+++ b/modules/tests/src/test/scala/skunk/sharp/tests/JoinSuite.scala
@@ -230,6 +230,86 @@ class JoinSuite extends PgFixture {
     }
   }
 
+  test("CROSS JOIN LATERAL returns top-N posts per user — classic per-group top-K pattern") {
+    withContainers { containers =>
+      session(containers).use { s =>
+        val tag  = "lateral-topn"
+        val uid1 = UUID.randomUUID
+        val uid2 = UUID.randomUUID
+        val no   = Option.empty[OffsetDateTime]
+        for {
+          _ <- users.insert.values(
+            (id = uid1, email = s"u1-$tag@x", age = 30, deleted_at = no),
+            (id = uid2, email = s"u2-$tag@x", age = 40, deleted_at = no)
+          ).compile.run(s)
+          // Seed 3 posts per user; LATERAL should surface only the 2 most-recent per user (top-K = 2).
+          _ <- posts.insert.values(
+            (id = UUID.randomUUID, user_id = uid1, title = s"u1-p1-$tag"),
+            (id = UUID.randomUUID, user_id = uid1, title = s"u1-p2-$tag"),
+            (id = UUID.randomUUID, user_id = uid1, title = s"u1-p3-$tag"),
+            (id = UUID.randomUUID, user_id = uid2, title = s"u2-p1-$tag"),
+            (id = UUID.randomUUID, user_id = uid2, title = s"u2-p2-$tag"),
+            (id = UUID.randomUUID, user_id = uid2, title = s"u2-p3-$tag")
+          ).compile.run(s)
+          // Per-user top 2 posts by created_at DESC, via LATERAL with a correlated inner WHERE + LIMIT.
+          pairs <- users
+            .alias("u")
+            .crossJoinLateral(o =>
+              posts.select
+                .where(p => p.user_id ==== o.id)
+                .orderBy(p => p.created_at.desc)
+                .limit(2)
+                .alias("recent")
+            )
+            .select(r => (r.u.email, r.recent.title))
+            .where(r => r.u.email.like(s"%-$tag@x"))
+            .compile.run(s).map(_.toSet)
+          _ = assertEquals(pairs.size, 4) // 2 users × top 2 posts each
+          _ = assert(pairs.forall((email, _) => email.endsWith(s"-$tag@x")), s"unexpected emails: $pairs")
+        } yield ()
+      }
+    }
+  }
+
+  test("LEFT JOIN LATERAL — users without posts still surface, with Option(None) on the lateral side") {
+    withContainers { containers =>
+      session(containers).use { s =>
+        val tag      = "lateral-left"
+        val withPost = UUID.randomUUID
+        val solo     = UUID.randomUUID
+        val no       = Option.empty[OffsetDateTime]
+        for {
+          _ <- users.insert.values(
+            (id = withPost, email = s"wp-$tag@x", age = 25, deleted_at = no),
+            (id = solo, email = s"solo-$tag@x", age = 25, deleted_at = no)
+          ).compile.run(s)
+          _ <- posts
+            .insert((id = UUID.randomUUID, user_id = withPost, title = s"only-post-$tag"))
+            .compile.run(s)
+          rows <- users
+            .alias("u")
+            .leftJoinLateral(o =>
+              posts.select
+                .where(p => p.user_id ==== o.id)
+                .limit(1)
+                .alias("latest")
+            )
+            .on(_ => Pg.True)
+            .select(r => (r.u.email, r.latest.title))
+            .where(r => r.u.email.like(s"%-$tag@x"))
+            .compile.run(s).map(_.toSet)
+          _ = assertEquals(
+            rows,
+            Set[(String, Option[String])](
+              (s"wp-$tag@x", Some(s"only-post-$tag")),
+              (s"solo-$tag@x", None) // no post → LEFT LATERAL null-pads the lateral side
+            )
+          )
+        } yield ()
+      }
+    }
+  }
+
   test("FULL OUTER JOIN returns NULL on either side for rows present only on one") {
     withContainers { containers =>
       session(containers).use { s =>


### PR DESCRIPTION
## Summary

**LATERAL joins** (part 2b of #2):

- \`.innerJoinLateral(fn)\` / \`.leftJoinLateral(fn)\` / \`.crossJoinLateral(fn)\` on both entry points (top-level on a \`Relation\`, chained on a \`SelectBuilder\`).
- The lambda receives the outer view so the inner subquery's \`.where\` / \`.limit\` can reference already-committed sources' columns — correlated references render as alias-qualified SQL that Postgres resolves against the outer FROM-clause entry.
- Implementation: \`isLateral: Boolean\` on \`SourceEntry\` (default false), threaded through \`IncompleteJoin\` so \`.on\` preserves it on finalise. Renderer prepends \` LATERAL\` after the kind keyword.

**Inline \`Pg.*\` constants**:

- \`PgConstants\`: \`Pg.True\` / \`Pg.False\` / \`Pg.nullOf[T]\` — the three SQL literals with no escape concerns or security benefit from parameterisation. Render inline (\`TRUE\` / \`FALSE\` / \`NULL\`) rather than \`\$N\`. LATERAL's \`ON TRUE\` now actually renders \`ON TRUE\`, not \`ON \$1\`.
- \`PgSession\`: \`current_user\` / \`session_user\` / \`user\` / \`current_schema\` / \`current_catalog\` / \`current_database()\` — SQL-standard keyword value functions + PG's one parenthesised extension.
- Extended \`PgTime\`: \`current_time\` and \`localtime\` round out the time-keyword set.

Not in scope — a separate PR would change \`lit(v)\` itself to render primitive literals inline (would shift every \`\$N\` position in existing snapshot tests). Today users opt into inline via the named \`Pg.*\` constants.

## Test plan

- [x] \`sbt core/test\` — 217 pass (+4 new LATERAL unit tests: INNER rendering + correlated WHERE, CROSS LATERAL without \`.on\`, LEFT LATERAL with Option cols, chained LATERAL after an INNER JOIN)
- [x] \`sbt tests/test\` — 99 pass (+2 new integration tests: per-user top-N via \`crossJoinLateral\`, \`leftJoinLateral\` null-padding when lateral produces zero rows)
- [x] \`SBT_TPOLECAT_CI=1 sbt compile\` — clean
- [x] \`sbt scalafmtCheckAll\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)