### PR TITLE
UpdateBuilder.patch — subset named-tuple update (closes #39)

### DIFF
--- a/modules/core/src/main/scala/skunk/sharp/dsl/Update.scala
+++ b/modules/core/src/main/scala/skunk/sharp/dsl/Update.scala
@@ -1,10 +1,14 @@
 package skunk.sharp.dsl
 
-import skunk.{AppliedFragment, Codec}
+import skunk.{AppliedFragment, Codec, Fragment}
 import skunk.sharp.*
-import skunk.sharp.internal.tupleCodec
+import skunk.sharp.internal.{tupleCodec, CompileChecks}
 import skunk.sharp.pg.PgTypeFor
 import skunk.sharp.where.{&&, Where}
+import skunk.util.Origin
+
+import scala.NamedTuple
+import scala.compiletime.constValueTuple
 
 /**
  * UPDATE builder — compile-time staged so you can't accidentally run a rowset-nuking `UPDATE` with no WHERE.
@@ -30,7 +34,7 @@ import skunk.sharp.where.{&&, Where}
  *
  * Future (v0.1+): `FROM`/`USING`, `.set` that accepts a subset named tuple, richer RHS expressions.
  */
-final class UpdateBuilder[Cols <: Tuple] private[sharp] (table: Table[Cols, ?]) {
+final class UpdateBuilder[Cols <: Tuple] private[sharp] (private[sharp] val table: Table[Cols, ?]) {
 
   /**
    * Declare the SET list. Accepts one [[SetAssignment]] or a tuple of them. Must be followed by `.where` or
@@ -45,6 +49,57 @@ final class UpdateBuilder[Cols <: Tuple] private[sharp] (table: Table[Cols, ?]) 
     new UpdateWithSet[Cols](table, assignments)
   }
 
+  /**
+   * Subset-named-tuple UPDATE — each field is `Option[ColumnType]`, and only the `Some` fields hit the SET list. The
+   * shape mirrors `insert`'s subset-named-tuple form: field names are a compile-time-checked subset of the table's
+   * columns, each value's Scala type must match `Option[<column's declared type>]`. Unlike INSERT, there's no "required
+   * columns must be covered" check — that's exactly why `patch` exists.
+   *
+   *   - `(email = Some("new@x"), age = None)` — set `email`, leave `age` alone.
+   *   - For a nullable column (`deleted_at: Option[OffsetDateTime]`), the patch field has type
+   *     `Option[Option[OffsetDateTime]]`: `None` = leave alone, `Some(None)` = set to NULL, `Some(Some(ts))` = set to
+   *     `ts`.
+   *
+   * Runtime check: if every field is `None`, throws — an empty SET list is always a mistake, and Postgres would reject
+   * the SQL.
+   */
+  inline def patch[R <: NamedTuple.AnyNamedTuple](p: R): UpdateWithSet[Cols] = {
+    CompileChecks.requireAllNamesInCols[Cols, NamedTuple.Names[R]]
+    CompileChecks.requirePatchValueTypes[Cols, NamedTuple.Names[R], NamedTuple.DropNames[R]]
+    val names  = constValueTuple[NamedTuple.Names[R]].toList.asInstanceOf[List[String]]
+    val values = p.asInstanceOf[Tuple].toList
+    buildPatch(table, names, values)
+  }
+
+}
+
+/**
+ * Runtime half of [[UpdateBuilder.patch]]. Lives outside the class so it isn't re-generated per inlining. Walks
+ * `(name, value)` pairs, drops the `None`s, and turns each `Some(v)` into a [[SetAssignment]] via the column's own
+ * codec — no `PgTypeFor` lookup needed (column already carries its codec).
+ */
+private[sharp] def buildPatch[Cols <: Tuple](
+  table: Table[Cols, ?],
+  names: List[String],
+  values: List[Any]
+): UpdateWithSet[Cols] = {
+  val allCols                             = table.columns.toList.asInstanceOf[List[Column[?, ?, ?, ?]]]
+  val byName                              = allCols.iterator.map(c => c.name.toString -> c).toMap
+  val assignments: List[SetAssignment[?]] =
+    names.zip(values).collect { case (n, Some(v)) =>
+      val col      = byName(n)
+      val codec    = col.codec.asInstanceOf[Codec[Any]]
+      val rowFrag  = Fragment(List(Right(codec.sql)), codec, Origin.unknown)
+      val rendered = rowFrag(v)
+      val expr     = TypedExpr(rendered, codec)
+      val tc       = TypedColumn.of(col.asInstanceOf[Column[Any, "x", Boolean, Tuple]])
+      SetAssignment[Any](tc, expr)
+    }
+  if (assignments.isEmpty)
+    throw new IllegalArgumentException(
+      "skunk-sharp: .patch(...) produced an empty SET list — every field was None. Postgres rejects UPDATE without SET; provide at least one Some(...)."
+    )
+  new UpdateWithSet[Cols](table, assignments)
 }
 
 /**

--- a/modules/core/src/main/scala/skunk/sharp/internal/CompileChecks.scala
+++ b/modules/core/src/main/scala/skunk/sharp/internal/CompileChecks.scala
@@ -105,6 +105,23 @@ object CompileChecks {
     }
 
   /**
+   * Patch-specific value-type check. Each `Vs`-element must be `Option[ColumnType[Cols, n]]` — the outer `Option` lets
+   * the caller mark the field as "leave alone" (`None`) or "set to this value" (`Some(...)`). For a nullable column
+   * whose Scala type is already `Option[X]`, the patch field is therefore `Option[Option[X]]`: `Some(None)` explicitly
+   * sets to NULL; `Some(Some(x))` sets to `x`.
+   */
+  inline def requirePatchValueTypes[Cols <: Tuple, Ns <: Tuple, Vs <: Tuple]: Unit =
+    inline erasedValue[Ns] match {
+      case _: EmptyTuple => ()
+      case _: (n *: ns)  =>
+        inline erasedValue[Vs] match {
+          case _: (v *: vs) =>
+            summonInline[v <:< Option[skunk.sharp.ColumnType[Cols, n & String & Singleton]]]
+            requirePatchValueTypes[Cols, ns, vs]
+        }
+    }
+
+  /**
    * Assert that the column name `N` is NOT already declared in `Cols`. Used by `Table.builder`'s `.column` /
    * `.columnOpt` / `.columnDefaulted` / `.columnOptDefaulted` to catch accidental typos that would otherwise silently
    * add a second column of the same name (e.g. `.column[UUID]("id") … .column[String]("id")`).

--- a/modules/core/src/test/scala/skunk/sharp/dsl/MutationsSuite.scala
+++ b/modules/core/src/test/scala/skunk/sharp/dsl/MutationsSuite.scala
@@ -120,4 +120,94 @@ class MutationsSuite extends munit.FunSuite {
       """DELETE FROM "users" WHERE "id" = $1 RETURNING "id", "email", "age", "created_at", "deleted_at""""
     )
   }
+
+  // ---- .patch ---------------------------------------------------------------------------------
+
+  test(".patch — only the Some fields reach the SET list, Nones are dropped") {
+    val id = UUID.fromString("00000000-0000-0000-0000-000000000001")
+    val af = users.update
+      .patch((email = Some("new@x"), age = None, deleted_at = None))
+      .where(u => u.id === id)
+      .compile.af
+
+    assertEquals(af.fragment.sql, """UPDATE "users" SET "email" = $1 WHERE "id" = $2""")
+  }
+
+  test(".patch — multiple Somes render in the order the named tuple lists them") {
+    val id = UUID.fromString("00000000-0000-0000-0000-000000000001")
+    val af = users.update
+      .patch((email = Some("x"), age = Some(42)))
+      .where(u => u.id === id)
+      .compile.af
+
+    assertEquals(af.fragment.sql, """UPDATE "users" SET "email" = $1, "age" = $2 WHERE "id" = $3""")
+  }
+
+  test(".patch — nullable column: Some(None) sets to NULL, Some(Some(v)) sets to v") {
+    val ts      = OffsetDateTime.parse("2024-01-01T00:00:00Z")
+    val id      = UUID.fromString("00000000-0000-0000-0000-000000000001")
+    val afClear = users.update
+      .patch((deleted_at = Some(Option.empty[OffsetDateTime])))
+      .where(u => u.id === id)
+      .compile.af
+    assertEquals(afClear.fragment.sql, """UPDATE "users" SET "deleted_at" = $1 WHERE "id" = $2""")
+
+    val afSet = users.update
+      .patch((deleted_at = Some(Some(ts))))
+      .where(u => u.id === id)
+      .compile.af
+    assertEquals(afSet.fragment.sql, """UPDATE "users" SET "deleted_at" = $1 WHERE "id" = $2""")
+  }
+
+  test(".patch with all-None throws at runtime — empty SET list is a user error") {
+    val id = UUID.fromString("00000000-0000-0000-0000-000000000001")
+    intercept[IllegalArgumentException] {
+      users.update
+        .patch((email = Option.empty[String], age = Option.empty[Int]))
+        .where(u => u.id === id)
+        .compile
+    }
+  }
+
+  test(".patch rejects unknown field names at compile time") {
+    val errs = compiletime.testing.typeCheckErrors("""
+      import skunk.sharp.dsl.*
+      val users = Table.of[MutationsSuite.User]("users")
+      users.update.patch((unknown_field = Some(1))).updateAll
+    """)
+    assert(errs.nonEmpty, "expected compile error for unknown field")
+  }
+
+  test(".patch rejects wrong value type at compile time") {
+    // age: Int → patch value must be Option[Int]. Passing Option[String] is a compile error.
+    val errs = compiletime.testing.typeCheckErrors("""
+      import skunk.sharp.dsl.*
+      val users = Table.of[MutationsSuite.User]("users")
+      users.update.patch((age = Some("not-an-int"))).updateAll
+    """)
+    assert(errs.nonEmpty, "expected compile error for wrong value type")
+  }
+
+  test(".patch on a nullable column rejects a single-wrapped Some — you need Some(Some(v))") {
+    // deleted_at: Option[OffsetDateTime] → patch value must be Option[Option[OffsetDateTime]]. A bare
+    // Some(ts: OffsetDateTime) would be Some[OffsetDateTime] which isn't a subtype of Option[Option[OffsetDateTime]].
+    val errs = compiletime.testing.typeCheckErrors("""
+      import skunk.sharp.dsl.*
+      import java.time.OffsetDateTime
+      val users = Table.of[MutationsSuite.User]("users")
+      val ts    = OffsetDateTime.parse("2024-01-01T00:00:00Z")
+      users.update.patch((deleted_at = Some(ts))).updateAll
+    """)
+    assert(errs.nonEmpty, "expected compile error for single-wrapped Some on a nullable column")
+  }
+
+  test(".patch chains into .returning*") {
+    val id = UUID.fromString("00000000-0000-0000-0000-000000000001")
+    val af = users.update
+      .patch((email = Some("new@x")))
+      .where(u => u.id === id)
+      .returning(u => u.email)
+      .compile.af
+    assert(af.fragment.sql.endsWith(""" RETURNING "email""""), af.fragment.sql)
+  }
 }

--- a/modules/tests/src/test/scala/skunk/sharp/tests/UpdateDeleteReturningSuite.scala
+++ b/modules/tests/src/test/scala/skunk/sharp/tests/UpdateDeleteReturningSuite.scala
@@ -65,6 +65,65 @@ class UpdateDeleteReturningSuite extends PgFixture {
     }
   }
 
+  test(".patch updates only the Some fields and leaves untouched fields unchanged") {
+    withContainers { containers =>
+      session(containers).use { s =>
+        val id = UUID.randomUUID
+        for {
+          _ <- users.insert((
+            id = id,
+            email = "patch-init@x",
+            age = 20,
+            created_at = OffsetDateTime.now(),
+            deleted_at = None
+          )).compile.run(s)
+          // Patch the email; leave age alone.
+          _ <- users.update
+            .patch((email = Some("patch-new@x"), age = Option.empty[Int]))
+            .where(u => u.id === id)
+            .compile.run(s)
+          row <- users.select.where(u => u.id === id).compile.unique(s)
+          _ = assertEquals(row.email, "patch-new@x")
+          _ = assertEquals(row.age, 20) // untouched
+          _ = assertEquals(row.deleted_at, Option.empty[OffsetDateTime])
+        } yield ()
+      }
+    }
+  }
+
+  test(".patch on a nullable column: Some(None) writes NULL, Some(Some(v)) writes v") {
+    withContainers { containers =>
+      session(containers).use { s =>
+        val id = UUID.randomUUID
+        val ts = OffsetDateTime.parse("2024-06-01T00:00:00Z")
+        val no = Option.empty[OffsetDateTime]
+        for {
+          _ <- users.insert((
+            id = id,
+            email = "patch-null@x",
+            age = 30,
+            created_at = OffsetDateTime.now(),
+            deleted_at = Some(ts) // starts with a value set
+          )).compile.run(s)
+          // Set to NULL via Some(None)
+          _ <- users.update
+            .patch((deleted_at = Some(no)))
+            .where(u => u.id === id)
+            .compile.run(s)
+          after1 <- users.select.where(u => u.id === id).compile.unique(s)
+          _ = assertEquals(after1.deleted_at, no)
+          // Now restore to a value via Some(Some(v))
+          _ <- users.update
+            .patch((deleted_at = Some(Some(ts))))
+            .where(u => u.id === id)
+            .compile.run(s)
+          after2 <- users.select.where(u => u.id === id).compile.unique(s)
+          _ = assertEquals(after2.deleted_at, Some(ts))
+        } yield ()
+      }
+    }
+  }
+
   test("DELETE ... RETURNING yields the deleted row values") {
     withContainers { containers =>
       session(containers).use { s =>


### PR DESCRIPTION
## Summary

Partial-update shorthand on \`UpdateBuilder\`: pass a named tuple whose fields are a subset of the table's columns and whose value types are \`Option[ColumnType]\`. Only the \`Some\` fields make it into the SET list; \`None\` fields are skipped entirely — no per-row rewriting, no \`COALESCE\` games.

\`\`\`scala
users.update
  .patch((email = Some(\"x\"), age = None))
  .where(u => u.id === id)
  .compile.run(session)
\`\`\`

Nullable columns compose naturally: \`deleted_at: Option[OffsetDateTime]\` wants \`Option[Option[OffsetDateTime]]\` on the patch side — \`Some(None)\` writes NULL, \`Some(Some(ts))\` writes \`ts\`, \`None\` leaves alone.

Compile-time gates (same trio as insert):
- \`AllNamesInCols\` — unknown field names fail at compile time.
- \`requirePatchValueTypes\` (new) — each field \`<:< Option[ColumnType[N]]\`.
- No \`CoversRequired\` check — patch is explicitly for subset updates.

Runtime gate: all-\`None\` patches throw \`IllegalArgumentException\` — an empty SET list is always a mistake, and Postgres rejects the SQL.

Closes #39.

## Test plan

- [x] 8 new core unit tests in \`MutationsSuite\` — SQL shape, nullable Some/None/Some(None) handling, empty-patch throw, all three compile-time rejections (unknown name, wrong type, single-wrapped Some on nullable).
- [x] 2 new integration round-trips in \`UpdateDeleteReturningSuite\` — patch only-somes leaves untouched fields unchanged; nullable column write-then-restore cycle.
- [x] \`SBT_TPOLECAT_CI=1 sbt core/test\` — 260 tests pass.
- [x] \`sbt scalafmtCheckAll\` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)