### PR TITLE
CASE WHEN + lit(String) for compile-time string literals (closes #26)

### DIFF
--- a/modules/core/src/main/scala/skunk/sharp/dsl/CaseExpr.scala
+++ b/modules/core/src/main/scala/skunk/sharp/dsl/CaseExpr.scala
@@ -1,0 +1,72 @@
+package skunk.sharp.dsl
+
+import skunk.Codec
+import skunk.sharp.TypedExpr
+import skunk.sharp.where.Where
+
+/**
+ * `CASE WHEN … THEN … [ELSE …] END` — the universal conditional primitive. Usable in SELECT projections, WHERE, ORDER
+ * BY, UPDATE SET right-hand sides, GROUP BY — anywhere a [[TypedExpr]] is accepted.
+ *
+ * {{{
+ *   caseWhen(u.age < 18, lit("minor"))
+ *     .when(u.age < 65, lit("adult"))
+ *     .otherwise(lit("senior"))        // TypedExpr[String]
+ * }}}
+ *
+ * Terminate with either `.otherwise(elseBranch)` (returns `TypedExpr[T]`) or `.end` (returns `TypedExpr[Option[T]]` —
+ * Postgres returns NULL when no branch matches and there's no ELSE).
+ *
+ * We ship only the **searched** form (arbitrary boolean per branch). SQL also has a **simple** switch-style form (`CASE
+ * target WHEN v1 THEN … END`) but it's strict sugar — `CASE target WHEN v THEN b END` is exactly
+ * `CASE WHEN target = v THEN b END`, and Postgres plans them identically. One verb keeps the DSL surface small.
+ *
+ * The branch output type `T` is inferred from the first `(condition, branch)` pair; subsequent `.when(..., b)` calls
+ * require `b: TypedExpr[T]`. A mismatched branch is a plain Scala type error — no match type needed.
+ *
+ * CASE is a SQL keyword-expression, not a function, so the entry point `caseWhen` lives at the top of the DSL surface
+ * (`import skunk.sharp.dsl.*`) alongside `lit` / `param` / `Table`, rather than under `Pg.…`.
+ */
+final class CaseWhen[T] private[sharp] (
+  private val branches: List[(Where, TypedExpr[T])],
+  private val branchCodec: Codec[T]
+) {
+
+  /** Append another `WHEN` branch. Branch type must match the first branch's `T`. */
+  def when(cond: Where, branch: TypedExpr[T]): CaseWhen[T] =
+    new CaseWhen[T](branches :+ (cond, branch), branchCodec)
+
+  /** `ELSE <branch> END` — all paths covered, result is always a value of `T`. */
+  def otherwise(branch: TypedExpr[T]): TypedExpr[T] =
+    renderCaseWhen[T](branches, Some(branch), branchCodec)
+
+  /** `END` without an ELSE — Postgres returns NULL when no branch matches, so result is `Option[T]`. */
+  def end: TypedExpr[Option[T]] =
+    renderCaseWhen[Option[T]](
+      branches.map { case (c, b) =>
+        (c, TypedExpr(b.render, b.codec.asInstanceOf[Codec[T]]).asInstanceOf[TypedExpr[Option[T]]])
+      },
+      None,
+      branchCodec.opt
+    )
+
+}
+
+private def renderCaseWhen[R](
+  branches: List[(Where, TypedExpr[?])],
+  elseOpt: Option[TypedExpr[?]],
+  codec0: Codec[R]
+): TypedExpr[R] =
+  TypedExpr(
+    {
+      val head      = TypedExpr.raw("CASE")
+      val whenParts = branches.foldLeft(head) { case (acc, (cond, br)) =>
+        acc |+|
+          TypedExpr.raw(" WHEN ") |+| cond.render |+|
+          TypedExpr.raw(" THEN ") |+| br.render
+      }
+      val withElse = elseOpt.fold(whenParts)(e => whenParts |+| TypedExpr.raw(" ELSE ") |+| e.render)
+      withElse |+| TypedExpr.raw(" END")
+    },
+    codec0
+  )

--- a/modules/core/src/main/scala/skunk/sharp/dsl/package.scala
+++ b/modules/core/src/main/scala/skunk/sharp/dsl/package.scala
@@ -158,4 +158,18 @@ package object dsl {
 
   def param[T](v: T)(using pf: PgTypeFor[T]): skunk.sharp.TypedExpr[T] = skunk.sharp.TypedExpr.parameterised(v)
 
+  // ---- CASE expression ----
+  //
+  // `CASE WHEN … THEN … [ELSE …] END` is a SQL *keyword-expression*, not a function, so the entry point lives here at
+  // the top of the DSL alongside `lit` / `param` rather than under `Pg.…`. Only the searched form (one boolean per
+  // branch) is exposed — SQL's simple switch-style `CASE target WHEN v THEN …` is strict sugar for
+  // `CASE WHEN target = v THEN …` and adds no expressiveness.
+
+  /**
+   * Start a `CASE`. Each branch has its own boolean predicate. The first branch's `branch: TypedExpr[T]` pins the
+   * output type; later `.when`s must agree.
+   */
+  def caseWhen[T](cond: skunk.sharp.where.Where, branch: skunk.sharp.TypedExpr[T]): CaseWhen[T] =
+    new CaseWhen[T](List((cond, branch)), branch.codec)
+
 }

--- a/modules/core/src/main/scala/skunk/sharp/litMacro.scala
+++ b/modules/core/src/main/scala/skunk/sharp/litMacro.scala
@@ -5,8 +5,8 @@ import skunk.sharp.pg.PgTypeFor
 import scala.quoted.{Expr, Quotes, Type}
 
 /**
- * Compile-time machinery behind [[TypedExpr.lit]]. **Literal-only**: the argument must be a compile-time primitive
- * constant (`Boolean`, `Int`, `Long`, `Short`, `Byte`, `Float`, `Double`). Anything else — runtime variables, strings,
+ * Compile-time machinery behind [[TypedExpr.lit]]. **Literal-only**: the argument must be a compile-time constant
+ * (`Boolean`, `Int`, `Long`, `Short`, `Byte`, `Float`, `Double`, or `String`). Anything else — runtime variables,
  * UUIDs, timestamps, arrays, refined / tag types, user-defined — is a compile error pointing at the available
  * alternatives:
  *
@@ -16,9 +16,10 @@ import scala.quoted.{Expr, Quotes, Type}
  *     when you need a `TypedExpr[T]` from a runtime value in a position no operator handles (e.g. an RHS passed to a
  *     non-operator extension).
  *
- * `lit` means "render as a literal in the SQL text". Falling through to a bound parameter would defeat the point — and
- * for Strings specifically would either be a SQL-injection footgun or confusing (inlining vs parameterising the same
- * value decided by type alone). Strict semantics → one error, two clean alternatives.
+ * `lit` means "render as a literal in the SQL text". **String literals are safe** here because they are compile-time
+ * constants lifted from source code, never runtime input — the macro refuses runtime `String` variables, which is what
+ * would cause injection. The rendered form is the SQL-standard single-quoted literal with embedded `'` doubled
+ * (`'it''s'`). Use [[skunk.sharp.dsl.param]] for any runtime-derived String.
  *
  * Implementation: pattern-match on the argument's `Term` tree for `Literal(*Constant(v))` shapes, after walking through
  * `Inlined` / `Block(Nil, …)` / `Typed` wrappers that `inline def` forwarding can introduce. Emits a pointed
@@ -36,14 +37,18 @@ private[sharp] object litMacro {
 
     def reject: Expr[TypedExpr[T]] =
       report.errorAndAbort(
-        "skunk-sharp: `lit(v)` requires `v` to be a compile-time primitive literal " +
-          "(Boolean / Int / Long / Short / Byte / Float / Double). " +
+        "skunk-sharp: `lit(v)` requires `v` to be a compile-time literal " +
+          "(Boolean / Int / Long / Short / Byte / Float / Double / String). " +
           "For runtime values, the WHERE operators (`col === v`, `col < v`, `col.in(xs)`, `col.contains(xs)`, `col.like(p)`, …) " +
           "take their RHS directly and parameterise it as `$N`. " +
           "Use `skunk.sharp.dsl.param(v)` only when you explicitly need a `TypedExpr[T]` from a runtime value in a position " +
           "no operator handles.",
         value.asTerm.pos
       )
+
+    // SQL single-quoted string literal, standard `'` → `''` escape. Compile-time-constant inputs only, so there's no
+    // injection vector — the source-code identity of `v` is the same as the rendered SQL.
+    def sqlStringLiteral(s: String): String = s"'${s.replace("'", "''")}'"
 
     // `inline def` forwarding wraps the argument in `Inlined(…)` nodes; the literal we want is nested inside. Walk
     // through all layers (plus blocks with empty statements, which the inline expander can introduce) to the
@@ -65,6 +70,7 @@ private[sharp] object litMacro {
       case Literal(ByteConstant(v))    => rendered(v.toString)
       case Literal(FloatConstant(v))   => rendered(TypedExpr.renderFloat(v))
       case Literal(DoubleConstant(v))  => rendered(TypedExpr.renderDouble(v))
+      case Literal(StringConstant(v))  => rendered(sqlStringLiteral(v))
       case _                           => reject
     }
   }

--- a/modules/core/src/test/scala/skunk/sharp/NegativeTestsSuite.scala
+++ b/modules/core/src/test/scala/skunk/sharp/NegativeTestsSuite.scala
@@ -558,17 +558,32 @@ class NegativeTestsSuite extends munit.FunSuite {
     assert(errs.nonEmpty, "lit of a runtime variable should be rejected")
     val msg = errs.map(_.message).mkString("\n")
     assert(
-      msg.contains("compile-time primitive literal"),
+      msg.contains("compile-time literal"),
       s"error should mention the literal-only rule; got: $msg"
     )
     assert(msg.contains("param"), s"error should suggest `param` as the runtime escape hatch; got: $msg")
   }
 
-  test("lit(\"string literal\") is rejected — strings always parameterise for SQL-injection safety") {
+  test("lit(\"string literal\") compiles — compile-time strings are safe to inline") {
     val errs = typeCheckErrors("""
       import skunk.sharp.dsl.*
-      lit("hello")
+      val e = lit("hello")
     """)
-    assert(errs.nonEmpty, "lit of a string is rejected (compile-time literal or not)")
+    assert(errs.isEmpty, s"lit of a String literal should compile; got: ${errs.map(_.message).mkString("\n")}")
+  }
+
+  test("lit(runtimeString) is still rejected — only compile-time String constants inline safely") {
+    val errs = typeCheckErrors("""
+      import skunk.sharp.dsl.*
+      val s: String = "hello"
+      lit(s)
+    """)
+    assert(errs.nonEmpty, "lit of a runtime String should be rejected")
+  }
+
+  test("lit(String) renders the SQL single-quoted literal with `'` doubled") {
+    import skunk.sharp.dsl.*
+    val af = lit("it's").render
+    assertEquals(af.fragment.sql, "'it''s'")
   }
 }

--- a/modules/core/src/test/scala/skunk/sharp/dsl/CaseWhenSuite.scala
+++ b/modules/core/src/test/scala/skunk/sharp/dsl/CaseWhenSuite.scala
@@ -1,0 +1,83 @@
+package skunk.sharp.dsl
+
+import skunk.sharp.dsl.*
+
+import java.time.OffsetDateTime
+import java.util.UUID
+
+object CaseWhenSuite {
+  case class User(id: UUID, email: String, age: Int, created_at: OffsetDateTime)
+}
+
+class CaseWhenSuite extends munit.FunSuite {
+  import CaseWhenSuite.User
+
+  private val users = Table.of[User]("users")
+
+  test("caseWhen with .otherwise renders CASE WHEN … THEN … ELSE … END") {
+    val af = users.select(u =>
+      caseWhen(u.age < 18, lit("minor"))
+        .when(u.age < 65, lit("adult"))
+        .otherwise(lit("senior"))
+    ).compile.af
+
+    assertEquals(
+      af.fragment.sql,
+      """SELECT CASE WHEN "age" < $1 THEN 'minor' WHEN "age" < $2 THEN 'adult' ELSE 'senior' END FROM "users""""
+    )
+  }
+
+  test("caseWhen with only .end — no ELSE, result decodes as Option[T]") {
+    val q: CompiledQuery[Option[String]] = users.select(u =>
+      caseWhen(u.age < 18, lit("minor")).end
+    ).compile
+
+    assertEquals(
+      q.af.fragment.sql,
+      """SELECT CASE WHEN "age" < $1 THEN 'minor' END FROM "users""""
+    )
+  }
+
+  test("caseWhen usable in WHERE — renders as a boolean expression at the filter") {
+    val af = users.select(u => u.email)
+      .where(u =>
+        caseWhen(u.age < 18, lit(false))
+          .otherwise(lit(true))
+      )
+      .compile.af
+
+    assert(af.fragment.sql.contains("""WHERE CASE WHEN "age" < $1 THEN FALSE ELSE TRUE END"""), af.fragment.sql)
+  }
+
+  test("caseWhen usable in ORDER BY") {
+    val af = users.select(u => u.email)
+      .orderBy(u =>
+        caseWhen(u.age < 18, lit(0)).otherwise(lit(1)).asc
+      )
+      .compile.af
+
+    assert(af.fragment.sql.contains("""ORDER BY CASE WHEN "age" < $1 THEN 0 ELSE 1 END ASC"""), af.fragment.sql)
+  }
+
+  test("mismatched branch types fail at compile time") {
+    val errs = compiletime.testing.typeCheckErrors("""
+      import skunk.sharp.dsl.*
+      val users = Table.of[CaseWhenSuite.User]("users")
+      users.select(u =>
+        caseWhen(u.age < 18, lit("minor"))
+          .when(u.age < 65, lit(42))   // Int branch against a String-typed case
+          .otherwise(lit("senior"))
+      )
+    """)
+    assert(errs.nonEmpty, "expected compile error for mismatched branch types")
+  }
+
+  test(".end decoded type IS Option[T], .otherwise is T") {
+    // Type-level assertion — no runtime content needed.
+    val withElse: CompiledQuery[String] =
+      users.select(u => caseWhen(u.age < 18, lit("a")).otherwise(lit("b"))).compile
+    val withoutElse: CompiledQuery[Option[String]] =
+      users.select(u => caseWhen(u.age < 18, lit("a")).end).compile
+    val _ = (withElse, withoutElse)
+  }
+}

--- a/modules/tests/src/test/scala/skunk/sharp/tests/DslRoundTripSuite.scala
+++ b/modules/tests/src/test/scala/skunk/sharp/tests/DslRoundTripSuite.scala
@@ -140,6 +140,71 @@ class DslRoundTripSuite extends PgFixture {
     }
   }
 
+  test("searched CASE WHEN in a projection — buckets users by age") {
+    withContainers { containers =>
+      session(containers).use { s =>
+        val tag = "case-w"
+        val no  = Option.empty[OffsetDateTime]
+        val now = OffsetDateTime.now()
+        for {
+          _ <- users.insert.values(
+            (id = UUID.randomUUID, email = s"u1-$tag@x", age = 10, created_at = now, deleted_at = no),
+            (id = UUID.randomUUID, email = s"u2-$tag@x", age = 30, created_at = now, deleted_at = no),
+            (id = UUID.randomUUID, email = s"u3-$tag@x", age = 80, created_at = now, deleted_at = no)
+          ).compile.run(s)
+          rows <- users
+            .select(u =>
+              (
+                u.email,
+                caseWhen(u.age < 18, lit("minor"))
+                  .when(u.age < 65, lit("adult"))
+                  .otherwise(lit("senior"))
+              )
+            )
+            .where(u => u.email.like(s"u%-$tag@x"))
+            .compile.run(s).map(_.toSet)
+          _ = assertEquals(
+            rows,
+            Set[(String, String)](
+              (s"u1-$tag@x", "minor"),
+              (s"u2-$tag@x", "adult"),
+              (s"u3-$tag@x", "senior")
+            )
+          )
+        } yield ()
+      }
+    }
+  }
+
+  test("CASE WHEN in ORDER BY — custom sort priority by email prefix") {
+    withContainers { containers =>
+      session(containers).use { s =>
+        val tag = "case-o"
+        val no  = Option.empty[OffsetDateTime]
+        val now = OffsetDateTime.now()
+        for {
+          _ <- users.insert.values(
+            (id = UUID.randomUUID, email = s"b-$tag@x", age = 1, created_at = now, deleted_at = no),
+            (id = UUID.randomUUID, email = s"a-$tag@x", age = 2, created_at = now, deleted_at = no),
+            (id = UUID.randomUUID, email = s"c-$tag@x", age = 3, created_at = now, deleted_at = no)
+          ).compile.run(s)
+          // Sort so that 'a-…' comes first, then 'b-…', then everything else.
+          out <- users
+            .select(u => u.email)
+            .where(u => u.email.like(s"%-$tag@x"))
+            .orderBy(u =>
+              caseWhen(u.email === s"a-$tag@x", lit(0))
+                .when(u.email === s"b-$tag@x", lit(1))
+                .otherwise(lit(2))
+                .asc
+            )
+            .compile.run(s)
+          _ = assertEquals(out, List(s"a-$tag@x", s"b-$tag@x", s"c-$tag@x"))
+        } yield ()
+      }
+    }
+  }
+
   test("select against a view works; mutations would not compile") {
     withContainers { containers =>
       session(containers).use { s =>


### PR DESCRIPTION
## Summary

Two changes landing together because they're intertwined in usage:

1. **`caseWhen(cond, branch).when(cond2, branch2).otherwise(elseBranch)`** — the universal conditional primitive, as a top-level DSL verb (not \`Pg.…\`, since CASE is a SQL keyword-expression rather than a function). Terminate with \`.otherwise\` for a total \`TypedExpr[T]\`, or \`.end\` for a partial \`TypedExpr[Option[T]]\`.

   Only the **searched** form is exposed — SQL's simple switch-style \`CASE target WHEN v THEN …\` is strict sugar for \`CASE WHEN target = v THEN …\`, plans identically, and adds no expressiveness. One verb keeps the DSL surface small.

   Branch output type \`T\` is inferred from the first branch; later \`.when(..., b)\` calls require \`b: TypedExpr[T]\` (plain Scala type error on mismatch).

2. **\`lit(v)\` now accepts compile-time \`String\` literals**, rendering as SQL single-quoted literals with \`'\` → \`''\` escaped. Compile-time \`String\` constants come from source code and are safe to inline; runtime \`String\` variables stay rejected. This makes \`caseWhen(…, lit(\"minor\"))\` read naturally instead of forcing \`param(...)\` everywhere.

Closes #26.

## Test plan

- [x] 6 new core unit tests in \`CaseWhenSuite\` — SQL rendering (with/without ELSE), use in WHERE/ORDER BY, type mismatch rejection, \`.end\` → \`Option[T]\` / \`.otherwise\` → \`T\` at the type level.
- [x] 2 new integration round-trips in \`DslRoundTripSuite\` — age-bucket projection and custom-priority ORDER BY via CASE.
- [x] \`NegativeTestsSuite\` updated: String literal now compiles; runtime String still rejected; new test pins the \`'\`-escape rendering.
- [x] \`SBT_TPOLECAT_CI=1 sbt core/test\` — 268 tests pass.
- [x] \`sbt scalafmtCheckAll\` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)