### PR TITLE
ORDER BY on any TypedExpr: generalise .asc/.desc beyond columns

### DIFF
--- a/modules/core/src/main/scala/skunk/sharp/dsl/Select.scala
+++ b/modules/core/src/main/scala/skunk/sharp/dsl/Select.scala
@@ -516,7 +516,7 @@ private[dsl] def renderClauses(
   val withHaving = havingOpt.fold(withGroup)(h => withGroup |+| TypedExpr.raw(" HAVING ") |+| h.render)
   val withOrder  =
     if (orderBys.isEmpty) withHaving
-    else withHaving |+| TypedExpr.raw(" ORDER BY " + orderBys.map(_.sql).mkString(", "))
+    else withHaving |+| TypedExpr.raw(" ORDER BY ") |+| TypedExpr.joined(orderBys.map(_.af), ", ")
   val withLimit  = limitOpt.fold(withOrder)(n => withOrder |+| TypedExpr.raw(s" LIMIT $n"))
   val withOffset = offsetOpt.fold(withLimit)(n => withLimit |+| TypedExpr.raw(s" OFFSET $n"))
   lockingOpt.fold(withOffset)(l => withOffset |+| TypedExpr.raw(" " + l.sql))
@@ -696,15 +696,21 @@ type LookupTypes[Cols <: Tuple, Names <: Tuple] <: Tuple = Names match {
 }
 
 /**
- * ORDER BY clause — produced by `.asc` / `.desc` on a [[TypedColumn]]. Chain `.nullsFirst` / `.nullsLast` to control
- * where NULLs land.
+ * ORDER BY clause element — produced by `.asc` / `.desc` on any [[TypedExpr]]. Chain `.nullsFirst` / `.nullsLast` to
+ * control where NULLs land. Holds an [[skunk.AppliedFragment]] so parameterised inner expressions (`(u.age >= 18).asc`,
+ * `Pg.lower(u.email).asc`) keep their bound values through to the outer compilation.
  */
-final case class OrderBy(sql: String) {
-  def nullsFirst: OrderBy = OrderBy(sql + " NULLS FIRST")
-  def nullsLast: OrderBy  = OrderBy(sql + " NULLS LAST")
+final case class OrderBy(af: skunk.AppliedFragment) {
+  def nullsFirst: OrderBy = OrderBy(af |+| TypedExpr.raw(" NULLS FIRST"))
+  def nullsLast: OrderBy  = OrderBy(af |+| TypedExpr.raw(" NULLS LAST"))
 }
 
-extension [T, Null <: Boolean, N <: String & Singleton](col: TypedColumn[T, Null, N]) {
-  def asc: OrderBy  = OrderBy(s"${col.sqlRef} ASC")
-  def desc: OrderBy = OrderBy(s"${col.sqlRef} DESC")
+/**
+ * `.asc` / `.desc` on any [[TypedExpr]] — produces an [[OrderBy]] suitable for `.orderBy(...)`. Works on columns,
+ * function calls, boolean comparisons, arithmetic, every expression shape the DSL supports. The returned `OrderBy` only
+ * makes sense passed to `.orderBy`; it isn't an expression itself.
+ */
+extension [T](expr: TypedExpr[T]) {
+  def asc: OrderBy  = OrderBy(expr.render |+| TypedExpr.raw(" ASC"))
+  def desc: OrderBy = OrderBy(expr.render |+| TypedExpr.raw(" DESC"))
 }

--- a/modules/core/src/test/scala/skunk/sharp/dsl/SelectSuite.scala
+++ b/modules/core/src/test/scala/skunk/sharp/dsl/SelectSuite.scala
@@ -193,8 +193,22 @@ class SelectSuite extends munit.FunSuite {
     )
   }
 
-  // Note: ORDER BY on a boolean expression would be `.orderBy(u => (u.age >= 18).asc)`. Today `.asc` / `.desc`
-  // only extend `TypedColumn`, not general `TypedExpr`, so that shape doesn't compile yet — a separate gap from
-  // the cross-position-operators story.
+  test("ORDER BY a boolean comparison expression — parameters in the ORDER BY clause flow through") {
+    // Postgres orders by a boolean treating FALSE < TRUE; useful for "give me matched rows last" style sorts.
+    // The `18` on the RHS of `>=` becomes `$1`, and the OrderBy carries that bound parameter via AppliedFragment.
+    val af = users.select(u => u.email).orderBy(u => (u.age >= 18).asc).compile.af
+    assertEquals(
+      af.fragment.sql,
+      """SELECT "email" FROM "users" ORDER BY "age" >= $1 ASC"""
+    )
+  }
+
+  test("ORDER BY a function call expression — `.asc` on any TypedExpr, not just columns") {
+    val af = users.select(u => u.email).orderBy(u => Pg.lower(u.email).asc).compile.af
+    assertEquals(
+      af.fragment.sql,
+      """SELECT "email" FROM "users" ORDER BY lower("email") ASC"""
+    )
+  }
 
 }


### PR DESCRIPTION
## Summary

\`.asc\` / \`.desc\` used to live as extensions on \`TypedColumn\` only — \`(u.age >= 18).asc\` or \`Pg.lower(u.email).desc\` didn't compile. Postgres accepts any expression in \`ORDER BY\`, so this lifts the extension to any \`TypedExpr[T]\` so the DSL matches SQL.

### Mechanical bit

\`OrderBy\` used to carry a plain \`String\` (fine when only column references flowed through it). Now it carries an \`AppliedFragment\` so bound parameters thread through to the outer query. \`(u.age >= 18).asc\` renders \`"age" >= \$1 ASC\` and the \`18\` lands in the outer argument list. The ORDER BY renderer composes via \`TypedExpr.joined(_, ", ")\`.

\`.nullsFirst\` / \`.nullsLast\` on \`OrderBy\` just append to the fragment; no external API change.

## Test plan

- [x] \`sbt core/test\` — 226 pass (+2 new SelectSuite tests: ORDER BY a boolean comparison with parameter flowing through, ORDER BY a function-call expression)
- [x] \`sbt tests/test\` — 99 pass
- [x] \`SBT_TPOLECAT_CI=1 sbt compile\` — clean
- [x] \`sbt scalafmtCheckAll\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)