### PR TITLE
Projected SELECT .alias + set-returning functions as Relations

### DIFF
--- a/modules/core/src/main/scala/skunk/sharp/Pg.scala
+++ b/modules/core/src/main/scala/skunk/sharp/Pg.scala
@@ -32,3 +32,4 @@ object Pg
     with PgNull
     with PgSubquery
     with PgArray
+    with PgSrf

--- a/modules/core/src/main/scala/skunk/sharp/TypedColumn.scala
+++ b/modules/core/src/main/scala/skunk/sharp/TypedColumn.scala
@@ -16,7 +16,8 @@ final class TypedColumn[T, Null <: Boolean, N <: String & Singleton](
   val name: N,
   val codec: Codec[T],
   val qualifier: Option[String] = None,
-  val quoteQualifier: Boolean = true
+  val quoteQualifier: Boolean = true,
+  val nullable: Boolean = false
 ) extends TypedExpr[T] {
 
   /** SQL identifier form — `"name"` or `"alias"."name"` / `alias."name"` depending on qualifier state. */
@@ -40,7 +41,7 @@ object TypedColumn {
   def of[T, N <: String & Singleton, Null <: Boolean, Attrs <: Tuple](
     c: Column[T, N, Null, Attrs]
   ): TypedColumn[T, Null, N] =
-    new TypedColumn[T, Null, N](c.name, c.codec)
+    new TypedColumn[T, Null, N](c.name, c.codec, nullable = c.isNullable)
 
   /**
    * Build a `TypedColumn` whose rendering is prefixed with a table/alias qualifier (`"u"."col"`). By default the
@@ -50,7 +51,7 @@ object TypedColumn {
     c: Column[T, N, Null, Attrs],
     qualifier: String
   ): TypedColumn[T, Null, N] =
-    new TypedColumn[T, Null, N](c.name, c.codec, Some(qualifier), quoteQualifier = true)
+    new TypedColumn[T, Null, N](c.name, c.codec, Some(qualifier), quoteQualifier = true, nullable = c.isNullable)
 
   /**
    * Same as [[qualified]] but leaves the qualifier unquoted in the SQL (`excluded."col"` instead of
@@ -61,6 +62,6 @@ object TypedColumn {
     c: Column[T, N, Null, Attrs],
     qualifier: String
   ): TypedColumn[T, Null, N] =
-    new TypedColumn[T, Null, N](c.name, c.codec, Some(qualifier), quoteQualifier = false)
+    new TypedColumn[T, Null, N](c.name, c.codec, Some(qualifier), quoteQualifier = false, nullable = c.isNullable)
 
 }

--- a/modules/core/src/main/scala/skunk/sharp/dsl/Join.scala
+++ b/modules/core/src/main/scala/skunk/sharp/dsl/Join.scala
@@ -111,6 +111,79 @@ extension [Ss <: Tuple](sb: SelectBuilder[Ss])(using ev: IsSingleSource[Ss]) {
 }
 
 /**
+ * `.alias("sub")` on a [[ProjectedSelect]] — promote a column-list SELECT to a joinable [[Relation]]. Every element of
+ * the projection must have a stable name (a bare column reference or `expr.as("name")`); arbitrary unaliased
+ * expressions (`Pg.lower(u.email)`, `u.email ++ u.suffix`) have no name Postgres is obliged to use, so they're rejected
+ * at compile time by [[AllNamedProj]] with a pointed error that names the fix.
+ *
+ * Enables projected subquery-as-relation and projected `LATERAL` sources — both ubiquitous for per-row-parameterised
+ * queries. The outer relation's `Cols` tuple is computed by [[ProjCols]] from the projection shape, so
+ * `r.<alias>.<col>` resolves at the outer site.
+ *
+ * A terminal `.compile` on the `ProjectedSelect` runs lazily when the outer query's own `.compile` walks this source —
+ * there's still only one user-visible `.compile` on the whole tree. `GroupCoverage` is summoned here so the inner
+ * rendering is as valid as a standalone `.compile` would be.
+ */
+extension [Ss <: Tuple, Proj <: Tuple, Groups <: Tuple, Row](
+  ps: ProjectedSelect[Ss, Proj, Groups, Row]
+)(using gc: GroupCoverage[Proj, Groups], @scala.annotation.unused np: AllNamedProj[Proj]) {
+
+  def alias[A <: String & Singleton](a: A): Relation[ProjCols[Proj]] {
+    type Alias = A
+    type Mode  = AliasMode.Explicit
+  } = {
+    val newAlias                           = a
+    val cols                               = buildProjectedCols(ps.projections).asInstanceOf[ProjCols[Proj]]
+    val renderInner: () => AppliedFragment = () => ps.compile(using gc).af
+    new Relation[ProjCols[Proj]] {
+      type Alias = A
+      type Mode  = AliasMode.Explicit
+      val currentAlias: A                                       = newAlias
+      val name: String                                          = newAlias
+      val schema: Option[String]                                = None
+      val columns: ProjCols[Proj]                               = cols
+      val expectedTableType: String                             = ""
+      override def fromFragmentWith(x: String): AppliedFragment =
+        TypedExpr.raw("(") |+| renderInner() |+| TypedExpr.raw(s""") AS "$x"""")
+    }
+  }
+
+}
+
+/**
+ * Reconstruct a runtime column tuple from a projection list. Each element is either a [[TypedColumn]] (column name +
+ * codec + compile-time nullability, now threaded through `.nullable`) or an [[AliasedExpr]] (alias name + codec, always
+ * treated as non-nullable — any expression that could produce NULL is the caller's responsibility to wrap in an
+ * explicit `Option[_]` codec). Third shapes are rejected at compile time by [[AllNamedProj]]; the default arm here
+ * throws only because pattern exhaustiveness on `TypedExpr[?]` is open.
+ */
+private[sharp] def buildProjectedCols(projections: List[TypedExpr[?]]): Tuple = {
+  val cols = projections.map {
+    case tc: TypedColumn[?, ?, ?] =>
+      Column[Any, "x", Boolean, Tuple](
+        name = tc.name.asInstanceOf["x"],
+        tpe = skunk.sharp.pg.PgTypes.typeOf(tc.codec.asInstanceOf[Codec[Any]]),
+        codec = tc.codec.asInstanceOf[Codec[Any]],
+        isNullable = tc.nullable.asInstanceOf[Boolean],
+        attrs = Nil
+      )
+    case ae: AliasedExpr[?, ?] =>
+      Column[Any, "x", Boolean, Tuple](
+        name = ae.aliasName.asInstanceOf["x"],
+        tpe = skunk.sharp.pg.PgTypes.typeOf(ae.codec.asInstanceOf[Codec[Any]]),
+        codec = ae.codec.asInstanceOf[Codec[Any]],
+        isNullable = false,
+        attrs = Nil
+      )
+    case other =>
+      throw new IllegalStateException(
+        s"skunk-sharp: projection element is neither a TypedColumn nor an AliasedExpr — should have been rejected at compile time: $other"
+      )
+  }
+  Tuple.fromArray(cols.toArray[Any])
+}
+
+/**
  * `.alias("v")` on a [[Values]] — promote the literal row source to a joinable [[Relation]]. Every relation extension
  * (`.innerJoin` / `.leftJoin` / `.select` / …) works on the result. The rendered FROM fragment is
  * `(VALUES (…), (…)) AS "alias" ("col1", "col2", …)` — Postgres requires a derived `VALUES` to declare both its alias

--- a/modules/core/src/main/scala/skunk/sharp/dsl/ProjCols.scala
+++ b/modules/core/src/main/scala/skunk/sharp/dsl/ProjCols.scala
@@ -1,0 +1,49 @@
+package skunk.sharp.dsl
+
+import skunk.sharp.{AliasedExpr, Column, TypedColumn}
+
+/**
+ * Type-level map from a projection tuple (as tracked by [[ProjectedSelect]]'s `Proj` phantom) to the tuple of
+ * [[Column]] descriptors it represents. Drives [[ProjectedSelect.alias]] — only projections with a known name (either a
+ * bare column reference or an `.as("name")`-aliased expression) can become named columns of a joinable relation.
+ * Arbitrary un-named expressions (`u.email ++ u.suffix`, `Pg.lower(u.email)`, …) have no stable name Postgres is
+ * obliged to use, so they can't be surfaced as a column — the compile-time guard below rejects them.
+ *
+ *   - `TypedColumn[T, Null, N]` → `Column[T, N, Null, EmptyTuple]` (preserves nullability at the phantom).
+ *   - `AliasedExpr[T, N]` → `Column[T, N, false, EmptyTuple]` (explicit alias; value's own nullability isn't
+ *     reintroduced here — `Option[_]` outputs still decode as `Option[_]` via the codec, but the column's `Null`
+ *     phantom is `false` because there's no declared-nullable column behind the alias).
+ */
+type ProjCols[Proj <: Tuple] <: Tuple = Proj match {
+  case EmptyTuple                    => EmptyTuple
+  case TypedColumn[t, nu, n] *: rest => Column[t, n, nu, EmptyTuple] *: ProjCols[rest]
+  case AliasedExpr[t, n] *: rest     => Column[t, n, false, EmptyTuple] *: ProjCols[rest]
+}
+
+/**
+ * Evidence that every element of `Proj` is either a `TypedColumn[_, _, _]` or an `AliasedExpr[_, _]`. Summoned by
+ * [[ProjectedSelect.alias]] so non-named projections produce a pointed compile error rather than a cryptic
+ * match-type-reduction failure.
+ */
+@scala.annotation.implicitNotFound(
+  "skunk-sharp: `.alias(\"…\")` on a projected SELECT requires every projected element to be a bare column " +
+    "reference or an expression aliased via `.as(\"name\")`. Found projections that have no stable name — pick " +
+    "columns (`u.email`), or add aliases (`Pg.lower(u.email).as(\"lower_email\")`)."
+)
+sealed trait AllNamedProj[Proj <: Tuple]
+
+object AllNamedProj {
+
+  given empty: AllNamedProj[EmptyTuple] = new AllNamedProj[EmptyTuple] {}
+
+  given consColumn[T, Nu <: Boolean, N <: String & Singleton, Rest <: Tuple](using
+    rest: AllNamedProj[Rest]
+  ): AllNamedProj[TypedColumn[T, Nu, N] *: Rest] =
+    new AllNamedProj[TypedColumn[T, Nu, N] *: Rest] {}
+
+  given consAliased[T, N <: String & Singleton, Rest <: Tuple](using
+    rest: AllNamedProj[Rest]
+  ): AllNamedProj[AliasedExpr[T, N] *: Rest] =
+    new AllNamedProj[AliasedExpr[T, N] *: Rest] {}
+
+}

--- a/modules/core/src/main/scala/skunk/sharp/pg/functions/PgSrf.scala
+++ b/modules/core/src/main/scala/skunk/sharp/pg/functions/PgSrf.scala
@@ -1,0 +1,115 @@
+package skunk.sharp.pg.functions
+
+import skunk.{AppliedFragment, Codec}
+import skunk.codec.all as pg
+import skunk.sharp.*
+import skunk.sharp.pg.{IsArray, PgTypeFor}
+
+/**
+ * Set-returning functions (`generate_series`, `unnest`, …) as joinable [[Relation]]s. The single-column shape below
+ * fits the common cases: one function, one output column, always non-nullable (both `generate_series` and `unnest` emit
+ * non-NULL rows for their declared ranges / array elements).
+ *
+ * Unlike Tables / Views, an SRF [[Relation]]'s default alias equals its output column name — Postgres auto-aliases an
+ * un-`AS`ed SRF source to the function name, but using the column name here keeps the [[skunk.sharp.dsl.SelectBuilder]]
+ * view's path `r.<colName>.<colName>` from repeating the noisy function name. `.alias("x")` re-aliases in the standard
+ * way and flows through `Relation.fromFragmentWith(x)`, which we override to emit `func(args) AS "x"("col")` — Postgres
+ * requires the explicit alias-and-column-list form when an SRF is renamed.
+ *
+ * Multi-column and composite-returning SRFs (`regexp_matches`, user-defined record-returning functions) are a later,
+ * separate addition — they need a column tuple and are niche. This module covers the non-composite 80%.
+ */
+private[sharp] def srfRelation1[T, N <: String & Singleton](
+  funcName: String,
+  args: List[AppliedFragment],
+  colName: N,
+  codec0: Codec[T]
+): Relation[Column[T, N, false, EmptyTuple] *: EmptyTuple] { type Alias = N; type Mode = AliasMode.Explicit } = {
+  val col: Column[T, N, false, EmptyTuple] =
+    Column[T, N, false, EmptyTuple](
+      name = colName,
+      tpe = skunk.sharp.pg.PgTypes.typeOf(codec0),
+      codec = codec0,
+      isNullable = false,
+      attrs = Nil
+    )
+  val cols: Column[T, N, false, EmptyTuple] *: EmptyTuple = col *: EmptyTuple
+
+  new Relation[Column[T, N, false, EmptyTuple] *: EmptyTuple] {
+    type Alias = N
+    type Mode  = AliasMode.Explicit
+    val currentAlias: N                                        = colName
+    val name: String                                           = colName
+    val schema: Option[String]                                 = None
+    val columns: Column[T, N, false, EmptyTuple] *: EmptyTuple = cols
+    val expectedTableType: String                              = ""
+    override def fromFragmentWith(x: String): AppliedFragment  = {
+      val joinedArgs = TypedExpr.joined(args, ", ")
+      TypedExpr.raw(s"$funcName(") |+| joinedArgs |+| TypedExpr.raw(s""") AS "$x"("$colName")""")
+    }
+  }
+}
+
+/**
+ * `Pg.generateSeries` / `Pg.unnestAsRelation` — set-returning functions exposed as [[Relation]]s. Drop them into any
+ * FROM / JOIN / LATERAL position:
+ *
+ * {{{
+ *   // 1..10 as a relation — one column "n" of type int.
+ *   Pg.generateSeries(1, 10).select
+ *
+ *   users.crossJoin(Pg.generateSeries(1, 3).alias("g"))
+ *        .select(r => (r.users.email, r.g.n))
+ *
+ *   // Expand an array column into rows via LATERAL.
+ *   users.innerJoinLateral(u => Pg.unnestAsRelation(u.tags).alias("t"))
+ *        .on(_ => lit(true))
+ *        .select(r => (r.users.email, r.t.v))
+ * }}}
+ */
+trait PgSrf {
+
+  /** `generate_series(start, stop)` — inclusive integer range, one column `n INT` per row. */
+  def generateSeries(start: Int, stop: Int): Relation[Column[Int, "n", false, EmptyTuple] *: EmptyTuple] {
+    type Alias = "n"
+    type Mode  = AliasMode.Explicit
+  } =
+    srfRelation1[Int, "n"](
+      "generate_series",
+      List(TypedExpr.parameterised(start).render, TypedExpr.parameterised(stop).render),
+      "n",
+      pg.int4
+    )
+
+  /** `generate_series(start, stop, step)` — with an explicit step (positive or negative). */
+  def generateSeries(start: Int, stop: Int, step: Int)
+    : Relation[Column[Int, "n", false, EmptyTuple] *: EmptyTuple] { type Alias = "n"; type Mode = AliasMode.Explicit } =
+    srfRelation1[Int, "n"](
+      "generate_series",
+      List(
+        TypedExpr.parameterised(start).render,
+        TypedExpr.parameterised(stop).render,
+        TypedExpr.parameterised(step).render
+      ),
+      "n",
+      pg.int4
+    )
+
+  /**
+   * `unnest(array)` as a [[Relation]] — each element becomes a row of a single-column output `v`. Named
+   * `unnestAsRelation` to avoid colliding with the expression-level [[PgArray.unnest]] that returns a `TypedExpr[E]`
+   * (usable in SELECT-list position). Use this one when you want a joinable source — most often inside a LATERAL join
+   * so the array column comes from the outer row.
+   */
+  def unnestAsRelation[A, E](a: TypedExpr[A])(using
+    @scala.annotation.unused ev: IsArray.Aux[A, E],
+    pf: PgTypeFor[E]
+  ): Relation[Column[E, "v", false, EmptyTuple] *: EmptyTuple] { type Alias = "v"; type Mode = AliasMode.Explicit } =
+    srfRelation1[E, "v"](
+      "unnest",
+      List(a.render),
+      "v",
+      pf.codec
+    )
+
+}

--- a/modules/core/src/test/scala/skunk/sharp/dsl/JoinSuite.scala
+++ b/modules/core/src/test/scala/skunk/sharp/dsl/JoinSuite.scala
@@ -296,6 +296,84 @@ class JoinSuite extends munit.FunSuite {
     assert(af.fragment.sql.contains("""WHERE "post_id" = "posts"."id""""), af.fragment.sql)
   }
 
+  // ---- projected-SELECT `.alias` as subquery / lateral source ---------------------------------
+
+  test("projected SELECT `.alias` renders as a derived table in FROM") {
+    val af = users
+      .select(u => (u.id, u.email))
+      .where(u => u.age >= 18)
+      .alias("adults")
+      .select
+      .compile
+      .af
+
+    assertEquals(
+      af.fragment.sql,
+      """SELECT "id", "email" FROM (SELECT "id", "email" FROM "users" WHERE "age" >= $1) AS "adults""""
+    )
+  }
+
+  test("projected SELECT `.alias` with `.as(\"lbl\")` expression — alias name surfaces as column name") {
+    val af = users
+      .select(u => (u.id, Pg.lower(u.email).as("lower_email")))
+      .alias("u2")
+      .select
+      .compile
+      .af
+
+    assertEquals(
+      af.fragment.sql,
+      """SELECT "id", "lower_email" FROM (SELECT "id", lower("email") AS "lower_email" FROM "users") AS "u2""""
+    )
+  }
+
+  test("projected SELECT joined with a base table — outer references derived cols by alias") {
+    val af = users
+      .select(u => (u.id, u.email))
+      .where(u => u.age >= 18)
+      .alias("adults")
+      .innerJoin(posts).on(r => r.adults.id ==== r.posts.user_id)
+      .select(r => (r.adults.email, r.posts.title))
+      .compile
+      .af
+
+    assertEquals(
+      af.fragment.sql,
+      """SELECT "adults"."email", "posts"."title" FROM (SELECT "id", "email" FROM "users" WHERE "age" >= $1) AS "adults" INNER JOIN "posts" ON "adults"."id" = "posts"."user_id""""
+    )
+  }
+
+  test("INNER JOIN LATERAL against a projected SELECT — per-outer-row top-N") {
+    val af = users
+      .innerJoinLateral(u =>
+        posts.select(p => (p.id, p.title)).where(p => p.user_id ==== u.id).limit(3).alias("recent")
+      )
+      .on(_ => lit(true))
+      .select(r => (r.users.email, r.recent.title))
+      .compile
+      .af
+
+    assertEquals(
+      af.fragment.sql,
+      """SELECT "users"."email", "recent"."title" FROM "users" INNER JOIN LATERAL (SELECT "id", "title" FROM "posts" WHERE "user_id" = "users"."id" LIMIT 3) AS "recent" ON TRUE"""
+    )
+  }
+
+  test("projected SELECT with an un-named expression fails to compile via AllNamedProj") {
+    val errs = compiletime.testing.typeCheckErrors("""
+      import skunk.sharp.dsl.*
+      import java.util.UUID
+      case class U(id: UUID, email: String, age: Int)
+      val t = Table.of[U]("users")
+      t.select(u => (u.id, Pg.lower(u.email))).alias("x")
+    """)
+    assert(errs.nonEmpty, "expected compile error from AllNamedProj")
+    assert(
+      errs.exists(_.message.contains("requires every projected element")),
+      errs.map(_.message).mkString("\n")
+    )
+  }
+
   test("LEFT then FULL — LEFT-nullabilified cols stay Option (no double-wrapping) under FULL") {
     // posts was already Option[_] from LEFT. FULL also nullabilifies users. The Scala type must NOT go to
     // Option[Option[_]] for posts — NullableCol is idempotent on already-nullable columns. In the inner ON of the

--- a/modules/core/src/test/scala/skunk/sharp/dsl/SrfSuite.scala
+++ b/modules/core/src/test/scala/skunk/sharp/dsl/SrfSuite.scala
@@ -1,0 +1,68 @@
+package skunk.sharp.dsl
+
+import skunk.data.Arr
+import skunk.sharp.dsl.*
+
+import java.util.UUID
+
+object SrfSuite {
+  case class User(id: UUID, email: String, tags: Arr[String])
+}
+
+class SrfSuite extends munit.FunSuite {
+  import SrfSuite.*
+
+  private val users = Table.of[User]("users")
+
+  test("Pg.generateSeries(1, 10) renders as `generate_series($1, $2) AS \"n\"(\"n\")` in FROM") {
+    val af = Pg.generateSeries(1, 10).select.compile.af
+    assertEquals(
+      af.fragment.sql,
+      """SELECT "n" FROM generate_series($1, $2) AS "n"("n")"""
+    )
+  }
+
+  test("Pg.generateSeries 3-arg form includes the step") {
+    val af = Pg.generateSeries(0, 10, 2).select.compile.af
+    assert(af.fragment.sql.contains("""generate_series($1, $2, $3)"""), af.fragment.sql)
+  }
+
+  test("SRF relation joined with a base table — CROSS JOIN form") {
+    val af = users
+      .crossJoin(Pg.generateSeries(1, 3).alias("g"))
+      .select(r => (r.users.email, r.g.n))
+      .compile
+      .af
+
+    assertEquals(
+      af.fragment.sql,
+      """SELECT "users"."email", "g"."n" FROM "users" CROSS JOIN generate_series($1, $2) AS "g"("n")"""
+    )
+  }
+
+  test("Pg.unnestAsRelation in a LATERAL join — expands an array column per outer row") {
+    val af = users
+      .innerJoinLateral(u => Pg.unnestAsRelation(u.tags).alias("t"))
+      .on(_ => lit(true))
+      .select(r => (r.users.email, r.t.v))
+      .compile
+      .af
+
+    assertEquals(
+      af.fragment.sql,
+      """SELECT "users"."email", "t"."v" FROM "users" INNER JOIN LATERAL unnest("users"."tags") AS "t"("v") ON TRUE"""
+    )
+  }
+
+  test("SRF output column is usable in WHERE / ORDER BY") {
+    val af = Pg.generateSeries(1, 10)
+      .select
+      .where(g => g.n >= 5)
+      .orderBy(g => g.n.desc)
+      .compile
+      .af
+
+    assert(af.fragment.sql.contains("""WHERE "n" >= $3"""), af.fragment.sql)
+    assert(af.fragment.sql.endsWith(""" ORDER BY "n" DESC"""), af.fragment.sql)
+  }
+}

--- a/modules/tests/src/test/scala/skunk/sharp/tests/ArraysSuite.scala
+++ b/modules/tests/src/test/scala/skunk/sharp/tests/ArraysSuite.scala
@@ -150,6 +150,52 @@ class ArraysSuite extends PgFixture {
     }
   }
 
+  test("Pg.unnestAsRelation — LATERAL-expand an Arr[String] column into rows") {
+    withContainers { containers =>
+      session(containers).use { s =>
+        for {
+          _ <- posts.insert.values(
+            (id = 801, tags = Arr("a", "b", "c"), score = 1),
+            (id = 802, tags = Arr("d"), score = 2)
+          ).compile.run(s)
+          rows <- posts
+            .alias("p")
+            .innerJoinLateral(p => Pg.unnestAsRelation(p.tags).alias("t"))
+            .on(_ => lit(true))
+            .select(r => (r.p.id, r.t.v))
+            .where(r => r.p.id.in(NonEmptyList.of(801, 802)))
+            .compile.run(s).map(_.toSet)
+          _ = assertEquals(
+            rows,
+            Set[(Int, String)](
+              (801, "a"),
+              (801, "b"),
+              (801, "c"),
+              (802, "d")
+            )
+          )
+        } yield ()
+      }
+    }
+  }
+
+  test("Pg.generateSeries — CROSS JOIN an int range with a base table") {
+    withContainers { containers =>
+      session(containers).use { s =>
+        for {
+          _    <- posts.insert((id = 901, tags = Arr("x"), score = 1)).compile.run(s)
+          rows <- posts
+            .alias("p")
+            .crossJoin(Pg.generateSeries(1, 3).alias("g"))
+            .select(r => (r.p.id, r.g.n))
+            .where(r => r.p.id === 901)
+            .compile.run(s).map(_.toSet)
+          _ = assertEquals(rows, Set[(Int, Int)]((901, 1), (901, 2), (901, 3)))
+        } yield ()
+      }
+    }
+  }
+
   test("generic collPgTypeFor — Vector[String] column round-trips") {
     withContainers { containers =>
       session(containers).use { s =>

--- a/modules/tests/src/test/scala/skunk/sharp/tests/JoinSuite.scala
+++ b/modules/tests/src/test/scala/skunk/sharp/tests/JoinSuite.scala
@@ -271,6 +271,47 @@ class JoinSuite extends PgFixture {
     }
   }
 
+  test("INNER JOIN LATERAL against a projected SELECT — per-user top-N with trimmed inner projection") {
+    // Same per-group top-K shape as the CROSS LATERAL test, but the inner query projects only the title column
+    // instead of the whole row. Exercises `.alias` on a `ProjectedSelect` (derived relation with a narrow column
+    // tuple) as the lateral source.
+    withContainers { containers =>
+      session(containers).use { s =>
+        val tag  = "lateral-proj"
+        val uid1 = UUID.randomUUID
+        val uid2 = UUID.randomUUID
+        val no   = Option.empty[OffsetDateTime]
+        for {
+          _ <- users.insert.values(
+            (id = uid1, email = s"u1-$tag@x", age = 30, deleted_at = no),
+            (id = uid2, email = s"u2-$tag@x", age = 40, deleted_at = no)
+          ).compile.run(s)
+          _ <- posts.insert.values(
+            (id = UUID.randomUUID, user_id = uid1, title = s"u1-p1-$tag"),
+            (id = UUID.randomUUID, user_id = uid1, title = s"u1-p2-$tag"),
+            (id = UUID.randomUUID, user_id = uid2, title = s"u2-p1-$tag"),
+            (id = UUID.randomUUID, user_id = uid2, title = s"u2-p2-$tag")
+          ).compile.run(s)
+          pairs <- users
+            .alias("u")
+            .innerJoinLateral(o =>
+              posts.select(p => p.title)
+                .where(p => p.user_id ==== o.id)
+                .orderBy(p => p.created_at.desc)
+                .limit(1)
+                .alias("recent")
+            )
+            .on(_ => lit(true))
+            .select(r => (r.u.email, r.recent.title))
+            .where(r => r.u.email.like(s"%-$tag@x"))
+            .compile.run(s).map(_.toSet)
+          _ = assertEquals(pairs.size, 2) // one top post per user
+          _ = assert(pairs.forall((email, _) => email.endsWith(s"-$tag@x")), s"unexpected: $pairs")
+        } yield ()
+      }
+    }
+  }
+
   test("LEFT JOIN LATERAL — users without posts still surface, with Option(None) on the lateral side") {
     withContainers { containers =>
       session(containers).use { s =>


### PR DESCRIPTION
## Summary

Two gaps filled in the N-source JOIN machinery:

- **`.alias("x")` on `ProjectedSelect`.** Until now, only whole-row `SelectBuilder` could be aliased into a joinable `Relation`, which meant projected LATERAL sources (`posts.select(p => p.title).limit(3).alias("top")`) and projected subqueries-as-relations didn't compile. Driven by a new `ProjCols` match type (projection tuple → runtime `Column` tuple) and an `AllNamedProj` typeclass that rejects un-named expressions (e.g. `Pg.lower(u.email)` — use `.as(\"x\")`) with a pointed compile-time error.
- **Set-returning functions as joinable `Relation`s.** `Pg.generateSeries` (2- and 3-arg int forms) and `Pg.unnestAsRelation` (the Relation counterpart to the expression-level `Pg.unnest` that already existed). Render as `func(args) AS "alias"("col")` in FROM position; slot into any JOIN / LATERAL flow through the same `AsRelation` typeclass Tables/Views use.

Also threads a runtime `nullable` flag through `TypedColumn` so projected relations with nullable inner columns don't get re-wrapped to `Option[Option[_]]` when subsequently LEFT/RIGHT/FULL joined.

## Test plan

- [x] `sbt core/test` — all 236 core unit tests pass (5 new `SrfSuite` + 5 new projected-alias tests in `JoinSuite`).
- [x] `sbt tests/testOnly skunk.sharp.tests.ArraysSuite skunk.sharp.tests.JoinSuite` — all 21 integration tests pass (2 new SRF round-trips in `ArraysSuite`, 1 new projected-LATERAL round-trip in `JoinSuite`).
- [x] `SBT_TPOLECAT_CI=1 sbt compile Test/compile` — clean under CI flags.
- [x] `sbt scalafmtCheckAll` — clean.
- [x] `sbt iron/test refined/test circe/test` — all companion modules still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)