### PR TITLE
Move operators out of skunk.sharp.where → skunk.sharp.ops

### DIFF
--- a/modules/core/src/main/scala/skunk/sharp/TypedExpr.scala
+++ b/modules/core/src/main/scala/skunk/sharp/TypedExpr.scala
@@ -66,12 +66,12 @@ object TypedExpr {
   }
 
   /**
-   * Render a `Float` literal as its SQL form. Always emits a `::float4` cast — Postgres's default numeric-literal
-   * parse type is `numeric`, and functions like `sqrt(9.0)` then return `numeric` instead of the expected `double
-   * precision`, which blows up the skunk decoder. The explicit cast pins the type.
+   * Render a `Float` literal as its SQL form. Always emits a `::float4` cast — Postgres's default numeric-literal parse
+   * type is `numeric`, and functions like `sqrt(9.0)` then return `numeric` instead of the expected `double precision`,
+   * which blows up the skunk decoder. The explicit cast pins the type.
    *
-   * IEEE specials (`NaN`, `±Infinity`) can't be written as bare numeric tokens in SQL — Postgres accepts them only
-   * as quoted strings cast to the target float type. Public so the `lit` macro can call it from spliced code.
+   * IEEE specials (`NaN`, `±Infinity`) can't be written as bare numeric tokens in SQL — Postgres accepts them only as
+   * quoted strings cast to the target float type. Public so the `lit` macro can call it from spliced code.
    */
   def renderFloat(v: Float): String = v match {
     case x if java.lang.Float.isNaN(x) => "'NaN'::float4"

--- a/modules/core/src/main/scala/skunk/sharp/dsl/package.scala
+++ b/modules/core/src/main/scala/skunk/sharp/dsl/package.scala
@@ -66,8 +66,14 @@ package object dsl {
   type Where = skunk.sharp.where.Where
   val Where: skunk.sharp.where.Where.type = skunk.sharp.where.Where
 
-  export skunk.sharp.where.{!==, &&, <, <=, ===, ====, >, >=, ||, and, ilike, in, isNotNull, isNull, like, not, or}
-  export skunk.sharp.where.Stripped
+  // The expression-level operators ("WHERE operators" historically, but they produce a plain
+  // `TypedExpr[Boolean]` and work anywhere an expression goes — projections, ORDER BY, HAVING, function args).
+  export skunk.sharp.ops.{!==, <, <=, ===, ====, >, >=, ilike, in, isNotNull, isNull, like}
+  export skunk.sharp.ops.Stripped
+
+  // Boolean combinators (`&&`, `||`, `!`, `and`, `or`, `not`) stay in `skunk.sharp.where` — they're about
+  // composing predicates, not building them.
+  export skunk.sharp.where.{&&, ||, and, not, or}
 
   // ---- Schema validation ----
   val SchemaValidator: skunk.sharp.validation.SchemaValidator.type = skunk.sharp.validation.SchemaValidator

--- a/modules/core/src/main/scala/skunk/sharp/ops/ExprOps.scala
+++ b/modules/core/src/main/scala/skunk/sharp/ops/ExprOps.scala
@@ -1,12 +1,20 @@
-package skunk.sharp.where
+package skunk.sharp.ops
 
 import skunk.sharp.{PgOperator, TypedExpr}
 import skunk.sharp.pg.PgTypeFor
+import skunk.sharp.where.Where
 
 import scala.annotation.unused
 
 /**
- * The v0 WHERE operator set: `=, <>, <, <=, >, >=, IN, LIKE, IS NULL` plus logical combinators (on `Where`).
+ * The v0 expression-level operator set: `=, <>, <, <=, >, >=, IN, LIKE, IS NULL`. Every operator produces a
+ * `TypedExpr[Boolean]` (aliased as [[skunk.sharp.where.Where]]), which is just a regular expression — it slots anywhere
+ * a `TypedExpr[_]` is valid in Postgres: WHERE clauses, SELECT projections (`users.select(u => u.age >= 18)` renders a
+ * boolean column), HAVING, ORDER BY, function arguments, CASE WHEN predicates.
+ *
+ * Lives in `skunk.sharp.ops` (not `.where`) because "WHERE" was misleading — the operators aren't WHERE-specific. The
+ * `skunk.sharp.where` package keeps the [[Where]] type alias + logical combinators (`&&`, `||`, unary `!`), which
+ * compose booleans regardless of where they end up.
  *
  * Operators are *extension methods* on `TypedExpr[T]` so third-party modules add new ones without touching core (jsonb
  * `->>`, ltree `~`, arrays `@>`, …).

--- a/modules/core/src/main/scala/skunk/sharp/pg/functions/PgNull.scala
+++ b/modules/core/src/main/scala/skunk/sharp/pg/functions/PgNull.scala
@@ -2,7 +2,7 @@ package skunk.sharp.pg.functions
 
 import skunk.sharp.{PgFunction, TypedExpr}
 import skunk.sharp.pg.PgTypeFor
-import skunk.sharp.where.Stripped
+import skunk.sharp.ops.Stripped
 
 /** NULL-handling helpers. Mixed into [[skunk.sharp.Pg]]. */
 trait PgNull {

--- a/modules/core/src/main/scala/skunk/sharp/pg/functions/Shared.scala
+++ b/modules/core/src/main/scala/skunk/sharp/pg/functions/Shared.scala
@@ -2,7 +2,7 @@ package skunk.sharp.pg.functions
 
 import skunk.sharp.TypedExpr
 import skunk.sharp.pg.PgTypeFor
-import skunk.sharp.where.Stripped
+import skunk.sharp.ops.Stripped
 
 // ---- Shared type-level helpers ------------------------------------------------------------------
 

--- a/modules/core/src/test/scala/skunk/sharp/NegativeTestsSuite.scala
+++ b/modules/core/src/test/scala/skunk/sharp/NegativeTestsSuite.scala
@@ -36,7 +36,7 @@ class NegativeTestsSuite extends munit.FunSuite {
   test("WHERE equality with a value of the wrong type does not compile") {
     val errs = typeCheckErrors("""
       import skunk.sharp.*
-      import skunk.sharp.where.*
+      import skunk.sharp.ops.*, skunk.sharp.where.*
       import NegativeTestsSuite.User
       val c = ColumnsView(Table.of[User]("users").columns)
       c.age === "not an int"
@@ -47,7 +47,7 @@ class NegativeTestsSuite extends munit.FunSuite {
   test("isNull on a non-nullable column does not compile with a helpful message") {
     val errs = typeCheckErrors("""
       import skunk.sharp.*
-      import skunk.sharp.where.*
+      import skunk.sharp.ops.*, skunk.sharp.where.*
       import NegativeTestsSuite.User
       val c = ColumnsView(Table.of[User]("users").columns)
       c.age.isNull
@@ -60,7 +60,7 @@ class NegativeTestsSuite extends munit.FunSuite {
   test("=== None on a nullable column does not compile (use isNull)") {
     val errs = typeCheckErrors("""
       import skunk.sharp.*
-      import skunk.sharp.where.*
+      import skunk.sharp.ops.*, skunk.sharp.where.*
       import NegativeTestsSuite.User
       val c = ColumnsView(Table.of[User]("users").columns)
       c.deleted_at === None
@@ -71,7 +71,7 @@ class NegativeTestsSuite extends munit.FunSuite {
   test("LIKE on a non-string column does not compile") {
     val errs = typeCheckErrors("""
       import skunk.sharp.*
-      import skunk.sharp.where.*
+      import skunk.sharp.ops.*, skunk.sharp.where.*
       import NegativeTestsSuite.User
       val c = ColumnsView(Table.of[User]("users").columns)
       c.age.like("%")
@@ -101,7 +101,7 @@ class NegativeTestsSuite extends munit.FunSuite {
     val errs = typeCheckErrors("""
       import skunk.sharp.*
       import skunk.sharp.dsl.*
-      import skunk.sharp.where.*
+      import skunk.sharp.ops.*, skunk.sharp.where.*
       import NegativeTestsSuite.User
       View.of[User]("active_users").update.set(u => u.age := 1)
     """)

--- a/modules/core/src/test/scala/skunk/sharp/dsl/SelectSuite.scala
+++ b/modules/core/src/test/scala/skunk/sharp/dsl/SelectSuite.scala
@@ -160,4 +160,41 @@ class SelectSuite extends munit.FunSuite {
     assert(errs.nonEmpty)
   }
 
+  // ---- Comparison operators work as expressions, not just in WHERE ------------------------------
+  //
+  // `===`, `!==`, `<`, `<=`, `>`, `>=`, `in`, `like`, `ilike`, `isNull`, `isNotNull` all produce `TypedExpr[Boolean]`
+  // (= `Where`), which is a regular expression — Postgres accepts boolean expressions anywhere, so the operators
+  // slot into projections, HAVING, ORDER BY, function arguments, etc. These tests lock the cross-position property in.
+
+  test("comparison operator in a SELECT projection — renders as a boolean column") {
+    val af = users.select(u => u.age >= 18).compile.af
+    assertEquals(
+      af.fragment.sql,
+      """SELECT "age" >= $1 FROM "users""""
+    )
+  }
+
+  test("comparison operator as one projection among many — decoded row type includes Boolean") {
+    val q: CompiledQuery[(String, Boolean)] = users
+      .select(u => (u.email, u.age >= 18))
+      .compile
+
+    assertEquals(
+      q.af.fragment.sql,
+      """SELECT "email", "age" >= $1 FROM "users""""
+    )
+  }
+
+  test("isNull as a projection element — same nullable-gating applies as in WHERE") {
+    val af = users.select(u => u.deleted_at.isNull).compile.af
+    assertEquals(
+      af.fragment.sql,
+      """SELECT "deleted_at" IS NULL FROM "users""""
+    )
+  }
+
+  // Note: ORDER BY on a boolean expression would be `.orderBy(u => (u.age >= 18).asc)`. Today `.asc` / `.desc`
+  // only extend `TypedColumn`, not general `TypedExpr`, so that shape doesn't compile yet — a separate gap from
+  // the cross-position-operators story.
+
 }

--- a/modules/core/src/test/scala/skunk/sharp/where/WhereSuite.scala
+++ b/modules/core/src/test/scala/skunk/sharp/where/WhereSuite.scala
@@ -73,7 +73,7 @@ class WhereSuite extends munit.FunSuite {
     import scala.compiletime.testing.*
     val result: List[Error] = typeCheckErrors("""
       import skunk.sharp.*
-      import skunk.sharp.where.*
+      import skunk.sharp.ops.*, skunk.sharp.where.*
       import WhereSuite.User
       import java.time.OffsetDateTime
       val t = Table.of[User]("users")


### PR DESCRIPTION
## Summary

Comparison / LIKE / IN / IS NULL operators produce a plain \`TypedExpr[Boolean]\`, and Postgres accepts boolean expressions anywhere an expression is valid — SELECT projections, HAVING, ORDER BY, function arguments, CASE WHEN. Putting them in a package called \`where\` was misleading.

- Moved \`skunk.sharp.where.Ops\` → \`skunk.sharp.ops.ExprOps\`.
- \`skunk.sharp.where\` keeps the \`Where\` type alias and the logical combinators (\`&&\`, \`||\`, unary \`!\`, \`and\`, \`or\`, \`not\`) — they're about composing booleans, which is a distinct concern.
- Internal imports flipped (Shared / PgNull / ArrayOps / \`dsl.package\` re-exports, two test files).
- User-facing surface via \`import skunk.sharp.dsl.*\` unchanged.

## Locked-in behaviour: operators work in projections

Added three \`SelectSuite\` tests that exercise the operators outside of WHERE:

\`\`\`scala
users.select(u => u.age >= 18)           // SELECT "age" >= \$1 FROM "users"
users.select(u => (u.email, u.age >= 18)) // returns (String, Boolean)
users.select(u => u.deleted_at.isNull)   // SELECT "deleted_at" IS NULL FROM "users"
\`\`\`

## Not in scope

ORDER BY on a boolean expression (e.g. \`.orderBy(u => (u.age >= 18).asc)\`) doesn't compile — \`.asc\` / \`.desc\` only extend \`TypedColumn\`, not general \`TypedExpr\`. Noted in a code comment; follow-up if you want it.

## Test plan

- [x] \`sbt core/test\` — 224 pass (+3 new projection tests)
- [x] \`sbt tests/test\` — 99 pass
- [x] \`SBT_TPOLECAT_CI=1 sbt compile\` — clean
- [x] \`sbt scalafmtCheckAll\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)