### PR TITLE
expr"..." interpolator, Param.list[T](n), and Param.bind purge from Pg* helpers

### DIFF
--- a/modules/core/src/main/scala/skunk/sharp/Interpolator.scala
+++ b/modules/core/src/main/scala/skunk/sharp/Interpolator.scala
@@ -1,0 +1,40 @@
+package skunk.sharp
+
+/**
+ * `expr"..."` — a typed SQL string interpolator that weaves literal SQL with [[TypedExpr]] interpolations,
+ * producing a [[RawExprBuilder]] you commit to a result type via `.as[T]` / `.asCodec(codec)` /
+ * `.asCodec(e: TypedExpr[T, ?])`.
+ *
+ * **Static-by-default**: every interpolation must be a `TypedExpr` — column refs, `Param[T]` (deferred),
+ * `lit(v)` (compile-time literal), or `Param.bind(v)` (explicit bake). Bare runtime values are rejected at
+ * compile time, mirroring the `=== / := / between / like` operators. This forces the caller to make the
+ * binding decision explicit.
+ *
+ * Each interpolation contributes its `Args` slot to the result; the visible `Args` type is the smart-flat
+ * concat over every slot (see `Where.FoldConcat`), matching how every other typed-args builder folds N
+ * inputs.
+ *
+ * Use `.asCodec(e)` (passing one of the spliced TypedExprs) to reuse that expression's exact codec — the
+ * common shape for tag-preserving function helpers — instead of writing `.asCodec(e.codec)`.
+ *
+ * {{{
+ *   val ageGte18: TypedExpr[Boolean, Int] =
+ *     expr"$ageCol >= ${Param[Int]}".as[Boolean]
+ *
+ *   val emailLike: TypedExpr[Boolean, Void] =
+ *     expr"$emailCol LIKE ${lit("%@example.com")}".as[Boolean]
+ *
+ *   // Reuse a column's exact codec for tag-preserving function calls
+ *   val upperEmail: TypedExpr[String, Void] =
+ *     expr"upper($emailCol)".asCodec(emailCol)
+ * }}}
+ *
+ * **Inline-def usage caveat**: Scala 3 `transparent inline` doesn't refine return types in inline-def
+ * bodies, so `expr"…"` cannot replace function helpers like `lpad`/`rpad` whose abstract type vars need to
+ * thread through the chained `.asCodec(...)` call. Use `expr"…"` in concrete user code; for
+ * variadic-typed function helpers in extension modules, build the expression manually (the existing
+ * `PgFunction.unary`/`binary`/`naryTypedFold` substrate is the right tool there).
+ */
+extension (inline sc: StringContext)
+  transparent inline def expr(inline args: Any*): RawExprBuilder[?] =
+    ${ skunk.sharp.internal.ExprMacro.impl('sc, 'args) }

--- a/modules/core/src/main/scala/skunk/sharp/Param.scala
+++ b/modules/core/src/main/scala/skunk/sharp/Param.scala
@@ -45,6 +45,37 @@ object Param {
   def of[T](codec: Codec[T]): Param[T] = new Param[T](codec)
 
   /**
+   * A `Param[List[T]]` for a fixed-size list — useful for `IN` lists where you want **one** prepared
+   * statement per size and a single `List[T]` bind at execute time, instead of N separate `Param.bind`s
+   * baked at builder-build time.
+   *
+   * {{{
+   *   val byIds = users.select.where(u => u.id.in(Param.list[UUID](3))).compile
+   *   //                                                  ^ size known at compile time
+   *   // val _: QueryTemplate[List[UUID], User] = byIds
+   *   byIds.run(session)(List(uid1, uid2, uid3))
+   * }}}
+   *
+   * The result fragment expands to N comma-separated `$N` placeholders sharing one prepared statement.
+   * Bind a list of exactly `size` elements at execute time — skunk raises if the list length disagrees.
+   *
+   * For lists whose size varies between calls, either rebuild the query per size (different prepared
+   * statement each time) or reach for `col === ANY(Param[Arr[T]])` (single statement, single array bind).
+   */
+  def list[T](size: Int)(using pf: PgTypeFor[T]): Param[List[T]] = {
+    val inner = pf.codec
+    val enc   = inner.list(size)
+    val codec: Codec[List[T]] = new Codec[List[T]] {
+      override def encode(xs: List[T]): List[Option[skunk.data.Encoded]] = enc.encode(xs)
+      override def decode(offset: Int, ss: List[Option[String]]): Either[skunk.Decoder.Error, List[T]] =
+        Left(skunk.Decoder.Error(offset, size, "Param.list[T] is bind-only — IN-list parameters can't appear in a SELECT projection."))
+      override val types: List[skunk.data.Type] = enc.types
+      override val sql: cats.data.State[Int, String] = enc.sql
+    }
+    Param.of(codec)
+  }
+
+  /**
    * Bake a runtime value into a `TypedExpr[T, Void]` — the value is fixed at construction time, not supplied at
    * execute. This is what the value-taking operator overloads (`=== v`, `>= v`, …) call internally; you rarely need it
    * directly unless you are constructing a dynamic expression outside the built-in operators.

--- a/modules/core/src/main/scala/skunk/sharp/RawExprBuilder.scala
+++ b/modules/core/src/main/scala/skunk/sharp/RawExprBuilder.scala
@@ -1,0 +1,31 @@
+package skunk.sharp
+
+import skunk.{Codec, Fragment}
+import skunk.sharp.pg.PgTypeFor
+
+/**
+ * Intermediate stage of the [[expr]] string interpolator. The interpolator weaves the literal SQL parts and the
+ * `$col` / `$value` interpolations into a single typed `Fragment[Args]`, but does not know the Scala type the
+ * resulting expression decodes to. Callers commit a result type via either [[as]] (resolves `PgTypeFor[T]`'s
+ * canonical codec) or [[asCodec]] (explicit `Codec[T]` — useful when reusing an input expression's codec, e.g.
+ * `expr"lower($e)".asCodec(e.codec)`).
+ */
+final class RawExprBuilder[Args](val fragment: Fragment[Args]) {
+
+  /** Commit the result type as `T`, resolving the codec via `PgTypeFor[T]`. */
+  def as[T](using pf: PgTypeFor[T]): TypedExpr[T, Args] =
+    TypedExpr(fragment, pf.codec)
+
+  /** Commit the result type as `T` with an explicit `Codec[T]`. */
+  def asCodec[T](codec: Codec[T]): TypedExpr[T, Args] =
+    TypedExpr(fragment, codec)
+
+  /**
+   * Commit the result type as `T`, reusing an existing `TypedExpr`'s codec. The common shape for tag- /
+   * type-preserving functions where the result codec is the input expression's codec — replaces
+   * `.asCodec(e.codec)` with `.asCodec(e)`.
+   */
+  def asCodec[T](e: TypedExpr[T, ?]): TypedExpr[T, Args] =
+    TypedExpr(fragment, e.codec)
+
+}

--- a/modules/core/src/main/scala/skunk/sharp/internal/ExprMacro.scala
+++ b/modules/core/src/main/scala/skunk/sharp/internal/ExprMacro.scala
@@ -1,0 +1,195 @@
+package skunk.sharp.internal
+
+import skunk.{Encoder, Fragment, Void}
+import skunk.sharp.{RawExprBuilder, TypedExpr}
+import skunk.sharp.where.Where
+import skunk.util.Origin
+
+import scala.quoted.*
+
+/**
+ * Macro behind the `expr"..."` interpolator (see [[skunk.sharp.expr]]).
+ *
+ * The job is exactly: concatenate the literal SQL pieces from the `StringContext` with each interpolated
+ * [[TypedExpr]]'s `fragment.parts`, threading their `Args` slots through `Where.FoldConcat`. No value-baking,
+ * no parameter wrapping — every interpolation must already be a `TypedExpr` (column ref, `Param[T]`,
+ * `lit(v)`, …). Literal SQL pieces show up as `Left(s)` entries in the assembled `Fragment.parts`; arg
+ * fragments contribute their own parts (which may carry `Right(state)` placeholders for `Param[T]`).
+ */
+private[sharp] object ExprMacro {
+
+  def impl(sc: Expr[StringContext], args: Expr[Seq[Any]])(using Quotes): Expr[RawExprBuilder[?]] = {
+    import quotes.reflect.*
+
+    // Decode the StringContext literal parts (compile-time strings).
+    val literalParts: List[String] = sc match {
+      case '{ StringContext(${ Varargs(Exprs(parts)) }*) } => parts.toList
+      case _                                               =>
+        report.errorAndAbort(
+          "skunk-sharp: `expr` interpolator literal parts must be compile-time strings.",
+          sc
+        )
+    }
+
+    val argExprs: List[Expr[Any]] = args match {
+      case Varargs(es) => es.toList
+      case _           =>
+        report.errorAndAbort("skunk-sharp: `expr` interpolator could not decode interpolated args.", args)
+    }
+
+    if (literalParts.size != argExprs.size + 1)
+      report.errorAndAbort(
+        s"skunk-sharp: `expr` interpolator parts/args arity mismatch " +
+          s"(parts=${literalParts.size}, args=${argExprs.size})."
+      )
+
+    // Per arg: (its Args TypeRepr, the Expr[Fragment[?]] to splice). `TypedExpr` is invariant, so we check
+    // class hierarchy via `baseClasses`. We also `simplified` the term type to reduce match-type aliases
+    // (e.g. `NamedTuple.Elem[…, 1]` for a column field access on a `ColumnsView` lambda parameter), then
+    // coerce via a `Typed` wrapper so the splice's `.fragment` projection sees the concrete `TypedExpr` type.
+    val typedExprSym = TypeRepr.of[TypedExpr[Any, Any]].typeSymbol
+    val argSlots: List[(TypeRepr, Expr[Fragment[?]])] = argExprs.map { argExpr =>
+      val widened = argExpr.asTerm.tpe.widen.dealias.simplified
+
+      if (widened.baseClasses.contains(typedExprSym)) {
+        widened.baseType(typedExprSym) match {
+          case AppliedType(_, List(tArgT, aTpe)) =>
+            tArgT.asType match {
+              case '[t] =>
+                aTpe.asType match {
+                  case '[a] =>
+                    val coercedTerm = Typed(argExpr.asTerm, TypeTree.of[TypedExpr[t, a]])
+                    val coerced     = coercedTerm.asExprOf[TypedExpr[t, a]]
+                    val frag        = '{ $coerced.fragment }
+                    (aTpe, frag.asExprOf[Fragment[?]])
+                }
+            }
+          case other =>
+            report.errorAndAbort(
+              s"skunk-sharp: `expr` interpolator could not extract TypedExpr's Args parameter from " +
+                s"${widened.show} (got ${other.show}).",
+              argExpr
+            )
+        }
+      } else {
+        // Static-by-default: every interpolation must be a `TypedExpr`. Raw runtime values are rejected —
+        // callers wrap explicitly with `lit(v)` / `Param[T]` / `Param.bind(v)`, mirroring every other DSL
+        // operator position.
+        report.errorAndAbort(
+          s"skunk-sharp: `expr` interpolator argument has type ${widened.show}. Wrap it explicitly: " +
+            s"`lit(v)` for a compile-time literal, `Param[T]` for an execute-time parameter, or " +
+            s"`Param.bind(v)` to bake a runtime value into a Void-args fragment now.",
+          argExpr
+        )
+      }
+    }
+
+    // Build the per-arg `Args` tuple `(A1, A2, …, An)` — no `Void` padding for literal SQL pieces; literals
+    // are plain `Left(s)` strings in the final `Fragment.parts` and don't contribute to the encoder.
+    val starCtr: TypeRepr = TypeRepr.of[Int *: EmptyTuple] match {
+      case AppliedType(tc, _) => tc
+      case other              =>
+        report.errorAndAbort(s"skunk-sharp: could not recover *: type constructor from ${other.show}")
+    }
+
+    val tupTpe: TypeRepr = {
+      val emptyT = TypeRepr.of[EmptyTuple]
+      argSlots.map(_._1).foldRight(emptyT)((h, t) => starCtr.appliedTo(List(h, t)))
+    }
+
+    // Pre-compute the visible `Args` type at macro time so the `transparent inline` return type is fully
+    // resolved at the call site (otherwise the abstract `t` would leak as `Nothing`). NOTE: we do *not*
+    // call `.simplified` here — when `tupTpe` contains abstract type variables (e.g. inside an outer
+    // generic helper body), simplifying `FoldConcat[A *: EmptyTuple]` re-enters match-type reduction with
+    // unreducible scrutinees and the compiler can spin. The unreduced application is already correct; the
+    // call-site expansion will reduce it once `A` is concrete.
+    val argsTpe: TypeRepr =
+      TypeRepr.of[Where.FoldConcat].appliedTo(tupTpe)
+
+    val argFragsExpr: Expr[List[Fragment[?]]] = Expr.ofList(argSlots.map(_._2))
+    val literalsExpr: Expr[List[String]]      = Expr.ofList(literalParts.map(Expr(_)))
+
+    tupTpe.asType match {
+      case '[tup] =>
+        argsTpe.asType match {
+          case '[args] =>
+            '{
+              ExprMacroRuntime.assemble[tup & Tuple, args]($literalsExpr, $argFragsExpr) match {
+                case frag => new RawExprBuilder[args](frag)
+              }
+            }
+        }
+    }
+  }
+
+}
+
+/**
+ * Runtime helpers used by `expr"..."`-emitted code. Lives in a regular object so the assembly + encoder
+ * construction don't get duplicated at every inline call site.
+ */
+object ExprMacroRuntime {
+
+  /**
+   * Direct concatenation: `literals(0)`, then for each `i`, `argFrags(i).parts ++ literals(i+1)`. The
+   * resulting `Fragment.parts` is exactly the user's SQL with each interpolated `TypedExpr`'s parts spliced
+   * in — including any `$N` placeholders the args carry. The encoder folds the args' encoders into one
+   * that consumes a `Where.FoldConcat[Tup]` value and emits each arg's encoded bytes in render order.
+   */
+  inline def assemble[Tup <: Tuple, Args](
+    literals: List[String],
+    argFrags: List[Fragment[?]]
+  ): Fragment[Args] = {
+    val parts: List[Either[String, cats.data.State[Int, String]]] = {
+      val buf = scala.collection.mutable.ListBuffer.empty[Either[String, cats.data.State[Int, String]]]
+      val head = literals.head
+      if (head.nonEmpty) buf += Left(head)
+      argFrags.zip(literals.tail).foreach { case (f, lit) =>
+        buf ++= f.parts
+        if (lit.nonEmpty) buf += Left(lit)
+      }
+      buf.toList
+    }
+    val projector: Args => List[Any] = c =>
+      Where.projectFoldConcat[Tup](c.asInstanceOf[Where.FoldConcat[Tup]])
+    val enc = buildEncoder[Args](argFrags, projector)
+    Fragment(parts, enc, Origin.unknown)
+  }
+
+  /**
+   * Build an encoder that consumes the user-facing `Args` value (a flat tuple, scalar, or `Void`), walks
+   * `argFrags` in render order, and for each non-`Void` slot delegates to its arg's encoder. The projector
+   * is materialised at the inline call site so `Where.projectFoldConcat[Tup]` reduces with the concrete
+   * tuple shape; this method itself is a non-inline def so the anonymous `Encoder` class isn't duplicated
+   * at every interpolation site.
+   */
+  private[sharp] def buildEncoder[Args](
+    argFrags: List[Fragment[?]],
+    projector: Args => List[Any]
+  ): Encoder[Args] = new Encoder[Args] {
+    override val types: List[skunk.data.Type] = argFrags.flatMap(_.encoder.types)
+
+    override val sql: cats.data.State[Int, String] =
+      cats.data.State { (n0: Int) =>
+        argFrags.foldLeft((n0, "")) { case ((n, acc), f) =>
+          val (n1, s) = f.encoder.sql.run(n).value
+          (n1, acc + s)
+        }
+      }
+
+    override def encode(combined: Args): List[Option[skunk.data.Encoded]] = {
+      val values = projector(combined)
+      if (values.size != argFrags.size)
+        throw new IllegalStateException(
+          s"skunk-sharp: `expr` interpolator encoder arity mismatch — " +
+            s"got ${values.size} projected values, expected ${argFrags.size}."
+        )
+      argFrags.zip(values).flatMap { case (f, v) =>
+        val e = f.encoder.asInstanceOf[Encoder[Any]]
+        if (e eq Void.codec) Nil
+        else e.encode(v)
+      }
+    }
+  }
+
+}

--- a/modules/core/src/main/scala/skunk/sharp/ops/ExprOps.scala
+++ b/modules/core/src/main/scala/skunk/sharp/ops/ExprOps.scala
@@ -1,8 +1,7 @@
 package skunk.sharp.ops
 
 import skunk.{Fragment, Void}
-import skunk.sharp.{Param, TypedExpr}
-import skunk.sharp.pg.PgTypeFor
+import skunk.sharp.TypedExpr
 import skunk.sharp.where.Where
 import skunk.util.Origin
 
@@ -178,13 +177,19 @@ object InRhs {
 
   type Aux[T, Rhs, A0] = InRhs[T, Rhs] { type RA = A0 }
 
-  given reducibleIn[T, F[_]](using R: cats.Reducible[F], pf: PgTypeFor[T]): InRhs.Aux[T, F[T], Void] =
-    new InRhs[T, F[T]] {
+  /**
+   * `lhs IN (e1, e2, …)` over a non-empty `Reducible` of typed expressions. Each item must be a
+   * `TypedExpr[T, Void]` — pass `lit(v)` (compile-time literal), `Param.bind(v)` (bake runtime value), or any
+   * other Void-args expression. For execute-time-deferred lists, prefer `lhs === ANY(Param[Arr[T]])` (see
+   * [[skunk.sharp.pg.ArrayOps.elemOf]]) — `IN` with multiple `Param[T]` would require N execute-time slots
+   * which the API doesn't model.
+   */
+  given reducibleIn[T, F[_]](using R: cats.Reducible[F]): InRhs.Aux[T, F[TypedExpr[T, Void]], Void] =
+    new InRhs[T, F[TypedExpr[T, Void]]] {
       type RA = Void
-      def renderParens(values: F[T]): Fragment[Void] = {
-        val literals = R.toNonEmptyList(values).toList.map(v => Param.bind[T](v).fragment)
-        // Combine all literal fragments via combineSepInl with ", " separator; wrap in parens.
-        val joined = literals.reduceLeft((a, b) =>
+      def renderParens(values: F[TypedExpr[T, Void]]): Fragment[Void] = {
+        val frags = R.toNonEmptyList(values).toList.map(_.fragment)
+        val joined = frags.reduceLeft((a, b) =>
           TypedExpr.combineSepInl[Void, Void](a, ", ", b).asInstanceOf[Fragment[Void]]
         )
         TypedExpr.wrap("(", joined, ")")
@@ -198,6 +203,18 @@ object InRhs {
         val inner: Fragment[A] = ev.fragment(q)
         TypedExpr.wrap("(", inner, ")")
       }
+    }
+
+  /**
+   * `lhs IN (listExpr)` where `listExpr` is a `Param[List[T]]` (built via [[skunk.sharp.Param.list]]) —
+   * expands to N comma-separated `$N` placeholders and binds a single `List[T]` at execute time. Single
+   * prepared statement per size; sidesteps the `Param.bind`-per-element pattern.
+   */
+  given paramListIn[T]: InRhs.Aux[T, skunk.sharp.Param[List[T]], List[T]] =
+    new InRhs[T, skunk.sharp.Param[List[T]]] {
+      type RA = List[T]
+      def renderParens(p: skunk.sharp.Param[List[T]]): Fragment[List[T]] =
+        TypedExpr.wrap("(", p.fragment, ")")
     }
 
 }

--- a/modules/core/src/main/scala/skunk/sharp/pg/functions/PgAggregate.scala
+++ b/modules/core/src/main/scala/skunk/sharp/pg/functions/PgAggregate.scala
@@ -1,7 +1,7 @@
 package skunk.sharp.pg.functions
 
 import skunk.{Fragment, Void}
-import skunk.sharp.{Param, TypedExpr}
+import skunk.sharp.TypedExpr
 import skunk.sharp.pg.PgTypeFor
 import skunk.sharp.where.Where
 
@@ -39,15 +39,7 @@ trait PgAggregate {
   def min[T, A](expr: TypedExpr[T, A]): TypedExpr[T, A] = sameTypeFn("min", expr)
   def max[T, A](expr: TypedExpr[T, A]): TypedExpr[T, A] = sameTypeFn("max", expr)
 
-  /** `string_agg(expr, sep)` — sep is a runtime value baked via Param.bind. */
-  def stringAgg[T, A](expr: TypedExpr[T, A], sep: String)(using ev: StrLike[T], pfs: PgTypeFor[String]): TypedExpr[String, A] = {
-    val sepFrag = Param.bind[String](sep).fragment
-    val inner   = TypedExpr.combineSep(expr.fragment, ", ", sepFrag, _.asInstanceOf[(A, Void)])
-    val frag    = TypedExpr.wrap("string_agg(", inner.asInstanceOf[Fragment[A]], ")")
-    TypedExpr[String, A](frag, skunk.codec.all.text)
-  }
-
-  /** `string_agg` taking a TypedExpr separator (Param[String], lit, etc.) — Args propagate from both. */
+  /** `string_agg(expr, sep)` — Args propagate from both. */
   def stringAgg[T, A, B](expr: TypedExpr[T, A], sep: TypedExpr[String, B])(using
     StrLike[T]
   ): TypedExpr[String, Where.Concat[A, B]] = {

--- a/modules/core/src/main/scala/skunk/sharp/pg/functions/PgArray.scala
+++ b/modules/core/src/main/scala/skunk/sharp/pg/functions/PgArray.scala
@@ -1,9 +1,8 @@
 package skunk.sharp.pg.functions
 
-import skunk.Fragment
 import skunk.codec.all as pg
 import skunk.data.Arr
-import skunk.sharp.{Param, TypedExpr}
+import skunk.sharp.TypedExpr
 import skunk.sharp.pg.{IsArray, PgTypeFor}
 import skunk.sharp.where.Where
 
@@ -13,13 +12,13 @@ import skunk.sharp.where.Where
  */
 trait PgArray {
 
-  def arrayLength[A, X](a: TypedExpr[A, X], dim: Int = 1)(using @annotation.unused ev: IsArray[A]): TypedExpr[Option[Int], X] = {
-    val parts = a.fragment.parts ++ List[Either[String, cats.data.State[Int, String]]](Left(s", $dim)"))
-    val frag  = Fragment[X](
-      List[Either[String, cats.data.State[Int, String]]](Left("array_length(")) ++ parts,
-      a.fragment.encoder, skunk.util.Origin.unknown
-    )
-    TypedExpr[Option[Int], X](frag, pg.int4.opt)
+  inline def arrayLength[A, X, Y](
+    a:   TypedExpr[A, X],
+    dim: TypedExpr[Int, Y]
+  )(using @annotation.unused ev: IsArray[A]): TypedExpr[Option[Int], Where.Concat[X, Y]] = {
+    val inner = TypedExpr.combineSepInl[X, Y](a.fragment, ", ", dim.fragment)
+    val frag  = TypedExpr.wrap("array_length(", inner, ")")
+    TypedExpr(frag, pg.int4.opt)
   }
 
   def cardinality[A, X](a: TypedExpr[A, X])(using @annotation.unused ev: IsArray[A]): TypedExpr[Int, X] = {
@@ -83,31 +82,33 @@ trait PgArray {
     TypedExpr[A, skunk.Void](frag, a.codec)
   }
 
-  def arrayToString[A, X](a: TypedExpr[A, X], sep: String)(using
-    @annotation.unused ev: IsArray[A], pfs: PgTypeFor[String]
-  ): TypedExpr[String, X] = {
-    val sepFrag = Param.bind[String](sep).fragment
-    val s1      = TypedExpr.combineSep(a.fragment, ", ", sepFrag, _.asInstanceOf[(X, skunk.Void)]).asInstanceOf[Fragment[X]]
-    val frag    = TypedExpr.wrap("array_to_string(", s1, ")")
-    TypedExpr[String, X](frag, pg.text)
+  inline def arrayToString[A, X, Y](
+    a:   TypedExpr[A, X],
+    sep: TypedExpr[String, Y]
+  )(using @annotation.unused ev: IsArray[A]): TypedExpr[String, Where.Concat[X, Y]] = {
+    val inner = TypedExpr.combineSepInl[X, Y](a.fragment, ", ", sep.fragment)
+    val frag  = TypedExpr.wrap("array_to_string(", inner, ")")
+    TypedExpr(frag, pg.text)
   }
 
-  def arrayToString[A, X](a: TypedExpr[A, X], sep: String, nullStr: String)(using
-    @annotation.unused ev: IsArray[A], pfs: PgTypeFor[String]
-  ): TypedExpr[String, X] = {
-    val sepFrag  = Param.bind[String](sep).fragment
-    val nullFrag = Param.bind[String](nullStr).fragment
-    val s1       = TypedExpr.combineSep(a.fragment, ", ", sepFrag, _.asInstanceOf[(X, skunk.Void)]).asInstanceOf[Fragment[X]]
-    val s2       = TypedExpr.combineSep(s1, ", ", nullFrag, _.asInstanceOf[(X, skunk.Void)]).asInstanceOf[Fragment[X]]
-    val frag     = TypedExpr.wrap("array_to_string(", s2, ")")
-    TypedExpr[String, X](frag, pg.text)
-  }
+  import skunk.sharp.PgFunction
 
-  def stringToArray[X](s: TypedExpr[String, X], sep: String)(using pfs: PgTypeFor[String]): TypedExpr[Arr[String], X] = {
-    val sepFrag = Param.bind[String](sep).fragment
-    val s1      = TypedExpr.combineSep(s.fragment, ", ", sepFrag, _.asInstanceOf[(X, skunk.Void)]).asInstanceOf[Fragment[X]]
-    val frag    = TypedExpr.wrap("string_to_array(", s1, ")")
-    TypedExpr[Arr[String], X](frag, pg._text)
+  inline def arrayToString[A, X, Y, Z](
+    a:       TypedExpr[A, X],
+    sep:     TypedExpr[String, Y],
+    nullStr: TypedExpr[String, Z]
+  )(using @annotation.unused ev: IsArray[A]): TypedExpr[String, Where.FoldConcat[X *: Y *: Z *: EmptyTuple]] =
+    PgFunction.naryTypedFold[String, X *: Y *: Z *: EmptyTuple](
+      "array_to_string", List(a.fragment, sep.fragment, nullStr.fragment), pg.text
+    )
+
+  inline def stringToArray[X, Y](
+    s:   TypedExpr[String, X],
+    sep: TypedExpr[String, Y]
+  ): TypedExpr[Arr[String], Where.Concat[X, Y]] = {
+    val inner = TypedExpr.combineSepInl[X, Y](s.fragment, ", ", sep.fragment)
+    val frag  = TypedExpr.wrap("string_to_array(", inner, ")")
+    TypedExpr(frag, pg._text)
   }
 
   def arrayAgg[T, X](expr: TypedExpr[T, X])(using pf: PgTypeFor[Arr[T]]): TypedExpr[Arr[T], X] = {

--- a/modules/core/src/main/scala/skunk/sharp/pg/functions/PgNull.scala
+++ b/modules/core/src/main/scala/skunk/sharp/pg/functions/PgNull.scala
@@ -1,7 +1,7 @@
 package skunk.sharp.pg.functions
 
-import skunk.{Fragment, Void}
-import skunk.sharp.{Param, PgFunction, TypedExpr}
+import skunk.Void
+import skunk.sharp.{PgFunction, TypedExpr}
 import skunk.sharp.pg.PgTypeFor
 import skunk.sharp.ops.Stripped
 import skunk.sharp.where.Where
@@ -116,17 +116,14 @@ trait PgNull {
       pf.codec
     )
 
-  /**
-   * `nullif(a, b)` — returns NULL if `a = b`, else `a`. `b` is a runtime value baked via [[Param.bind]];
-   * Args of the result equals Args of `a`.
-   */
-  inline def nullif[T, A](a: TypedExpr[T, A], b: Stripped[T])(using
-    pf: PgTypeFor[Stripped[T]]
-  ): TypedExpr[Option[Stripped[T]], A] = {
-    val bFrag = Param.bind[Stripped[T]](b)(using pf).fragment
-    val inner = TypedExpr.combineSepInl[A, Void](a.fragment, ", ", bFrag).asInstanceOf[Fragment[A]]
+  /** `nullif(a, b)` — returns NULL if `a = b`, else `a`. */
+  inline def nullif[T, A1, A2](
+    a: TypedExpr[T, A1],
+    b: TypedExpr[Stripped[T], A2]
+  )(using pf: PgTypeFor[Stripped[T]]): TypedExpr[Option[Stripped[T]], Where.Concat[A1, A2]] = {
+    val inner = TypedExpr.combineSepInl[A1, A2](a.fragment, ", ", b.fragment)
     val frag  = TypedExpr.wrap("nullif(", inner, ")")
-    TypedExpr[Option[Stripped[T]], A](frag, pf.codec.opt)
+    TypedExpr(frag, pf.codec.opt)
   }
 
 }

--- a/modules/core/src/main/scala/skunk/sharp/pg/functions/PgNumeric.scala
+++ b/modules/core/src/main/scala/skunk/sharp/pg/functions/PgNumeric.scala
@@ -1,6 +1,6 @@
 package skunk.sharp.pg.functions
 
-import skunk.{Fragment, Void}
+import skunk.Void
 import skunk.sharp.{PgFunction, TypedExpr}
 import skunk.sharp.pg.PgTypeFor
 import skunk.sharp.where.Where
@@ -20,14 +20,13 @@ trait PgNumeric {
   def round[T, A](e: TypedExpr[T, A]): TypedExpr[T, A] = sameTypeFn("round", e)
 
   /** `round(x, digits)` — Postgres defines this only for `numeric`. */
-  def round[T, A](e: TypedExpr[T, A], digits: Int): TypedExpr[T, A] = {
-    val parts = e.fragment.parts ++ List[Either[String, cats.data.State[Int, String]]](Left(s", $digits)"))
-    val frag  = Fragment[A](
-      List[Either[String, cats.data.State[Int, String]]](Left("round(")) ++ parts,
-      e.fragment.encoder,
-      skunk.util.Origin.unknown
-    )
-    TypedExpr[T, A](frag, e.codec)
+  inline def round[T, A1, A2](
+    e:      TypedExpr[T, A1],
+    digits: TypedExpr[Int, A2]
+  ): TypedExpr[T, Where.Concat[A1, A2]] = {
+    val inner = TypedExpr.combineSepInl[A1, A2](e.fragment, ", ", digits.fragment)
+    val frag  = TypedExpr.wrap("round(", inner, ")")
+    TypedExpr(frag, e.codec)
   }
 
   /** `mod(a, b)` — both arms typed; combined Args. */

--- a/modules/core/src/main/scala/skunk/sharp/pg/functions/PgRange.scala
+++ b/modules/core/src/main/scala/skunk/sharp/pg/functions/PgRange.scala
@@ -1,9 +1,8 @@
 package skunk.sharp.pg.functions
 
 
-import skunk.{Fragment, Void}
 import skunk.codec.all as pg
-import skunk.sharp.{Param, TypedExpr}
+import skunk.sharp.{PgFunction, TypedExpr}
 import skunk.sharp.pg.{IsRange, PgTypeFor}
 import skunk.sharp.pg.tags.PgRange as PgRangeTag
 import skunk.sharp.where.Where
@@ -46,37 +45,55 @@ trait PgRangeFns {
     pf: PgTypeFor[PgRangeTag[Int]]
   ): TypedExpr[PgRangeTag[Int], Where.Concat[X, Y]] = rangeCtor2("int4range", lo, hi, pf.codec)
 
-  inline def int4range[X, Y](lo: TypedExpr[Int, X], hi: TypedExpr[Int, Y], bounds: String)(using pf: PgTypeFor[PgRangeTag[Int]], pfs: PgTypeFor[String]): TypedExpr[PgRangeTag[Int], Where.Concat[X, Y]] = rangeCtor3("int4range", lo, hi, bounds, pf.codec)
+  inline def int4range[X, Y, Z](lo: TypedExpr[Int, X], hi: TypedExpr[Int, Y], bounds: TypedExpr[String, Z])(using
+    pf: PgTypeFor[PgRangeTag[Int]]
+  ): TypedExpr[PgRangeTag[Int], Where.FoldConcat[X *: Y *: Z *: EmptyTuple]] =
+    rangeCtor3("int4range", lo, hi, bounds, pf.codec)
 
   inline def int8range[X, Y](lo: TypedExpr[Long, X], hi: TypedExpr[Long, Y])(using
     pf: PgTypeFor[PgRangeTag[Long]]
   ): TypedExpr[PgRangeTag[Long], Where.Concat[X, Y]] = rangeCtor2("int8range", lo, hi, pf.codec)
 
-  inline def int8range[X, Y](lo: TypedExpr[Long, X], hi: TypedExpr[Long, Y], bounds: String)(using pf: PgTypeFor[PgRangeTag[Long]], pfs: PgTypeFor[String]): TypedExpr[PgRangeTag[Long], Where.Concat[X, Y]] = rangeCtor3("int8range", lo, hi, bounds, pf.codec)
+  inline def int8range[X, Y, Z](lo: TypedExpr[Long, X], hi: TypedExpr[Long, Y], bounds: TypedExpr[String, Z])(using
+    pf: PgTypeFor[PgRangeTag[Long]]
+  ): TypedExpr[PgRangeTag[Long], Where.FoldConcat[X *: Y *: Z *: EmptyTuple]] =
+    rangeCtor3("int8range", lo, hi, bounds, pf.codec)
 
   inline def numrange[X, Y](lo: TypedExpr[BigDecimal, X], hi: TypedExpr[BigDecimal, Y])(using
     pf: PgTypeFor[PgRangeTag[BigDecimal]]
   ): TypedExpr[PgRangeTag[BigDecimal], Where.Concat[X, Y]] = rangeCtor2("numrange", lo, hi, pf.codec)
 
-  inline def numrange[X, Y](lo: TypedExpr[BigDecimal, X], hi: TypedExpr[BigDecimal, Y], bounds: String)(using pf: PgTypeFor[PgRangeTag[BigDecimal]], pfs: PgTypeFor[String]): TypedExpr[PgRangeTag[BigDecimal], Where.Concat[X, Y]] = rangeCtor3("numrange", lo, hi, bounds, pf.codec)
+  inline def numrange[X, Y, Z](lo: TypedExpr[BigDecimal, X], hi: TypedExpr[BigDecimal, Y], bounds: TypedExpr[String, Z])(using
+    pf: PgTypeFor[PgRangeTag[BigDecimal]]
+  ): TypedExpr[PgRangeTag[BigDecimal], Where.FoldConcat[X *: Y *: Z *: EmptyTuple]] =
+    rangeCtor3("numrange", lo, hi, bounds, pf.codec)
 
   inline def daterange[X, Y](lo: TypedExpr[LocalDate, X], hi: TypedExpr[LocalDate, Y])(using
     pf: PgTypeFor[PgRangeTag[LocalDate]]
   ): TypedExpr[PgRangeTag[LocalDate], Where.Concat[X, Y]] = rangeCtor2("daterange", lo, hi, pf.codec)
 
-  inline def daterange[X, Y](lo: TypedExpr[LocalDate, X], hi: TypedExpr[LocalDate, Y], bounds: String)(using pf: PgTypeFor[PgRangeTag[LocalDate]], pfs: PgTypeFor[String]): TypedExpr[PgRangeTag[LocalDate], Where.Concat[X, Y]] = rangeCtor3("daterange", lo, hi, bounds, pf.codec)
+  inline def daterange[X, Y, Z](lo: TypedExpr[LocalDate, X], hi: TypedExpr[LocalDate, Y], bounds: TypedExpr[String, Z])(using
+    pf: PgTypeFor[PgRangeTag[LocalDate]]
+  ): TypedExpr[PgRangeTag[LocalDate], Where.FoldConcat[X *: Y *: Z *: EmptyTuple]] =
+    rangeCtor3("daterange", lo, hi, bounds, pf.codec)
 
   inline def tsrange[X, Y](lo: TypedExpr[LocalDateTime, X], hi: TypedExpr[LocalDateTime, Y])(using
     pf: PgTypeFor[PgRangeTag[LocalDateTime]]
   ): TypedExpr[PgRangeTag[LocalDateTime], Where.Concat[X, Y]] = rangeCtor2("tsrange", lo, hi, pf.codec)
 
-  inline def tsrange[X, Y](lo: TypedExpr[LocalDateTime, X], hi: TypedExpr[LocalDateTime, Y], bounds: String)(using pf: PgTypeFor[PgRangeTag[LocalDateTime]], pfs: PgTypeFor[String]): TypedExpr[PgRangeTag[LocalDateTime], Where.Concat[X, Y]] = rangeCtor3("tsrange", lo, hi, bounds, pf.codec)
+  inline def tsrange[X, Y, Z](lo: TypedExpr[LocalDateTime, X], hi: TypedExpr[LocalDateTime, Y], bounds: TypedExpr[String, Z])(using
+    pf: PgTypeFor[PgRangeTag[LocalDateTime]]
+  ): TypedExpr[PgRangeTag[LocalDateTime], Where.FoldConcat[X *: Y *: Z *: EmptyTuple]] =
+    rangeCtor3("tsrange", lo, hi, bounds, pf.codec)
 
   inline def tstzrange[X, Y](lo: TypedExpr[OffsetDateTime, X], hi: TypedExpr[OffsetDateTime, Y])(using
     pf: PgTypeFor[PgRangeTag[OffsetDateTime]]
   ): TypedExpr[PgRangeTag[OffsetDateTime], Where.Concat[X, Y]] = rangeCtor2("tstzrange", lo, hi, pf.codec)
 
-  inline def tstzrange[X, Y](lo: TypedExpr[OffsetDateTime, X], hi: TypedExpr[OffsetDateTime, Y], bounds: String)(using pf: PgTypeFor[PgRangeTag[OffsetDateTime]], pfs: PgTypeFor[String]): TypedExpr[PgRangeTag[OffsetDateTime], Where.Concat[X, Y]] = rangeCtor3("tstzrange", lo, hi, bounds, pf.codec)
+  inline def tstzrange[X, Y, Z](lo: TypedExpr[OffsetDateTime, X], hi: TypedExpr[OffsetDateTime, Y], bounds: TypedExpr[String, Z])(using
+    pf: PgTypeFor[PgRangeTag[OffsetDateTime]]
+  ): TypedExpr[PgRangeTag[OffsetDateTime], Where.FoldConcat[X *: Y *: Z *: EmptyTuple]] =
+    rangeCtor3("tstzrange", lo, hi, bounds, pf.codec)
 
   // -------- Helpers -------------------------------------------------------------------------
 
@@ -95,34 +112,12 @@ trait PgRangeFns {
     TypedExpr[T, Where.Concat[X, Y]](frag, outCodec)
   }
 
-  /**
-   * Three-arg range constructor (lo, hi, bounds). `bounds` is a baked runtime String
-   * (Param.bind); Args is `Concat[X, Y]` from `lo` / `hi`.
-   */
-  private inline def rangeCtor3[T, A, B, X, Y](
-    name: String, lo: TypedExpr[A, X], hi: TypedExpr[B, Y], bounds: String, outCodec: skunk.Codec[T]
-  )(using pfs: PgTypeFor[String]): TypedExpr[T, Where.Concat[X, Y]] = {
-    val boundsFrag = Param.bind[String](bounds).fragment
-    val parts =
-      List[Either[String, cats.data.State[Int, String]]](Left(s"$name(")) ++
-        lo.fragment.parts ++
-        List[Either[String, cats.data.State[Int, String]]](Left(", ")) ++
-        hi.fragment.parts ++
-        List[Either[String, cats.data.State[Int, String]]](Left(", ")) ++
-        boundsFrag.parts ++
-        List[Either[String, cats.data.State[Int, String]]](Left(")"))
-    // lo/hi typed; bounds Void. Combine [Concat[X, Y], Void] with right-Void projection.
-    val loHiEnc      = TypedExpr.combineEnc[X, Y](
-      lo.fragment.encoder, hi.fragment.encoder, c => Where.projectConcat[X, Y](c)
+  /** Three-arg range constructor `name(lo, hi, bounds)`. */
+  private inline def rangeCtor3[T, A, B, X, Y, Z](
+    name: String, lo: TypedExpr[A, X], hi: TypedExpr[B, Y], bounds: TypedExpr[String, Z], outCodec: skunk.Codec[T]
+  ): TypedExpr[T, Where.FoldConcat[X *: Y *: Z *: EmptyTuple]] =
+    PgFunction.naryTypedFold[T, X *: Y *: Z *: EmptyTuple](
+      name, List(lo.fragment, hi.fragment, bounds.fragment), outCodec
     )
-    val withBoundsEnc =
-      TypedExpr.combineEnc[Where.Concat[X, Y], Void](
-        loHiEnc.asInstanceOf[skunk.Encoder[Where.Concat[X, Y]]],
-        boundsFrag.encoder,
-        c => (c.asInstanceOf[Where.Concat[X, Y]], Void)
-      )
-    val frag = Fragment(parts, withBoundsEnc.asInstanceOf[skunk.Encoder[Where.Concat[X, Y]]], skunk.util.Origin.unknown)
-    TypedExpr[T, Where.Concat[X, Y]](frag, outCodec)
-  }
 
 }

--- a/modules/core/src/main/scala/skunk/sharp/pg/functions/PgString.scala
+++ b/modules/core/src/main/scala/skunk/sharp/pg/functions/PgString.scala
@@ -1,14 +1,20 @@
 package skunk.sharp.pg.functions
 
-import skunk.{Fragment, Void}
-import skunk.sharp.{Param, PgFunction, TypedExpr}
+import skunk.sharp.{PgFunction, TypedExpr}
 import skunk.sharp.pg.PgTypeFor
 import skunk.sharp.where.Where
 
-/** String functions. Mixed into [[skunk.sharp.Pg]]. Args of input expression(s) propagate to result. */
+/**
+ * String functions. Mixed into [[skunk.sharp.Pg]]. Args of input expression(s) propagate to result.
+ *
+ * Every value-arg is a `TypedExpr[T, Args]`: callers pass column refs, `Param[T]` (deferred), `lit(v)`
+ * (compile-time literal), or `Param.bind(v)` (explicit bake) — same static-by-default rule the operator
+ * positions enforce. The result `Args` is the smart-flat concat over every input's `Args` (see
+ * [[Where.FoldConcat]]).
+ */
 trait PgString {
 
-  // ---- Preserve-tag (T -> T) -----------------------------------------------------------------
+  // ---- Preserve-tag, single-arg (T -> T) -------------------------------------------------------
 
   def lower[T, A](e: TypedExpr[T, A])(using StrLike[T]): TypedExpr[T, A]   = stringPreserveFn("lower",   e)
   def upper[T, A](e: TypedExpr[T, A])(using StrLike[T]): TypedExpr[T, A]   = stringPreserveFn("upper",   e)
@@ -18,105 +24,99 @@ trait PgString {
   def reverse[T, A](e: TypedExpr[T, A])(using StrLike[T]): TypedExpr[T, A] = stringPreserveFn("reverse", e)
   def initcap[T, A](e: TypedExpr[T, A])(using StrLike[T]): TypedExpr[T, A] = stringPreserveFn("initcap", e)
 
+  // ---- Tag-preserving multi-arg (T -> T) -------------------------------------------------------
+
   /** `trim(chars FROM s)`. */
-  inline def trim[T, A](e: TypedExpr[T, A], chars: String)(using ev: StrLike[T], pf: PgTypeFor[String]): TypedExpr[T, A] = {
-    val charsFrag = Param.bind[String](chars).fragment
-    val inner     = TypedExpr.combineSepInl[Void, A](charsFrag, " FROM ", e.fragment).asInstanceOf[Fragment[A]]
-    val frag      = TypedExpr.wrap("trim(", inner, ")")
-    TypedExpr[T, A](frag, e.codec)
+  inline def trim[T, A1, A2](
+    chars: TypedExpr[String, A1],
+    e:     TypedExpr[T, A2]
+  )(using StrLike[T]): TypedExpr[T, Where.Concat[A1, A2]] = {
+    val inner = TypedExpr.combineSepInl[A1, A2](chars.fragment, " FROM ", e.fragment)
+    val frag  = TypedExpr.wrap("trim(", inner, ")")
+    TypedExpr(frag, e.codec)
   }
 
-  /** `replace(s, from, to)` with runtime String args (Param.bind). */
-  inline def replace[T, A](e: TypedExpr[T, A], from: String, to: String)(using ev: StrLike[T], pf: PgTypeFor[String]): TypedExpr[T, A] = {
-    val fromFrag = Param.bind[String](from).fragment
-    val toFrag   = Param.bind[String](to).fragment
-    val s1       = TypedExpr.combineSepInl[A, Void](e.fragment, ", ", fromFrag).asInstanceOf[Fragment[A]]
-    val s2       = TypedExpr.combineSepInl[A, Void](s1, ", ", toFrag).asInstanceOf[Fragment[A]]
-    val frag     = TypedExpr.wrap("replace(", s2, ")")
-    TypedExpr[T, A](frag, e.codec)
-  }
+  /** `replace(s, from, to)`. */
+  inline def replace[T, A1, A2, A3](
+    e:    TypedExpr[T, A1],
+    from: TypedExpr[String, A2],
+    to:   TypedExpr[String, A3]
+  )(using StrLike[T]): TypedExpr[T, Where.FoldConcat[A1 *: A2 *: A3 *: EmptyTuple]] =
+    PgFunction.naryTypedFold[T, A1 *: A2 *: A3 *: EmptyTuple](
+      "replace", List(e.fragment, from.fragment, to.fragment), e.codec
+    )
 
   /** `substring(s FROM n)`. */
-  def substring[T, A](e: TypedExpr[T, A], from: Int)(using StrLike[T]): TypedExpr[T, A] = {
-    val parts = e.fragment.parts ++ List[Either[String, cats.data.State[Int, String]]](Left(s" FROM $from)"))
-    val frag  = Fragment[A](
-      List[Either[String, cats.data.State[Int, String]]](Left("substring(")) ++ parts,
-      e.fragment.encoder,
-      skunk.util.Origin.unknown
-    )
-    TypedExpr[T, A](frag, e.codec)
+  inline def substring[T, A1, A2](
+    e:    TypedExpr[T, A1],
+    from: TypedExpr[Int, A2]
+  )(using StrLike[T]): TypedExpr[T, Where.Concat[A1, A2]] = {
+    val inner = TypedExpr.combineSepInl[A1, A2](e.fragment, " FROM ", from.fragment)
+    val frag  = TypedExpr.wrap("substring(", inner, ")")
+    TypedExpr(frag, e.codec)
   }
 
   /** `substring(s FROM n FOR m)`. */
-  def substring[T, A](e: TypedExpr[T, A], from: Int, forLen: Int)(using StrLike[T]): TypedExpr[T, A] = {
-    val frag  = Fragment[A](
-      List[Either[String, cats.data.State[Int, String]]](Left("substring(")) ++ e.fragment.parts ++
-        List[Either[String, cats.data.State[Int, String]]](Left(s" FROM $from FOR $forLen)")),
-      e.fragment.encoder,
-      skunk.util.Origin.unknown
-    )
-    TypedExpr[T, A](frag, e.codec)
+  inline def substring[T, A1, A2, A3](
+    e:      TypedExpr[T, A1],
+    from:   TypedExpr[Int, A2],
+    forLen: TypedExpr[Int, A3]
+  )(using StrLike[T]): TypedExpr[T, Where.Concat[Where.Concat[A1, A2], A3]] = {
+    val ab  = TypedExpr.combineSepInl[A1, A2](e.fragment, " FROM ", from.fragment)
+    val abc = TypedExpr.combineSepInl[Where.Concat[A1, A2], A3](ab, " FOR ", forLen.fragment)
+    val frag = TypedExpr.wrap("substring(", abc, ")")
+    TypedExpr(frag, e.codec)
   }
 
   /** `left(s, n)`. */
-  def left[T, A](e: TypedExpr[T, A], n: Int)(using StrLike[T]): TypedExpr[T, A] = {
-    val frag = Fragment[A](
-      List[Either[String, cats.data.State[Int, String]]](Left("left(")) ++ e.fragment.parts ++
-        List[Either[String, cats.data.State[Int, String]]](Left(s", $n)")),
-      e.fragment.encoder,
-      skunk.util.Origin.unknown
-    )
-    TypedExpr[T, A](frag, e.codec)
+  inline def left[T, A1, A2](
+    e: TypedExpr[T, A1],
+    n: TypedExpr[Int, A2]
+  )(using StrLike[T]): TypedExpr[T, Where.Concat[A1, A2]] = {
+    val inner = TypedExpr.combineSepInl[A1, A2](e.fragment, ", ", n.fragment)
+    val frag  = TypedExpr.wrap("left(", inner, ")")
+    TypedExpr(frag, e.codec)
   }
 
   /** `right(s, n)`. */
-  def right[T, A](e: TypedExpr[T, A], n: Int)(using StrLike[T]): TypedExpr[T, A] = {
-    val frag = Fragment[A](
-      List[Either[String, cats.data.State[Int, String]]](Left("right(")) ++ e.fragment.parts ++
-        List[Either[String, cats.data.State[Int, String]]](Left(s", $n)")),
-      e.fragment.encoder,
-      skunk.util.Origin.unknown
-    )
-    TypedExpr[T, A](frag, e.codec)
+  inline def right[T, A1, A2](
+    e: TypedExpr[T, A1],
+    n: TypedExpr[Int, A2]
+  )(using StrLike[T]): TypedExpr[T, Where.Concat[A1, A2]] = {
+    val inner = TypedExpr.combineSepInl[A1, A2](e.fragment, ", ", n.fragment)
+    val frag  = TypedExpr.wrap("right(", inner, ")")
+    TypedExpr(frag, e.codec)
   }
 
   /** `repeat(s, n)`. */
-  def repeat[T, A](e: TypedExpr[T, A], n: Int)(using StrLike[T]): TypedExpr[T, A] = {
-    val frag = Fragment[A](
-      List[Either[String, cats.data.State[Int, String]]](Left("repeat(")) ++ e.fragment.parts ++
-        List[Either[String, cats.data.State[Int, String]]](Left(s", $n)")),
-      e.fragment.encoder,
-      skunk.util.Origin.unknown
-    )
-    TypedExpr[T, A](frag, e.codec)
+  inline def repeat[T, A1, A2](
+    e: TypedExpr[T, A1],
+    n: TypedExpr[Int, A2]
+  )(using StrLike[T]): TypedExpr[T, Where.Concat[A1, A2]] = {
+    val inner = TypedExpr.combineSepInl[A1, A2](e.fragment, ", ", n.fragment)
+    val frag  = TypedExpr.wrap("repeat(", inner, ")")
+    TypedExpr(frag, e.codec)
   }
 
   /** `regexp_replace(s, pattern, replacement)`. */
-  inline def regexpReplace[T, A](e: TypedExpr[T, A], pattern: String, replacement: String)(using
-    ev: StrLike[T], pf: PgTypeFor[String]
-  ): TypedExpr[T, A] = {
-    val pf1 = Param.bind[String](pattern).fragment
-    val pf2 = Param.bind[String](replacement).fragment
-    val s1  = TypedExpr.combineSepInl[A, Void](e.fragment, ", ", pf1).asInstanceOf[Fragment[A]]
-    val s2  = TypedExpr.combineSepInl[A, Void](s1, ", ", pf2).asInstanceOf[Fragment[A]]
-    val frag = TypedExpr.wrap("regexp_replace(", s2, ")")
-    TypedExpr[T, A](frag, e.codec)
-  }
+  inline def regexpReplace[T, A1, A2, A3](
+    e:           TypedExpr[T, A1],
+    pattern:     TypedExpr[String, A2],
+    replacement: TypedExpr[String, A3]
+  )(using StrLike[T]): TypedExpr[T, Where.FoldConcat[A1 *: A2 *: A3 *: EmptyTuple]] =
+    PgFunction.naryTypedFold[T, A1 *: A2 *: A3 *: EmptyTuple](
+      "regexp_replace", List(e.fragment, pattern.fragment, replacement.fragment), e.codec
+    )
 
   /** `split_part(s, delim, field)`. */
-  inline def splitPart[T, A](e: TypedExpr[T, A], delim: String, field: Int)(using
-    ev: StrLike[T], pf: PgTypeFor[String]
-  ): TypedExpr[T, A] = {
-    val delimFrag = Param.bind[String](delim).fragment
-    val s1        = TypedExpr.combineSepInl[A, Void](e.fragment, ", ", delimFrag).asInstanceOf[Fragment[A]]
-    val frag      = Fragment[A](
-      List[Either[String, cats.data.State[Int, String]]](Left("split_part(")) ++ s1.parts ++
-        List[Either[String, cats.data.State[Int, String]]](Left(s", $field)")),
-      s1.encoder,
-      skunk.util.Origin.unknown
+  inline def splitPart[T, A1, A2, A3](
+    e:     TypedExpr[T, A1],
+    delim: TypedExpr[String, A2],
+    field: TypedExpr[Int, A3]
+  )(using StrLike[T]): TypedExpr[T, Where.FoldConcat[A1 *: A2 *: A3 *: EmptyTuple]] =
+    PgFunction.naryTypedFold[T, A1 *: A2 *: A3 *: EmptyTuple](
+      "split_part", List(e.fragment, delim.fragment, field.fragment), e.codec
     )
-    TypedExpr[T, A](frag, e.codec)
-  }
 
   /** `concat(a)` — single arg; Args propagates from `a`. */
   def concat[A1](a: TypedExpr[String, A1]): TypedExpr[String, A1] = {
@@ -133,25 +133,15 @@ trait PgString {
     TypedExpr[String, Where.Concat[A1, A2]](frag, skunk.codec.all.text)
   }
 
-  /** `concat(a, b, c)` — `Args` flattens to `(A1, A2, A3)` via `Where.Concat` (Void slots dropped). */
+  /** `concat(a, b, c)` — `Args` flattens to the non-Void slots of `(A1…A3)` via `Where.FoldConcat`. */
   inline def concat[A1, A2, A3](
     a: TypedExpr[String, A1], b: TypedExpr[String, A2], c: TypedExpr[String, A3]
-  ): TypedExpr[String, Where.Concat[Where.Concat[A1, A2], A3]] = {
-    val projector: Where.Concat[Where.Concat[A1, A2], A3] => List[Any] = combined => {
-      val (a12, a3v) = Where.projectConcat[Where.Concat[A1, A2], A3](combined)
-      val (a1v, a2v) = Where.projectConcat[A1, A2](a12.asInstanceOf[Where.Concat[A1, A2]])
-      List(a1v, a2v, a3v)
-    }
-    val combined = TypedExpr.combineList[Where.Concat[Where.Concat[A1, A2], A3]](
-      List(a.fragment, b.fragment, c.fragment),
-      ", ",
-      projector
+  ): TypedExpr[String, Where.FoldConcat[A1 *: A2 *: A3 *: EmptyTuple]] =
+    PgFunction.naryTypedFold[String, A1 *: A2 *: A3 *: EmptyTuple](
+      "concat", List(a.fragment, b.fragment, c.fragment), skunk.codec.all.text
     )
-    val frag = TypedExpr.wrap("concat(", combined, ")")
-    TypedExpr[String, Where.Concat[Where.Concat[A1, A2], A3]](frag, skunk.codec.all.text)
-  }
 
-  /** `concat(a, b, c, d)` — `Args` flattens to the non-Void slots of `(A1, A2, A3, A4)` via `Where.Concat`.  */
+  /** `concat(a, b, c, d)` — `Args` flattens to the non-Void slots of `(A1…A4)` via `Where.FoldConcat`. */
   inline def concat[A1, A2, A3, A4](
     a: TypedExpr[String, A1], b: TypedExpr[String, A2], c: TypedExpr[String, A3], d: TypedExpr[String, A4]
   ): TypedExpr[String, Where.FoldConcat[A1 *: A2 *: A3 *: A4 *: EmptyTuple]] =
@@ -159,7 +149,7 @@ trait PgString {
       "concat", List(a.fragment, b.fragment, c.fragment, d.fragment), skunk.codec.all.text
     )
 
-  /** `concat(a, b, c, d, e)` — `Args` flattens to the non-Void slots of `(A1…A5)` via `Where.Concat`.  */
+  /** `concat(a, b, c, d, e)` — `Args` flattens to the non-Void slots of `(A1…A5)` via `Where.FoldConcat`. */
   inline def concat[A1, A2, A3, A4, A5](
     a: TypedExpr[String, A1], b: TypedExpr[String, A2], c: TypedExpr[String, A3],
     d: TypedExpr[String, A4], e: TypedExpr[String, A5]
@@ -168,7 +158,7 @@ trait PgString {
       "concat", List(a.fragment, b.fragment, c.fragment, d.fragment, e.fragment), skunk.codec.all.text
     )
 
-  /** `concat(a, b, c, d, e, f)` — `Args` flattens to the non-Void slots of `(A1…A6)` via `Where.Concat`.  */
+  /** `concat(a, b, c, d, e, f)` — `Args` flattens to the non-Void slots of `(A1…A6)` via `Where.FoldConcat`. */
   inline def concat[A1, A2, A3, A4, A5, A6](
     a: TypedExpr[String, A1], b: TypedExpr[String, A2], c: TypedExpr[String, A3],
     d: TypedExpr[String, A4], e: TypedExpr[String, A5], f: TypedExpr[String, A6]
@@ -179,7 +169,7 @@ trait PgString {
       skunk.codec.all.text
     )
 
-  /** `concat(a, b, c, d, e, f, g)` — `Args` flattens to the non-Void slots of `(A1…A7)` via `Where.Concat`.  */
+  /** `concat(a, b, c, d, e, f, g)` — `Args` flattens to the non-Void slots of `(A1…A7)` via `Where.FoldConcat`. */
   inline def concat[A1, A2, A3, A4, A5, A6, A7](
     a: TypedExpr[String, A1], b: TypedExpr[String, A2], c: TypedExpr[String, A3],
     d: TypedExpr[String, A4], e: TypedExpr[String, A5], f: TypedExpr[String, A6], g: TypedExpr[String, A7]
@@ -190,7 +180,7 @@ trait PgString {
       skunk.codec.all.text
     )
 
-  /** `concat(a, b, c, d, e, f, g, h)` — `Args` flattens to the non-Void slots of `(A1…A8)` via `Where.Concat`.  */
+  /** `concat(a, b, c, d, e, f, g, h)` — `Args` flattens to the non-Void slots of `(A1…A8)` via `Where.FoldConcat`. */
   inline def concat[A1, A2, A3, A4, A5, A6, A7, A8](
     a: TypedExpr[String, A1], b: TypedExpr[String, A2], c: TypedExpr[String, A3], d: TypedExpr[String, A4],
     e: TypedExpr[String, A5], f: TypedExpr[String, A6], g: TypedExpr[String, A7], h: TypedExpr[String, A8]
@@ -201,7 +191,7 @@ trait PgString {
       skunk.codec.all.text
     )
 
-  /** `concat(a, b, c, d, e, f, g, h, i)` — `Args` flattens to the non-Void slots of `(A1…A9)` via `Where.Concat`.  */
+  /** `concat(a, b, c, d, e, f, g, h, i)` — `Args` flattens to the non-Void slots of `(A1…A9)` via `Where.FoldConcat`. */
   inline def concat[A1, A2, A3, A4, A5, A6, A7, A8, A9](
     a: TypedExpr[String, A1], b: TypedExpr[String, A2], c: TypedExpr[String, A3], d: TypedExpr[String, A4],
     e: TypedExpr[String, A5], f: TypedExpr[String, A6], g: TypedExpr[String, A7],
@@ -224,90 +214,67 @@ trait PgString {
   def octetLength[T, A](e: TypedExpr[T, A])(using ev: StrLike[T], pf: PgTypeFor[Lift[T, Int]]): TypedExpr[Lift[T, Int], A] =
     stringToIntFn("octet_length", e)
 
-  /** `position(substr IN str)` — substr is runtime String; nullability tracked via Lift. */
-  inline def position[T, A](substr: String, in: TypedExpr[T, A])(using
-    ev: StrLike[T],
-    pf: PgTypeFor[Lift[T, Int]],
-    pfs: PgTypeFor[String]
-  ): TypedExpr[Lift[T, Int], A] = {
-    val substrFrag = Param.bind[String](substr).fragment
-    val s1         = TypedExpr.combineSepInl[Void, A](substrFrag, " IN ", in.fragment).asInstanceOf[Fragment[A]]
-    val frag       = TypedExpr.wrap("position(", s1, ")")
-    TypedExpr[Lift[T, Int], A](frag, pf.codec)
+  /** `position(substr IN str)` — nullability tracked via Lift on `in`. */
+  inline def position[T, A1, A2](
+    substr: TypedExpr[String, A1],
+    in:     TypedExpr[T, A2]
+  )(using ev: StrLike[T], pf: PgTypeFor[Lift[T, Int]]): TypedExpr[Lift[T, Int], Where.Concat[A1, A2]] = {
+    val inner = TypedExpr.combineSepInl[A1, A2](substr.fragment, " IN ", in.fragment)
+    val frag  = TypedExpr.wrap("position(", inner, ")")
+    TypedExpr(frag, pf.codec)
   }
 
   // ---- Tag-preserving misc -------------------------------------------------------------------
 
-  inline def translate[T, A](e: TypedExpr[T, A], from: String, to: String)(using
-    ev: StrLike[T], pf: PgTypeFor[String]
-  ): TypedExpr[T, A] = {
-    val ff = Param.bind[String](from).fragment
-    val tf = Param.bind[String](to).fragment
-    val s1 = TypedExpr.combineSepInl[A, Void](e.fragment, ", ", ff).asInstanceOf[Fragment[A]]
-    val s2 = TypedExpr.combineSepInl[A, Void](s1, ", ", tf).asInstanceOf[Fragment[A]]
-    val frag = TypedExpr.wrap("translate(", s2, ")")
-    TypedExpr[T, A](frag, e.codec)
-  }
-
-  def lpad[T, A](e: TypedExpr[T, A], n: Int)(using StrLike[T]): TypedExpr[T, A] = {
-    val frag = Fragment[A](
-      List[Either[String, cats.data.State[Int, String]]](Left("lpad(")) ++ e.fragment.parts ++
-        List[Either[String, cats.data.State[Int, String]]](Left(s", $n)")),
-      e.fragment.encoder, skunk.util.Origin.unknown)
-    TypedExpr[T, A](frag, e.codec)
-  }
-
-  /**
-   * `lpad(e, n, fill)` — `n` and `fill` are baked runtime values (Param.bind);  Args propagates
-   * from `e` only.
-   */
-  def lpad[T, A](e: TypedExpr[T, A], n: Int, fill: String)(using
-    ev: StrLike[T], pf: PgTypeFor[String]
-  ): TypedExpr[T, A] = {
-    val fillFrag = Param.bind[String](fill).fragment
-    // Build parts: lpad( | e.parts | , n, | fill.parts | )
-    val parts =
-      List[Either[String, cats.data.State[Int, String]]](Left("lpad(")) ++
-        e.fragment.parts ++
-        List[Either[String, cats.data.State[Int, String]]](Left(s", $n, ")) ++
-        fillFrag.parts ++
-        List[Either[String, cats.data.State[Int, String]]](Left(")"))
-    // Encoder: e.encoder takes A; fill encoder takes Void (baked). Combine left-Void.
-    val combinedEnc = TypedExpr.combineEnc[A, Void](
-      e.fragment.encoder, fillFrag.encoder, c => (c.asInstanceOf[A], Void)
+  /** `translate(s, from, to)`. */
+  inline def translate[T, A1, A2, A3](
+    e:    TypedExpr[T, A1],
+    from: TypedExpr[String, A2],
+    to:   TypedExpr[String, A3]
+  )(using StrLike[T]): TypedExpr[T, Where.FoldConcat[A1 *: A2 *: A3 *: EmptyTuple]] =
+    PgFunction.naryTypedFold[T, A1 *: A2 *: A3 *: EmptyTuple](
+      "translate", List(e.fragment, from.fragment, to.fragment), e.codec
     )
-    val frag        = Fragment(parts, combinedEnc.asInstanceOf[skunk.Encoder[A]], skunk.util.Origin.unknown)
-    TypedExpr[T, A](frag, e.codec)
+
+  /** `lpad(s, n)`. */
+  inline def lpad[T, A1, A2](
+    e: TypedExpr[T, A1],
+    n: TypedExpr[Int, A2]
+  )(using StrLike[T]): TypedExpr[T, Where.Concat[A1, A2]] = {
+    val inner = TypedExpr.combineSepInl[A1, A2](e.fragment, ", ", n.fragment)
+    val frag  = TypedExpr.wrap("lpad(", inner, ")")
+    TypedExpr(frag, e.codec)
   }
 
-  def rpad[T, A](e: TypedExpr[T, A], n: Int)(using StrLike[T]): TypedExpr[T, A] = {
-    val frag = Fragment[A](
-      List[Either[String, cats.data.State[Int, String]]](Left("rpad(")) ++ e.fragment.parts ++
-        List[Either[String, cats.data.State[Int, String]]](Left(s", $n)")),
-      e.fragment.encoder, skunk.util.Origin.unknown)
-    TypedExpr[T, A](frag, e.codec)
-  }
-
-  /**
-   * `rpad(e, n, fill)` — `n` and `fill` are baked runtime values (Param.bind); Args propagates
-   * from `e` only.
-   */
-  def rpad[T, A](e: TypedExpr[T, A], n: Int, fill: String)(using
-    ev: StrLike[T], pf: PgTypeFor[String]
-  ): TypedExpr[T, A] = {
-    val fillFrag = Param.bind[String](fill).fragment
-    val parts =
-      List[Either[String, cats.data.State[Int, String]]](Left("rpad(")) ++
-        e.fragment.parts ++
-        List[Either[String, cats.data.State[Int, String]]](Left(s", $n, ")) ++
-        fillFrag.parts ++
-        List[Either[String, cats.data.State[Int, String]]](Left(")"))
-    val combinedEnc = TypedExpr.combineEnc[A, Void](
-      e.fragment.encoder, fillFrag.encoder, c => (c.asInstanceOf[A], Void)
+  /** `lpad(s, n, fill)`. */
+  inline def lpad[T, A1, A2, A3](
+    e:    TypedExpr[T, A1],
+    n:    TypedExpr[Int, A2],
+    fill: TypedExpr[String, A3]
+  )(using StrLike[T]): TypedExpr[T, Where.FoldConcat[A1 *: A2 *: A3 *: EmptyTuple]] =
+    PgFunction.naryTypedFold[T, A1 *: A2 *: A3 *: EmptyTuple](
+      "lpad", List(e.fragment, n.fragment, fill.fragment), e.codec
     )
-    val frag        = Fragment(parts, combinedEnc.asInstanceOf[skunk.Encoder[A]], skunk.util.Origin.unknown)
-    TypedExpr[T, A](frag, e.codec)
+
+  /** `rpad(s, n)`. */
+  inline def rpad[T, A1, A2](
+    e: TypedExpr[T, A1],
+    n: TypedExpr[Int, A2]
+  )(using StrLike[T]): TypedExpr[T, Where.Concat[A1, A2]] = {
+    val inner = TypedExpr.combineSepInl[A1, A2](e.fragment, ", ", n.fragment)
+    val frag  = TypedExpr.wrap("rpad(", inner, ")")
+    TypedExpr(frag, e.codec)
   }
+
+  /** `rpad(s, n, fill)`. */
+  inline def rpad[T, A1, A2, A3](
+    e:    TypedExpr[T, A1],
+    n:    TypedExpr[Int, A2],
+    fill: TypedExpr[String, A3]
+  )(using StrLike[T]): TypedExpr[T, Where.FoldConcat[A1 *: A2 *: A3 *: EmptyTuple]] =
+    PgFunction.naryTypedFold[T, A1 *: A2 *: A3 *: EmptyTuple](
+      "rpad", List(e.fragment, n.fragment, fill.fragment), e.codec
+    )
 
   // ---- Fixed text return (NULL-propagating via Lift) ------------------------------------------
 
@@ -321,21 +288,26 @@ trait PgString {
     TypedExpr[Lift[T, String], A](frag, pf.codec)
   }
 
-  inline def toChar[T, A](e: TypedExpr[T, A], fmt: String)(using
-    pf: PgTypeFor[Lift[T, String]], pfs: PgTypeFor[String]
-  ): TypedExpr[Lift[T, String], A] = {
-    val fmtFrag = Param.bind[String](fmt).fragment
-    val s1      = TypedExpr.combineSepInl[A, Void](e.fragment, ", ", fmtFrag).asInstanceOf[Fragment[A]]
-    val frag    = TypedExpr.wrap("to_char(", s1, ")")
-    TypedExpr[Lift[T, String], A](frag, pf.codec)
+  /** `to_char(e, fmt)` — result is `Lift[T, String]`. */
+  inline def toChar[T, A1, A2](
+    e:   TypedExpr[T, A1],
+    fmt: TypedExpr[String, A2]
+  )(using pf: PgTypeFor[Lift[T, String]]): TypedExpr[Lift[T, String], Where.Concat[A1, A2]] = {
+    val inner = TypedExpr.combineSepInl[A1, A2](e.fragment, ", ", fmt.fragment)
+    val frag  = TypedExpr.wrap("to_char(", inner, ")")
+    TypedExpr(frag, pf.codec)
   }
 
-  /** `format(fmt, args*)` — variadic; Args = Void (all inputs treated as Void-args). */
-  def format(fmt: String, args: TypedExpr[?, ?]*)(using pf: PgTypeFor[String]): TypedExpr[String, Void] = {
-    val fmtFrag = Param.bind[String](fmt).fragment
-    val joined  = TypedExpr.joinedVoid(", ", fmtFrag :: args.toList.map(_.fragment))
-    val frag    = TypedExpr.wrap("format(", joined, ")")
-    TypedExpr[String, Void](frag, skunk.codec.all.text)
+  /**
+   * `format(fmt, args*)` — variadic. Result `Args = Void`: every input is treated as Void-args by
+   * [[TypedExpr.joinedVoid]], so any `Param[T]` baked into a spliced fragment must already be a
+   * `Param.bind`-style Void-args fragment. Threading typed `Args` through the variadic shape is a
+   * roadmap item.
+   */
+  def format(fmt: TypedExpr[String, ?], args: TypedExpr[?, ?]*): TypedExpr[String, skunk.Void] = {
+    val joined = TypedExpr.joinedVoid(", ", fmt.fragment :: args.toList.map(_.fragment))
+    val frag   = TypedExpr.wrap("format(", joined, ")")
+    TypedExpr[String, skunk.Void](frag, skunk.codec.all.text)
   }
 
   // ---- String -> Int -------------------------------------------------------------------------
@@ -345,13 +317,14 @@ trait PgString {
 
   // ---- String -> BigDecimal ------------------------------------------------------------------
 
-  inline def toNumber[T, A](e: TypedExpr[T, A], fmt: String)(using
-    ev: StrLike[T], pf: PgTypeFor[Lift[T, BigDecimal]], pfs: PgTypeFor[String]
-  ): TypedExpr[Lift[T, BigDecimal], A] = {
-    val fmtFrag = Param.bind[String](fmt).fragment
-    val s1      = TypedExpr.combineSepInl[A, Void](e.fragment, ", ", fmtFrag).asInstanceOf[Fragment[A]]
-    val frag    = TypedExpr.wrap("to_number(", s1, ")")
-    TypedExpr[Lift[T, BigDecimal], A](frag, pf.codec)
+  /** `to_number(e, fmt)`. */
+  inline def toNumber[T, A1, A2](
+    e:   TypedExpr[T, A1],
+    fmt: TypedExpr[String, A2]
+  )(using ev: StrLike[T], pf: PgTypeFor[Lift[T, BigDecimal]]): TypedExpr[Lift[T, BigDecimal], Where.Concat[A1, A2]] = {
+    val inner = TypedExpr.combineSepInl[A1, A2](e.fragment, ", ", fmt.fragment)
+    val frag  = TypedExpr.wrap("to_number(", inner, ")")
+    TypedExpr(frag, pf.codec)
   }
 
 }

--- a/modules/core/src/main/scala/skunk/sharp/pg/functions/PgTime.scala
+++ b/modules/core/src/main/scala/skunk/sharp/pg/functions/PgTime.scala
@@ -1,7 +1,7 @@
 package skunk.sharp.pg.functions
 
 import skunk.{Codec, Fragment, Void}
-import skunk.sharp.{Param, PgFunction, TypedExpr}
+import skunk.sharp.{PgFunction, TypedExpr}
 import skunk.sharp.pg.PgTypeFor
 import skunk.sharp.where.Where
 
@@ -69,11 +69,14 @@ trait PgTime {
 
   // -------- Truncation -------------------------------------------------------------------------
 
-  inline def dateTrunc[T, A](precision: String, e: TypedExpr[T, A])(using pfs: PgTypeFor[String]): TypedExpr[T, A] = {
-    val pFrag = Param.bind[String](precision).fragment
-    val s1    = TypedExpr.combineSepInl[Void, A](pFrag, ", ", e.fragment).asInstanceOf[Fragment[A]]
-    val frag  = TypedExpr.wrap("date_trunc(", s1, ")")
-    TypedExpr[T, A](frag, e.codec)
+  /** `date_trunc(precision, e)`. */
+  inline def dateTrunc[T, A1, A2](
+    precision: TypedExpr[String, A1],
+    e:         TypedExpr[T, A2]
+  ): TypedExpr[T, Where.Concat[A1, A2]] = {
+    val inner = TypedExpr.combineSepInl[A1, A2](precision.fragment, ", ", e.fragment)
+    val frag  = TypedExpr.wrap("date_trunc(", inner, ")")
+    TypedExpr(frag, e.codec)
   }
 
   // -------- Interval arithmetic ----------------------------------------------------------------
@@ -159,11 +162,14 @@ trait PgTime {
   def toTimestamp[A](e: TypedExpr[Double, A]): TypedExpr[OffsetDateTime, A] =
     unaryOut("to_timestamp", e, skunk.codec.all.timestamptz)
 
-  inline def toDate[T, A](e: TypedExpr[T, A], fmt: String)(using ev: StrLike[T], pfs: PgTypeFor[String]): TypedExpr[LocalDate, A] = {
-    val fmtFrag = Param.bind[String](fmt).fragment
-    val s1      = TypedExpr.combineSepInl[A, Void](e.fragment, ", ", fmtFrag).asInstanceOf[Fragment[A]]
-    val frag    = TypedExpr.wrap("to_date(", s1, ")")
-    TypedExpr[LocalDate, A](frag, skunk.codec.all.date)
+  /** `to_date(e, fmt)`. */
+  inline def toDate[T, A1, A2](
+    e:   TypedExpr[T, A1],
+    fmt: TypedExpr[String, A2]
+  )(using ev: StrLike[T]): TypedExpr[LocalDate, Where.Concat[A1, A2]] = {
+    val inner = TypedExpr.combineSepInl[A1, A2](e.fragment, ", ", fmt.fragment)
+    val frag  = TypedExpr.wrap("to_date(", inner, ")")
+    TypedExpr(frag, skunk.codec.all.date)
   }
 
   // -------- Helpers -------------------------------------------------------------------------

--- a/modules/core/src/main/scala/skunk/sharp/pg/functions/PgWindow.scala
+++ b/modules/core/src/main/scala/skunk/sharp/pg/functions/PgWindow.scala
@@ -1,8 +1,8 @@
 package skunk.sharp.pg.functions
 
-import skunk.{Fragment, Void}
-import skunk.sharp.{Param, TypedExpr}
-import skunk.sharp.pg.PgTypeFor
+import skunk.Void
+import skunk.sharp.{PgFunction, TypedExpr}
+import skunk.sharp.where.Where
 
 /** Window-only functions. Args of input expression(s) propagate. */
 trait PgWindow {
@@ -15,67 +15,51 @@ trait PgWindow {
   val percentRank: TypedExpr[Double, Void] = TypedExpr(TypedExpr.voidFragment("percent_rank()"), skunk.codec.all.float8)
   val cumeDist:    TypedExpr[Double, Void] = TypedExpr(TypedExpr.voidFragment("cume_dist()"),    skunk.codec.all.float8)
 
-  /** `ntile(n)` — `n` is a literal Int rendered inline. */
-  def ntile(n: Int): TypedExpr[Int, Void] =
-    TypedExpr(TypedExpr.voidFragment(s"ntile($n)"), skunk.codec.all.int4)
+  /** `ntile(n)`. */
+  inline def ntile[A](n: TypedExpr[Int, A]): TypedExpr[Int, A] = {
+    val frag = TypedExpr.wrap("ntile(", n.fragment, ")")
+    TypedExpr(frag, skunk.codec.all.int4)
+  }
 
   // ---- Offset access functions ------------------------------------------------------------------
 
   def lag[T, A](expr: TypedExpr[T, A]): TypedExpr[Option[T], A] =
     unaryOpt("lag", expr)
 
-  def lag[T, A](expr: TypedExpr[T, A], offset: Int): TypedExpr[Option[T], A] = {
-    val parts = e2parts("lag(", expr.fragment, s", $offset)")
-    val frag  = Fragment[A](parts, expr.fragment.encoder, skunk.util.Origin.unknown)
-    TypedExpr[Option[T], A](frag, expr.codec.opt)
+  inline def lag[T, A1, A2](expr: TypedExpr[T, A1], offset: TypedExpr[Int, A2]): TypedExpr[Option[T], Where.Concat[A1, A2]] = {
+    val inner = TypedExpr.combineSepInl[A1, A2](expr.fragment, ", ", offset.fragment)
+    val frag  = TypedExpr.wrap("lag(", inner, ")")
+    TypedExpr(frag, expr.codec.opt)
   }
 
-  /**
-   * `lag(expr, offset, default)` — `offset` is a literal Int (rendered inline) and `default` is a
-   * baked runtime value (Param.bind); Args propagates from `expr` only.
-   */
-  def lag[T, A](expr: TypedExpr[T, A], offset: Int, default: T)(using pf: PgTypeFor[T]): TypedExpr[T, A] = {
-    val defFrag = Param.bind[T](default).fragment
-    val parts =
-      List[Either[String, cats.data.State[Int, String]]](Left("lag(")) ++
-        expr.fragment.parts ++
-        List[Either[String, cats.data.State[Int, String]]](Left(s", $offset, ")) ++
-        defFrag.parts ++
-        List[Either[String, cats.data.State[Int, String]]](Left(")"))
-    val combinedEnc = TypedExpr.combineEnc[A, Void](
-      expr.fragment.encoder, defFrag.encoder, c => (c.asInstanceOf[A], Void)
+  /** `lag(expr, offset, default)`. */
+  inline def lag[T, A1, A2, A3](
+    expr:    TypedExpr[T, A1],
+    offset:  TypedExpr[Int, A2],
+    default: TypedExpr[T, A3]
+  ): TypedExpr[T, Where.FoldConcat[A1 *: A2 *: A3 *: EmptyTuple]] =
+    PgFunction.naryTypedFold[T, A1 *: A2 *: A3 *: EmptyTuple](
+      "lag", List(expr.fragment, offset.fragment, default.fragment), expr.codec
     )
-    val frag        = Fragment(parts, combinedEnc.asInstanceOf[skunk.Encoder[A]], skunk.util.Origin.unknown)
-    TypedExpr[T, A](frag, expr.codec)
-  }
 
   def lead[T, A](expr: TypedExpr[T, A]): TypedExpr[Option[T], A] =
     unaryOpt("lead", expr)
 
-  def lead[T, A](expr: TypedExpr[T, A], offset: Int): TypedExpr[Option[T], A] = {
-    val parts = e2parts("lead(", expr.fragment, s", $offset)")
-    val frag  = Fragment[A](parts, expr.fragment.encoder, skunk.util.Origin.unknown)
-    TypedExpr[Option[T], A](frag, expr.codec.opt)
+  inline def lead[T, A1, A2](expr: TypedExpr[T, A1], offset: TypedExpr[Int, A2]): TypedExpr[Option[T], Where.Concat[A1, A2]] = {
+    val inner = TypedExpr.combineSepInl[A1, A2](expr.fragment, ", ", offset.fragment)
+    val frag  = TypedExpr.wrap("lead(", inner, ")")
+    TypedExpr(frag, expr.codec.opt)
   }
 
-  /**
-   * `lead(expr, offset, default)` — `offset` is a literal Int (rendered inline) and `default` is a
-   * baked runtime value (Param.bind); Args propagates from `expr` only.
-   */
-  def lead[T, A](expr: TypedExpr[T, A], offset: Int, default: T)(using pf: PgTypeFor[T]): TypedExpr[T, A] = {
-    val defFrag = Param.bind[T](default).fragment
-    val parts =
-      List[Either[String, cats.data.State[Int, String]]](Left("lead(")) ++
-        expr.fragment.parts ++
-        List[Either[String, cats.data.State[Int, String]]](Left(s", $offset, ")) ++
-        defFrag.parts ++
-        List[Either[String, cats.data.State[Int, String]]](Left(")"))
-    val combinedEnc = TypedExpr.combineEnc[A, Void](
-      expr.fragment.encoder, defFrag.encoder, c => (c.asInstanceOf[A], Void)
+  /** `lead(expr, offset, default)`. */
+  inline def lead[T, A1, A2, A3](
+    expr:    TypedExpr[T, A1],
+    offset:  TypedExpr[Int, A2],
+    default: TypedExpr[T, A3]
+  ): TypedExpr[T, Where.FoldConcat[A1 *: A2 *: A3 *: EmptyTuple]] =
+    PgFunction.naryTypedFold[T, A1 *: A2 *: A3 *: EmptyTuple](
+      "lead", List(expr.fragment, offset.fragment, default.fragment), expr.codec
     )
-    val frag        = Fragment(parts, combinedEnc.asInstanceOf[skunk.Encoder[A]], skunk.util.Origin.unknown)
-    TypedExpr[T, A](frag, expr.codec)
-  }
 
   // ---- Value functions --------------------------------------------------------------------------
 
@@ -89,19 +73,15 @@ trait PgWindow {
     TypedExpr[T, A](frag, expr.codec)
   }
 
-  def nthValue[T, A](expr: TypedExpr[T, A], n: Int): TypedExpr[T, A] = {
-    val parts = e2parts("nth_value(", expr.fragment, s", $n)")
-    val frag  = Fragment[A](parts, expr.fragment.encoder, skunk.util.Origin.unknown)
-    TypedExpr[T, A](frag, expr.codec)
+  inline def nthValue[T, A1, A2](expr: TypedExpr[T, A1], n: TypedExpr[Int, A2]): TypedExpr[T, Where.Concat[A1, A2]] = {
+    val inner = TypedExpr.combineSepInl[A1, A2](expr.fragment, ", ", n.fragment)
+    val frag  = TypedExpr.wrap("nth_value(", inner, ")")
+    TypedExpr(frag, expr.codec)
   }
 
   private def unaryOpt[T, A](name: String, expr: TypedExpr[T, A]): TypedExpr[Option[T], A] = {
     val frag = TypedExpr.wrap(s"$name(", expr.fragment, ")")
     TypedExpr[Option[T], A](frag, expr.codec.opt)
   }
-
-  private def e2parts(prefix: String, f: Fragment[?], suffix: String): List[Either[String, cats.data.State[Int, String]]] =
-    List[Either[String, cats.data.State[Int, String]]](Left(prefix)) ++ f.parts ++
-      List[Either[String, cats.data.State[Int, String]]](Left(suffix))
 
 }

--- a/modules/core/src/test/scala/skunk/sharp/ArraysSuite.scala
+++ b/modules/core/src/test/scala/skunk/sharp/ArraysSuite.scala
@@ -64,8 +64,8 @@ class ArraysSuite extends munit.FunSuite {
     assert(af.fragment.sql.contains("$1 = ANY(\"tags\")"), af.fragment.sql)
   }
 
-  test("Pg.arrayLength renders array_length(col, 1)") {
-    val af = posts.select(p => Pg.arrayLength(p.tags)).compile.af
+  test("Pg.arrayLength renders array_length(col, dim)") {
+    val af = posts.select(p => Pg.arrayLength(p.tags, lit(1))).compile.af
     assertEquals(af.fragment.sql, """SELECT array_length("tags", 1) FROM "posts"""")
   }
 
@@ -95,15 +95,15 @@ class ArraysSuite extends munit.FunSuite {
   }
 
   test("Pg.arrayToString renders with optional null-string") {
-    val af  = posts.select(p => Pg.arrayToString(p.tags, ", ")).compile.af
-    val af2 = posts.select(p => Pg.arrayToString(p.tags, ", ", "∅")).compile.af
-    assertEquals(af.fragment.sql, """SELECT array_to_string("tags", $1) FROM "posts"""")
-    assertEquals(af2.fragment.sql, """SELECT array_to_string("tags", $1, $2) FROM "posts"""")
+    val af  = posts.select(p => Pg.arrayToString(p.tags, lit(", "))).compile.af
+    val af2 = posts.select(p => Pg.arrayToString(p.tags, lit(", "), lit("∅"))).compile.af
+    assertEquals(af.fragment.sql, """SELECT array_to_string("tags", ', ') FROM "posts"""")
+    assertEquals(af2.fragment.sql, """SELECT array_to_string("tags", ', ', '∅') FROM "posts"""")
   }
 
   test("Pg.stringToArray renders as an input-split") {
-    val af = empty.select(Pg.stringToArray(param("a,b,c"), ",")).compile.af
-    assertEquals(af.fragment.sql, """SELECT string_to_array($1, $2)""")
+    val af = empty.select(_ => Pg.stringToArray(param("a,b,c"), lit(","))).compile.af
+    assertEquals(af.fragment.sql, """SELECT string_to_array($1, ',')""")
   }
 
   test("Pg.arrayAgg aggregates rows into an array") {

--- a/modules/core/src/test/scala/skunk/sharp/ExprInterpolatorSuite.scala
+++ b/modules/core/src/test/scala/skunk/sharp/ExprInterpolatorSuite.scala
@@ -1,0 +1,140 @@
+package skunk.sharp
+
+import skunk.Void
+import skunk.sharp.dsl.*
+
+import java.util.UUID
+
+object ExprInterpolatorSuite {
+  case class User(id: UUID, email: String, age: Int)
+}
+
+class ExprInterpolatorSuite extends munit.FunSuite {
+  import ExprInterpolatorSuite.User
+
+  private val users = Table.of[User]("users")
+
+  // -------- No-arg form ------------------------------------------------------------------------
+
+  test("expr with no interpolations renders the literal SQL and Args = Void") {
+    val e = expr"now()".as[java.time.OffsetDateTime]
+    val _: TypedExpr[java.time.OffsetDateTime, Void] = e
+    assertEquals(e.fragment.sql, "now()")
+  }
+
+  // -------- TypedExpr (column) interpolation ---------------------------------------------------
+
+  test("expr splicing a single column ref preserves Args = Void") {
+    val q                              = users.select(u => expr"lower(${u.email})".asCodec(skunk.codec.all.text)).compile
+    val _: QueryTemplate[Void, String] = q
+    assert(q.fragment.sql.contains("""lower("email")"""), q.fragment.sql)
+  }
+
+  test("expr splicing two column refs renders with literal separator + Args = Void") {
+    val q                              = users.select(u => expr"${u.email} || ${u.email}".asCodec(skunk.codec.all.text)).compile
+    val _: QueryTemplate[Void, String] = q
+    assert(q.fragment.sql.contains(""""email" || "email""""), q.fragment.sql)
+  }
+
+  // -------- Param interpolation (TypedExpr branch) ---------------------------------------------
+
+  test("expr splicing a Param[T] threads Args = T") {
+    val q                                  = users.select(u => expr"lower(${u.email}) = lower(${Param[String]})".as[Boolean]).compile
+    val _: QueryTemplate[String, Boolean] = q
+    assert(q.fragment.sql.contains("$1"), q.fragment.sql)
+  }
+
+  test("expr splicing two Params via FoldConcat collapses to flat tuple Args") {
+    val q                                       = users.select(_ => expr"${Param[Int]} + ${Param[Int]}".as[Int]).compile
+    val _: QueryTemplate[(Int, Int), Int]       = q
+    assert(q.fragment.sql.contains("$1 + $2"), q.fragment.sql)
+  }
+
+  test("expr splicing column + Param threads Args = the Param's type") {
+    val q                              = users.select(u => expr"${u.age} + ${Param[Int]}".as[Int]).compile
+    val _: QueryTemplate[Int, Int]     = q
+    assert(q.fragment.sql.contains(""""age" + $1"""), q.fragment.sql)
+  }
+
+  // -------- Value interpolation requires explicit wrapping ------------------------------------
+
+  test("expr with lit(v) for a compile-time literal — Args = Void") {
+    val q                                = users.select(u => expr"${u.email} = ${lit("@example.com")}".as[Boolean]).compile
+    val _: QueryTemplate[Void, Boolean]  = q
+    assert(q.fragment.sql.contains("@example.com"), q.fragment.sql)
+  }
+
+  test("expr with Param.bind(v) for a runtime value — Args = Void") {
+    val n                                = 18
+    val q                                = users.select(u => expr"${u.age} >= ${Param.bind(n)}".as[Boolean]).compile
+    val _: QueryTemplate[Void, Boolean]  = q
+    assert(q.fragment.sql.contains("$1"), q.fragment.sql)
+  }
+
+  // -------- Mixed shapes ------------------------------------------------------------------------
+
+  test("expr mixing TypedExpr Params and baked values composes Args = only the Params") {
+    val q = users.select(u => expr"${u.age} >= ${Param[Int]} AND ${u.age} <= ${lit(99)}".as[Boolean]).compile
+    val _: QueryTemplate[Int, Boolean] = q
+  }
+
+  // -------- Encoder execution path -------------------------------------------------------------
+
+  test("encoder for a Param-bearing expr binds the supplied value at execute") {
+    val q       = users.select(u => expr"${u.age} + ${Param[Int]}".as[Int]).compile
+    val af      = q.bind(7)
+    val encoded = af.fragment.encoder.encode(af.argument).flatten.map(_.value)
+    assertEquals(encoded, List("7"))
+  }
+
+  test("encoder for two-Param expr binds both supplied values in render order") {
+    val q       = users.select(_ => expr"${Param[Int]} + ${Param[Int]}".as[Int]).compile
+    val af      = q.bind((3, 4))
+    val encoded = af.fragment.encoder.encode(af.argument).flatten.map(_.value)
+    assertEquals(encoded, List("3", "4"))
+  }
+
+  test("encoder for a Param + Param.bind expr emits both — execute-time + baked") {
+    val n       = 42
+    val q       = users.select(_ => expr"${Param[Int]} + ${Param.bind(n)}".as[Int]).compile
+    val af      = q.bind(8)
+    val encoded = af.fragment.encoder.encode(af.argument).flatten.map(_.value)
+    assertEquals(encoded, List("8", "42"))
+  }
+
+  // -------- Negative test: bare values rejected at compile time --------------------------------
+
+  test("expr with bare runtime value does not compile — message points to lit / Param / Param.bind") {
+    val errors = scala.compiletime.testing.typeCheckErrors(
+      "import skunk.sharp.*; import skunk.sharp.dsl.*; val n = 18; val e = expr\"$n + ${lit(1)}\".as[Int]"
+    )
+    assert(
+      errors.exists(_.message.contains("Wrap it explicitly")),
+      s"expected the macro's wrap-it-explicitly diagnostic, got: ${errors.map(_.message).mkString("; ")}"
+    )
+  }
+
+  // -------- .as / .asCodec parity --------------------------------------------------------------
+
+  test("expr.asCodec(codec) reuses an explicit codec") {
+    val q = users.select(u => expr"upper(${u.email})".asCodec(u_emailCodec)).compile
+    assertEquals(q.fragment.sql.trim, """SELECT upper("email") FROM "users"""")
+  }
+  private val u_emailCodec: skunk.Codec[String] = skunk.codec.all.text
+
+  test("expr.asCodec(e) reuses the spliced expression's codec without naming the codec") {
+    val q = users.select(u => expr"upper(${u.email})".asCodec(u.email)).compile
+    val _: QueryTemplate[Void, String] = q
+    assertEquals(q.fragment.sql.trim, """SELECT upper("email") FROM "users"""")
+  }
+
+  // -------- Used inside a WHERE clause via Where.fromTypedExpr ---------------------------------
+
+  test("expr-built boolean expression slots into WHERE through Where.fromTypedExpr") {
+    val q = users.select
+      .where(u => skunk.sharp.where.Where.fromTypedExpr(expr"${u.age} >= ${Param[Int]}".as[Boolean]))
+      .compile
+    val _: QueryTemplate[Int, ?] = q
+    assert(q.fragment.sql.contains("$1"), q.fragment.sql)
+  }
+}

--- a/modules/core/src/test/scala/skunk/sharp/ParamSuite.scala
+++ b/modules/core/src/test/scala/skunk/sharp/ParamSuite.scala
@@ -672,18 +672,18 @@ class ParamSuite extends munit.FunSuite {
     val _: QueryTemplate[(java.time.LocalDate, java.time.LocalDate, java.time.LocalDate, java.time.LocalDate), ?] = q
   }
 
-  test("Pg.lpad(col, 4, fill) propagates Args from the typed expr only") {
-    val q                              = users.select(u => Pg.lpad(u.email, 4, "*")).compile
+  test("Pg.lpad(col, lit(4), lit(fill)) propagates Args from the typed expr only") {
+    val q                              = users.select(u => Pg.lpad(u.email, lit(4), lit("*"))).compile
     val _: QueryTemplate[Void, String] = q
   }
 
-  test("Pg.rpad(Param, 4, fill) threads Param through expr position") {
-    val q                                = empty.select(_ => Pg.rpad(Param[String], 4, "_")).compile
+  test("Pg.rpad(Param, lit(4), lit(fill)) threads Param through expr position") {
+    val q                                = empty.select(_ => Pg.rpad(Param[String], lit(4), lit("_"))).compile
     val _: QueryTemplate[String, String] = q
   }
 
-  test("Pg.lag(Param, 1, default) threads Param through expr position") {
-    val q                                = users.select(_ => Pg.lag(Param[String], 1, "n/a")).compile
+  test("Pg.lag(Param, lit(1), lit(default)) threads Param through expr position") {
+    val q                                = users.select(_ => Pg.lag(Param[String], lit(1), lit("n/a"))).compile
     val _: QueryTemplate[String, String] = q
   }
 
@@ -1106,10 +1106,10 @@ class ParamSuite extends munit.FunSuite {
     assert(q.fragment.sql.contains("<= ANY") && q.fragment.sql.contains("$1"), q.fragment.sql)
   }
 
-  test("col.in(values) preserves Args = Void (values are Param.bind-baked)") {
+  test("col.in(lits) preserves Args = Void") {
     case class User(id: UUID, email: String, age: Int)
     val users                     = Table.of[User]("users")
-    val q                         = users.select.where(u => u.age.in(cats.data.NonEmptyList.of(20, 21, 22))).compile
+    val q                         = users.select.where(u => u.age.in(cats.data.NonEmptyList.of(lit(20), lit(21), lit(22)))).compile
     val _: QueryTemplate[Void, ?] = q
   }
 

--- a/modules/core/src/test/scala/skunk/sharp/PgFunctionSuite.scala
+++ b/modules/core/src/test/scala/skunk/sharp/PgFunctionSuite.scala
@@ -27,7 +27,7 @@ class PgFunctionSuite extends munit.FunSuite {
   }
 
   test("round with digits") {
-    val af = products.select(p => Pg.round(p.price, 2)).compile.af
+    val af = products.select(p => Pg.round(p.price, lit(2))).compile.af
     assertEquals(af.fragment.sql, """SELECT round("price", 2) FROM "products"""")
   }
 
@@ -67,10 +67,10 @@ class PgFunctionSuite extends munit.FunSuite {
 
   // ---- NULL handling ----
 
-  test("nullif returns an Option and binds b as a literal parameter") {
-    val q                                = products.select(p => Pg.nullif(p.qty, 0)).compile
+  test("nullif renders inline lit value") {
+    val q                                = products.select(p => Pg.nullif(p.qty, lit(0))).compile
     val _: QueryTemplate[?, Option[Int]] = q
-    assertEquals(q.fragment.sql, """SELECT nullif("qty", $1) FROM "products"""")
+    assertEquals(q.fragment.sql, """SELECT nullif("qty", 0) FROM "products"""")
   }
 
   // ---- String (preserve tag) ----
@@ -87,23 +87,23 @@ class PgFunctionSuite extends munit.FunSuite {
   }
 
   test("trim with chars arg — `trim(chars FROM s)`") {
-    val af = products.select(p => Pg.trim(p.name, " \t")).compile.af
-    assertEquals(af.fragment.sql, """SELECT trim($1 FROM "name") FROM "products"""")
+    val af = products.select(p => Pg.trim(lit(" \t"), p.name)).compile.af
+    assertEquals(af.fragment.sql, "SELECT trim(' \t' FROM \"name\") FROM \"products\"")
   }
 
   test("replace / repeat / reverse") {
     val af = products
-      .select(p => (Pg.replace(p.name, "a", "b"), Pg.repeat(p.name, 3), Pg.reverse(p.name)))
+      .select(p => (Pg.replace(p.name, lit("a"), lit("b")), Pg.repeat(p.name, lit(3)), Pg.reverse(p.name)))
       .compile
       .af
-    assert(af.fragment.sql.contains("""replace("name", $1, $2)"""), af.fragment.sql)
+    assert(af.fragment.sql.contains("""replace("name", 'a', 'b')"""), af.fragment.sql)
     assert(af.fragment.sql.contains("""repeat("name", 3)"""), af.fragment.sql)
     assert(af.fragment.sql.contains("""reverse("name")"""), af.fragment.sql)
   }
 
   test("substring — single-arg and with FOR length") {
     val af = products
-      .select(p => (Pg.substring(p.name, 2), Pg.substring(p.name, 2, 3)))
+      .select(p => (Pg.substring(p.name, lit(2)), Pg.substring(p.name, lit(2), lit(3))))
       .compile
       .af
     assertEquals(
@@ -113,7 +113,7 @@ class PgFunctionSuite extends munit.FunSuite {
   }
 
   test("left / right") {
-    val af = products.select(p => (Pg.left(p.name, 5), Pg.right(p.name, 5))).compile.af
+    val af = products.select(p => (Pg.left(p.name, lit(5)), Pg.right(p.name, lit(5)))).compile.af
     assertEquals(
       af.fragment.sql,
       """SELECT left("name", 5), right("name", 5) FROM "products""""
@@ -122,23 +122,23 @@ class PgFunctionSuite extends munit.FunSuite {
 
   test("regexpReplace / splitPart") {
     val af = products
-      .select(p => (Pg.regexpReplace(p.name, "^[a-z]+", ""), Pg.splitPart(p.name, "-", 1)))
+      .select(p => (Pg.regexpReplace(p.name, lit("^[a-z]+"), lit("")), Pg.splitPart(p.name, lit("-"), lit(1))))
       .compile
       .af
-    assert(af.fragment.sql.contains("""regexp_replace("name", $1, $2)"""), af.fragment.sql)
-    assert(af.fragment.sql.contains("""split_part("name", $3, 1)"""), af.fragment.sql)
+    assert(af.fragment.sql.contains("""regexp_replace("name", '^[a-z]+', '')"""), af.fragment.sql)
+    assert(af.fragment.sql.contains("""split_part("name", '-', 1)"""), af.fragment.sql)
   }
 
   // ---- String returning Int via Lift ----
 
   test("charLength / octetLength / position — Lift preserves input nullability") {
     val af = products
-      .select(p => (Pg.charLength(p.name), Pg.octetLength(p.name), Pg.position("x", p.name)))
+      .select(p => (Pg.charLength(p.name), Pg.octetLength(p.name), Pg.position(lit("x"), p.name)))
       .compile
       .af
     assertEquals(
       af.fragment.sql,
-      """SELECT char_length("name"), octet_length("name"), position($1 IN "name") FROM "products""""
+      """SELECT char_length("name"), octet_length("name"), position('x' IN "name") FROM "products""""
     )
   }
 
@@ -193,16 +193,16 @@ class PgFunctionSuite extends munit.FunSuite {
       .select(p =>
         (
           Pg.initcap(p.name),
-          Pg.translate(p.name, "abc", "xyz"),
-          Pg.lpad(p.name, 10),
-          Pg.rpad(p.name, 10, "*")
+          Pg.translate(p.name, lit("abc"), lit("xyz")),
+          Pg.lpad(p.name, lit(10)),
+          Pg.rpad(p.name, lit(10), lit("*"))
         )
       )
       .compile.af
     assert(af.fragment.sql.contains("""initcap("name")"""), af.fragment.sql)
-    assert(af.fragment.sql.contains("""translate("name", $"""), af.fragment.sql)
+    assert(af.fragment.sql.contains("""translate("name", 'abc', 'xyz')"""), af.fragment.sql)
     assert(af.fragment.sql.contains("""lpad("name", 10)"""), af.fragment.sql)
-    assert(af.fragment.sql.contains("""rpad("name", 10, $"""), af.fragment.sql)
+    assert(af.fragment.sql.contains("""rpad("name", 10, '*')"""), af.fragment.sql)
   }
 
   test("md5 returns string via Lift") {
@@ -220,19 +220,19 @@ class PgFunctionSuite extends munit.FunSuite {
     assertEquals(af.fragment.sql, """SELECT chr("qty") FROM "products"""")
   }
 
-  test("toChar renders to_char(e, $fmt)") {
-    val af = products.select(p => Pg.toChar(p.price, "FM999990.00")).compile.af
-    assert(af.fragment.sql.startsWith("""SELECT to_char("price", $"""), af.fragment.sql)
+  test("toChar renders to_char(e, fmt)") {
+    val af = products.select(p => Pg.toChar(p.price, lit("FM999990.00"))).compile.af
+    assert(af.fragment.sql.startsWith("""SELECT to_char("price", 'FM999990.00')"""), af.fragment.sql)
   }
 
-  test("toNumber renders to_number(e, $fmt)") {
-    val af = products.select(p => Pg.toNumber(p.name, "99.99")).compile.af
-    assert(af.fragment.sql.contains("""to_number("name", $"""), af.fragment.sql)
+  test("toNumber renders to_number(e, fmt)") {
+    val af = products.select(p => Pg.toNumber(p.name, lit("99.99"))).compile.af
+    assert(af.fragment.sql.contains("""to_number("name", '99.99')"""), af.fragment.sql)
   }
 
-  test("format renders format($fmt, args…)") {
-    val af = products.select(p => Pg.format("%s-%s", p.name, p.name)).compile.af
-    assert(af.fragment.sql.contains("""format($"""), af.fragment.sql)
+  test("format renders format(fmt, args…)") {
+    val af = products.select(p => Pg.format(lit("%s-%s"), p.name, p.name)).compile.af
+    assert(af.fragment.sql.contains("""format('%s-%s'"""), af.fragment.sql)
     assert(af.fragment.sql.contains(""""name""""), af.fragment.sql)
   }
 
@@ -243,10 +243,9 @@ class PgFunctionSuite extends munit.FunSuite {
     assertEquals(af.fragment.sql, "SELECT extract(year FROM now())")
   }
 
-  test("dateTrunc renders date_trunc($precision, e)") {
-    val af = empty.select(_ => Pg.dateTrunc("month", Pg.now)).compile.af
-    assert(af.fragment.sql.contains("date_trunc($"), af.fragment.sql)
-    assert(af.fragment.sql.contains("now()"), af.fragment.sql)
+  test("dateTrunc renders date_trunc(precision, e)") {
+    val af = empty.select(_ => Pg.dateTrunc(lit("month"), Pg.now)).compile.af
+    assert(af.fragment.sql.contains("date_trunc('month', now())"), af.fragment.sql)
   }
 
   test("age(a, b) renders age(a, b)") {
@@ -264,8 +263,8 @@ class PgFunctionSuite extends munit.FunSuite {
     assertEquals(af.fragment.sql, "SELECT to_timestamp($1)")
   }
 
-  test("toDate renders to_date(e, $fmt)") {
-    val af = empty.select(_ => Pg.toDate(param("2024-01-15"), "YYYY-MM-DD")).compile.af
+  test("toDate renders to_date(e, fmt)") {
+    val af = empty.select(_ => Pg.toDate(param("2024-01-15"), lit("YYYY-MM-DD"))).compile.af
     assert(af.fragment.sql.contains("to_date("), af.fragment.sql)
   }
 

--- a/modules/core/src/test/scala/skunk/sharp/RangeSuite.scala
+++ b/modules/core/src/test/scala/skunk/sharp/RangeSuite.scala
@@ -66,10 +66,10 @@ class RangeSuite extends munit.FunSuite {
     assert(af.fragment.sql.contains("daterange("), af.fragment.sql)
   }
 
-  test("int4range(lo, hi, bounds) passes bounds as param") {
-    val af = empty.select(_ => Pg.int4range(param(1), param(10), "[]")).compile.af
+  test("int4range(lo, hi, bounds) renders bounds inline") {
+    val af = empty.select(_ => Pg.int4range(param(1), param(10), lit("[]"))).compile.af
     assert(af.fragment.sql.contains("int4range("), af.fragment.sql)
-    assert(af.fragment.sql.contains("$3"), af.fragment.sql) // bounds is the 3rd param
+    assert(af.fragment.sql.contains("'[]'"), af.fragment.sql)
   }
 
   // -------- Operators ---------------------------------------------------------------

--- a/modules/core/src/test/scala/skunk/sharp/dsl/GroupBySuite.scala
+++ b/modules/core/src/test/scala/skunk/sharp/dsl/GroupBySuite.scala
@@ -40,9 +40,9 @@ class GroupBySuite extends munit.FunSuite {
     assertEquals(maxAf.fragment.sql, """SELECT max("age") FROM "users"""")
   }
 
-  test("Pg.stringAgg renders string_agg(expr, sep) and takes sep as a bound parameter") {
-    val af = users.select(u => Pg.stringAgg(u.email, ", ")).compile.af
-    assertEquals(af.fragment.sql, """SELECT string_agg("email", $1) FROM "users"""")
+  test("Pg.stringAgg renders string_agg(expr, sep)") {
+    val af = users.select(u => Pg.stringAgg(u.email, lit(", "))).compile.af
+    assertEquals(af.fragment.sql, """SELECT string_agg("email", ', ') FROM "users"""")
   }
 
   test(".groupBy single column") {

--- a/modules/core/src/test/scala/skunk/sharp/dsl/WindowSuite.scala
+++ b/modules/core/src/test/scala/skunk/sharp/dsl/WindowSuite.scala
@@ -56,8 +56,8 @@ class WindowSuite extends munit.FunSuite {
     assertEquals(af.fragment.sql, """SELECT cume_dist() OVER (ORDER BY "age" ASC) FROM "users"""")
   }
 
-  test("ntile(4) OVER (ORDER BY age)") {
-    val af = users.select(u => Pg.ntile(4).over(WindowSpec.orderBy(u.age.asc))).compile.af
+  test("ntile(lit(4)) OVER (ORDER BY age)") {
+    val af = users.select(u => Pg.ntile(lit(4)).over(WindowSpec.orderBy(u.age.asc))).compile.af
     assertEquals(af.fragment.sql, """SELECT ntile(4) OVER (ORDER BY "age" ASC) FROM "users"""")
   }
 
@@ -137,18 +137,18 @@ class WindowSuite extends munit.FunSuite {
     assertEquals(af.fragment.sql, """SELECT lag("age") OVER (ORDER BY "age" ASC) FROM "users"""")
   }
 
-  test("lag(age, 2) OVER (ORDER BY age)") {
+  test("lag(age, lit(2)) OVER (ORDER BY age)") {
     val af = users
-      .select(u => Pg.lag(u.age, 2).over(WindowSpec.orderBy(u.age.asc)))
+      .select(u => Pg.lag(u.age, lit(2)).over(WindowSpec.orderBy(u.age.asc)))
       .compile.af
     assertEquals(af.fragment.sql, """SELECT lag("age", 2) OVER (ORDER BY "age" ASC) FROM "users"""")
   }
 
-  test("lag(age, 1, 0) OVER (ORDER BY age) — with default, non-optional result") {
+  test("lag(age, lit(1), lit(0)) OVER (ORDER BY age) — with default, non-optional result") {
     val af = users
-      .select(u => Pg.lag(u.age, 1, 0).over(WindowSpec.orderBy(u.age.asc)))
+      .select(u => Pg.lag(u.age, lit(1), lit(0)).over(WindowSpec.orderBy(u.age.asc)))
       .compile.af
-    assertEquals(af.fragment.sql, """SELECT lag("age", 1, $1) OVER (ORDER BY "age" ASC) FROM "users"""")
+    assertEquals(af.fragment.sql, """SELECT lag("age", 1, 0) OVER (ORDER BY "age" ASC) FROM "users"""")
   }
 
   test("lead(age) OVER (ORDER BY age)") {
@@ -158,11 +158,11 @@ class WindowSuite extends munit.FunSuite {
     assertEquals(af.fragment.sql, """SELECT lead("age") OVER (ORDER BY "age" ASC) FROM "users"""")
   }
 
-  test("lead(age, 1, 0) OVER (ORDER BY age) — with default") {
+  test("lead(age, lit(1), lit(0)) OVER (ORDER BY age) — with default") {
     val af = users
-      .select(u => Pg.lead(u.age, 1, 0).over(WindowSpec.orderBy(u.age.asc)))
+      .select(u => Pg.lead(u.age, lit(1), lit(0)).over(WindowSpec.orderBy(u.age.asc)))
       .compile.af
-    assertEquals(af.fragment.sql, """SELECT lead("age", 1, $1) OVER (ORDER BY "age" ASC) FROM "users"""")
+    assertEquals(af.fragment.sql, """SELECT lead("age", 1, 0) OVER (ORDER BY "age" ASC) FROM "users"""")
   }
 
   // ---- Value functions -------------------------------------------------------------------------
@@ -181,9 +181,9 @@ class WindowSuite extends munit.FunSuite {
     assertEquals(af.fragment.sql, """SELECT last_value("age") OVER (ORDER BY "age" ASC) FROM "users"""")
   }
 
-  test("nth_value(age, 2) OVER (ORDER BY age)") {
+  test("nth_value(age, lit(2)) OVER (ORDER BY age)") {
     val af = users
-      .select(u => Pg.nthValue(u.age, 2).over(WindowSpec.orderBy(u.age.asc)))
+      .select(u => Pg.nthValue(u.age, lit(2)).over(WindowSpec.orderBy(u.age.asc)))
       .compile.af
     assertEquals(af.fragment.sql, """SELECT nth_value("age", 2) OVER (ORDER BY "age" ASC) FROM "users"""")
   }
@@ -209,7 +209,7 @@ class WindowSuite extends munit.FunSuite {
 
   test("lag with default decodes as Int (non-optional)") {
     val _: QueryTemplate[?, Int] =
-      users.select(u => Pg.lag(u.age, 1, 0).over(WindowSpec.orderBy(u.age.asc))).compile
+      users.select(u => Pg.lag(u.age, lit(1), lit(0)).over(WindowSpec.orderBy(u.age.asc))).compile
   }
 
   test("row_number decodes as Long") {

--- a/modules/core/src/test/scala/skunk/sharp/where/WhereSuite.scala
+++ b/modules/core/src/test/scala/skunk/sharp/where/WhereSuite.scala
@@ -30,14 +30,26 @@ class WhereSuite extends munit.FunSuite {
     assertEquals(w.fragment.sql, """NOT (("age" < 18 OR "age" > 100))""")
   }
 
-  test("IN renders comma-separated placeholders (from NonEmptyList)") {
-    val w = cols.age.in(cats.data.NonEmptyList.of(1, 2, 3))
-    assertEquals(w.fragment.sql, """"age" IN ($1, $2, $3)""")
+  test("IN renders comma-separated lits (from NonEmptyList)") {
+    val w = cols.age.in(cats.data.NonEmptyList.of(lit(1), lit(2), lit(3)))
+    assertEquals(w.fragment.sql, """"age" IN (1, 2, 3)""")
   }
 
   test("IN accepts any cats.Reducible container (NonEmptyVector here)") {
-    val w = cols.age.in(cats.data.NonEmptyVector.of(1, 2))
+    val w = cols.age.in(cats.data.NonEmptyVector.of(lit(1), lit(2)))
+    assertEquals(w.fragment.sql, """"age" IN (1, 2)""")
+  }
+
+  test("IN with Param.bind values still renders bound placeholders") {
+    val w = cols.age.in(cats.data.NonEmptyList.of(Param.bind(1), Param.bind(2)))
     assertEquals(w.fragment.sql, """"age" IN ($1, $2)""")
+  }
+
+  test("IN with Param.list[T](size) renders N placeholders, one bind slot of List[T] at execute") {
+    val w = cols.age.in(Param.list[Int](3))
+    assertEquals(w.fragment.sql, """"age" IN ($1, $2, $3)""")
+    // The bind type is the `Param.list`'s `List[Int]` — single execute-time slot regardless of size.
+    val _: skunk.sharp.where.Where[List[Int]] = w
   }
 
   test("empty input is a compile error (Seq is no longer accepted; Reducible guarantees non-empty)") {

--- a/modules/tests/src/test/scala/skunk/sharp/tests/ArraysSuite.scala
+++ b/modules/tests/src/test/scala/skunk/sharp/tests/ArraysSuite.scala
@@ -24,7 +24,7 @@ class ArraysSuite extends PgFixture {
             (id = 102, tags = Arr("scala"), score = 20),
             (id = 103, tags = Arr("sql"), score = 30)
           ).compile.run(s)
-          rows <- posts.select.where(p => p.id.in(NonEmptyList.of(101, 102, 103))).compile.run(s)
+          rows <- posts.select.where(p => p.id.in(NonEmptyList.of(101, 102, 103).map(Param.bind(_)))).compile.run(s)
           _      = assertEquals(rows.map(_.id).toSet, Set(101, 102, 103))
           tag101 = rows.find(_.id == 101).get.tags.flattenTo(List)
           _      = assertEquals(tag101, List("scala", "pg"))
@@ -44,7 +44,7 @@ class ArraysSuite extends PgFixture {
           ids <- posts
             .select(p => p.id)
             .where(p => p.tags.contains(param(Arr("scala"))))
-            .where(p => p.id.in(NonEmptyList.of(201, 202)))
+            .where(p => p.id.in(NonEmptyList.of(201, 202).map(Param.bind(_))))
             .compile.run(s)
           _ = assertEquals(ids.toSet, Set(201))
         } yield ()
@@ -64,7 +64,7 @@ class ArraysSuite extends PgFixture {
           ids <- posts
             .select(p => p.id)
             .where(p => p.tags.containedBy(param(Arr("a", "b"))))
-            .where(p => p.id.in(NonEmptyList.of(301, 302, 303)))
+            .where(p => p.id.in(NonEmptyList.of(301, 302, 303).map(Param.bind(_))))
             .compile.run(s)
           _ = assertEquals(ids.toSet, Set(301, 302))
         } yield ()
@@ -84,7 +84,7 @@ class ArraysSuite extends PgFixture {
           ids <- posts
             .select(p => p.id)
             .where(p => p.tags.overlaps(param(Arr("y"))))
-            .where(p => p.id.in(NonEmptyList.of(401, 402, 403)))
+            .where(p => p.id.in(NonEmptyList.of(401, 402, 403).map(Param.bind(_))))
             .compile.run(s)
           _ = assertEquals(ids.toSet, Set(401, 403))
         } yield ()
@@ -104,7 +104,7 @@ class ArraysSuite extends PgFixture {
           ids <- posts
             .select(p => p.id)
             .where(p => param("alpha").elemOf(p.tags))
-            .where(p => p.id.in(NonEmptyList.of(501, 502, 503)))
+            .where(p => p.id.in(NonEmptyList.of(501, 502, 503).map(Param.bind(_))))
             .compile.run(s)
           _ = assertEquals(ids.toSet, Set(501))
         } yield ()
@@ -121,8 +121,8 @@ class ArraysSuite extends PgFixture {
             (id = 602, tags = Arr("a", "b"), score = 2)
           ).compile.run(s)
           lens <- posts
-            .select(p => (p.id, Pg.arrayLength(p.tags), Pg.cardinality(p.tags)))
-            .where(p => p.id.in(NonEmptyList.of(601, 602)))
+            .select(p => (p.id, Pg.arrayLength(p.tags, lit(1)), Pg.cardinality(p.tags)))
+            .where(p => p.id.in(NonEmptyList.of(601, 602).map(Param.bind(_))))
             .compile.run(s).map(rs => rs.map { case (id, len, card) => id -> (len, card) }.toMap)
           _ = assertEquals(lens(601), (Option(3), 3))
           _ = assertEquals(lens(602), (Option(2), 2))
@@ -141,7 +141,7 @@ class ArraysSuite extends PgFixture {
           ).compile.run(s)
           agg <- posts
             .select(p => Pg.arrayAgg(p.id))
-            .where(p => p.id.in(NonEmptyList.of(611, 612)))
+            .where(p => p.id.in(NonEmptyList.of(611, 612).map(Param.bind(_))))
             .compile
             .unique(s)
           _ = assertEquals(agg.flattenTo(List).toSet, Set(611, 612))
@@ -163,7 +163,7 @@ class ArraysSuite extends PgFixture {
             .innerJoinLateral(p => Pg.unnestAsRelation(p.tags).alias("t"))
             .on(_ => lit(true))
             .select(r => (r.p.id, r.t.v))
-            .where(r => r.p.id.in(NonEmptyList.of(801, 802)))
+            .where(r => r.p.id.in(NonEmptyList.of(801, 802).map(Param.bind(_))))
             .compile.run(s).map(_.toSet)
           _ = assertEquals(
             rows,

--- a/modules/tests/src/test/scala/skunk/sharp/tests/GroupBySuite.scala
+++ b/modules/tests/src/test/scala/skunk/sharp/tests/GroupBySuite.scala
@@ -140,7 +140,7 @@ class GroupBySuite extends PgFixture {
             (id = UUID.randomUUID, email = "sa2@x", age = bucket, deleted_at = Option.empty[OffsetDateTime])
           ).compile.run(s)
           concat <-
-            users.select(u => Pg.stringAgg(u.email, ", ")).where(u => u.age === Param.bind(bucket)).compile.unique(s)
+            users.select(u => Pg.stringAgg(u.email, lit(", "))).where(u => u.age === Param.bind(bucket)).compile.unique(s)
           _ = assert(concat.contains("sa1@x") && concat.contains("sa2@x"), s"got '$concat'")
           _ = assert(concat.contains(", "), s"separator missing: '$concat'")
         } yield ()

--- a/modules/tests/src/test/scala/skunk/sharp/tests/InListSizesSuite.scala
+++ b/modules/tests/src/test/scala/skunk/sharp/tests/InListSizesSuite.scala
@@ -1,0 +1,207 @@
+package skunk.sharp.tests
+
+import cats.data.NonEmptyList
+import cats.effect.IO
+import skunk.sharp.dsl.*
+
+import java.time.OffsetDateTime
+import java.util.UUID
+
+object InListSizesSuite {
+  case class User(id: UUID, email: String, age: Int, created_at: OffsetDateTime, deleted_at: Option[OffsetDateTime])
+}
+
+/**
+ * Dynamically-sized IN lists. Exercises the new `col.in(NonEmptyList[TypedExpr[T, Void]])` API across a range
+ * of list sizes — both `Param.bind`-baked (the realistic runtime case) and `lit`-rendered (compile-time).
+ *
+ * The risk being verified: skunk's prepared-statement protocol historically struggles with variable-arity
+ * `IN` lists because every `$N` placeholder needs an encoder slot. Our design has each `Param.bind(v)`
+ * carry its own Void-args encoder (the value is baked via `contramap[Void](_ => v)`), so the visible
+ * `Args` stays `Void` regardless of list size — execution should bind the right placeholders without
+ * growing the user-facing tuple.
+ */
+class InListSizesSuite extends PgFixture {
+  import InListSizesSuite.*
+
+  private val users = Table.of[User]("users").withDefault("created_at")
+
+  /** Insert N users with sequential emails, return their generated UUIDs in insert order. */
+  private def seedUsers(s: skunk.Session[IO], n: Int, prefix: String): IO[List[UUID]] = {
+    val ids = (1 to n).map(_ => UUID.randomUUID()).toList
+    val rows = ids.zipWithIndex.map { case (id, i) =>
+      (id = id, email = s"$prefix-$i@x", age = 20 + i, deleted_at = Option.empty[OffsetDateTime])
+    }
+    val insert = users.insert.values(NonEmptyList.fromListUnsafe(rows)).compile.run(s)
+    insert.as(ids)
+  }
+
+  // -------- Runtime list, Param.bind path ---------------------------------------------------------
+
+  List(1, 2, 5, 25, 100).foreach { n =>
+    test(s"IN with $n Param.bind-baked values matches the right rows") {
+      withContainers { containers =>
+        session(containers).use { s =>
+          val pfx = s"in-bind-$n"
+          for {
+            ids   <- seedUsers(s, n, pfx)
+            // Pick a subset (every other id) so we can prove the IN really filtered.
+            wanted = ids.zipWithIndex.collect { case (id, i) if i % 2 == 0 => id }
+            nel    = NonEmptyList.fromListUnsafe(wanted.map(Param.bind(_)))
+            rows  <- users.select(u => u.id).where(u => u.id.in(nel)).compile.run(s)
+            _      = assertEquals(rows.toSet, wanted.toSet, s"n=$n returned wrong subset")
+            _      = assertEquals(rows.size, wanted.size, s"n=$n returned wrong row count")
+          } yield ()
+        }
+      }
+    }
+  }
+
+  // -------- Compile-time literal path (lit) -------------------------------------------------------
+
+  test("IN with `lit` literals (compile-time, rendered inline)") {
+    withContainers { containers =>
+      session(containers).use { s =>
+        val pfx = "in-lit"
+        for {
+          _    <- users.insert.values(
+                    (id = UUID.randomUUID, email = s"$pfx-21@x", age = 21, deleted_at = Option.empty[OffsetDateTime]),
+                    (id = UUID.randomUUID, email = s"$pfx-22@x", age = 22, deleted_at = Option.empty[OffsetDateTime]),
+                    (id = UUID.randomUUID, email = s"$pfx-99@x", age = 99, deleted_at = Option.empty[OffsetDateTime])
+                  ).compile.run(s)
+          rows <- users
+                    .select(u => u.email)
+                    .where(u => u.email.like(Param.bind(s"$pfx-%")) && u.age.in(NonEmptyList.of(lit(21), lit(22))))
+                    .compile.run(s)
+          _ = assertEquals(rows.toSet, Set(s"$pfx-21@x", s"$pfx-22@x"))
+        } yield ()
+      }
+    }
+  }
+
+  // -------- Single-element NonEmptyList — degenerate but legal -----------------------------------
+
+  test("IN with a single Param.bind value (NonEmptyList of one)") {
+    withContainers { containers =>
+      session(containers).use { s =>
+        for {
+          ids  <- seedUsers(s, 3, "in-one")
+          one   = ids.head
+          rows <- users
+                    .select(u => u.id)
+                    .where(u => u.id.in(NonEmptyList.one(Param.bind(one))))
+                    .compile.run(s)
+          _ = assertEquals(rows, List(one))
+        } yield ()
+      }
+    }
+  }
+
+  // -------- Composing IN with other Param-bearing predicates --------------------------------------
+
+  test("IN(Param.bind list) combined with WHERE Param[T] composes typed Args correctly") {
+    withContainers { containers =>
+      session(containers).use { s =>
+        for {
+          ids  <- seedUsers(s, 6, "in-mix")
+          want  = ids.take(3)
+          q     = users
+                    .select(u => u.id)
+                    .where(u => u.id.in(NonEmptyList.fromListUnsafe(want.map(Param.bind(_)))))
+                    .where(u => u.age >= Param[Int])
+                    .compile
+          // The Param.bind values bake into Void — only the `Param[Int]` shows up in the bind tuple.
+          rows <- q.run(s)(0)
+          _     = assertEquals(rows.toSet, want.toSet)
+        } yield ()
+      }
+    }
+  }
+
+  // -------- Param.list[T](size) — single bind slot, fixed size ------------------------------------
+
+  List(1, 2, 5, 25).foreach { n =>
+    test(s"IN with Param.list[UUID]($n) — one bind slot, the list supplied at execute time") {
+      withContainers { containers =>
+        session(containers).use { s =>
+          val pfx = s"in-paramlist-$n"
+          for {
+            ids   <- seedUsers(s, n, pfx)
+            wanted = ids.zipWithIndex.collect { case (id, i) if i % 2 == 0 => id }
+            // Build a query for exactly `wanted.size` ids — single prepared statement bound once.
+            q      = users.select(u => u.id).where(u => u.id.in(Param.list[UUID](wanted.size))).compile
+            _      = {
+              val _: skunk.sharp.dsl.QueryTemplate[List[UUID], UUID] = q
+            }
+            rows  <- q.run(s)(wanted)
+            _      = assertEquals(rows.toSet, wanted.toSet)
+            _      = assertEquals(rows.size, wanted.size)
+          } yield ()
+        }
+      }
+    }
+  }
+
+  test("Param.list reuses one prepared statement across multiple bind calls of the same size") {
+    withContainers { containers =>
+      session(containers).use { s =>
+        for {
+          all <- seedUsers(s, 8, "in-paramlist-reuse")
+          q    = users.select(u => u.id).where(u => u.id.in(Param.list[UUID](3))).compile
+          // Three calls with three different lists of size 3 — same prepared statement.
+          r1  <- q.run(s)(all.take(3))
+          r2  <- q.run(s)(all.slice(2, 5))
+          r3  <- q.run(s)(all.takeRight(3))
+          _    = assertEquals(r1.toSet, all.take(3).toSet)
+          _    = assertEquals(r2.toSet, all.slice(2, 5).toSet)
+          _    = assertEquals(r3.toSet, all.takeRight(3).toSet)
+        } yield ()
+      }
+    }
+  }
+
+  test("Param.list combined with WHERE Param[T] threads (List[T], T) at execute") {
+    withContainers { containers =>
+      session(containers).use { s =>
+        for {
+          ids <- seedUsers(s, 6, "in-paramlist-mix")
+          q    = users
+                   .select(u => u.id)
+                   .where(u => u.id.in(Param.list[UUID](3)))
+                   .where(u => u.age >= Param[Int])
+                   .compile
+          _    = {
+            val _: skunk.sharp.dsl.QueryTemplate[(List[UUID], Int), UUID] = q
+          }
+          rows <- q.run(s)((ids.take(3), 0))
+          _     = assertEquals(rows.toSet, ids.take(3).toSet)
+        } yield ()
+      }
+    }
+  }
+
+  // -------- Same predicate built dynamically and reused across sizes -----------------------------
+
+  test("the same dynamic IN-builder works whether N=1 or N=64 (no plan-cache aliasing)") {
+    def runFor(s: skunk.Session[IO], ids: List[UUID]): IO[Set[UUID]] =
+      users
+        .select(u => u.id)
+        .where(u => u.id.in(NonEmptyList.fromListUnsafe(ids.map(Param.bind(_)))))
+        .compile.run(s).map(_.toSet)
+
+    withContainers { containers =>
+      session(containers).use { s =>
+        val pfx = "in-reuse"
+        for {
+          allIds <- seedUsers(s, 64, pfx)
+          first   <- runFor(s,allIds.take(1))
+          some    <- runFor(s,allIds.take(7))
+          all     <- runFor(s,allIds)
+          _ = assertEquals(first.size, 1)
+          _ = assertEquals(some.size, 7)
+          _ = assertEquals(all.size, 64)
+        } yield ()
+      }
+    }
+  }
+}

--- a/modules/tests/src/test/scala/skunk/sharp/tests/PgFunctionSuite.scala
+++ b/modules/tests/src/test/scala/skunk/sharp/tests/PgFunctionSuite.scala
@@ -30,7 +30,7 @@ class PgFunctionSuite extends PgFixture {
     withContainers { containers =>
       session(containers).use { s =>
         assertIO(
-          empty.select(Pg.round(param(BigDecimal("1.2345")), 2)).compile.unique(s),
+          empty.select(_ => Pg.round(param(BigDecimal("1.2345")), lit(2))).compile.unique(s),
           BigDecimal("1.23")
         )
       }
@@ -91,8 +91,8 @@ class PgFunctionSuite extends PgFixture {
     withContainers { containers =>
       session(containers).use { s =>
         for {
-          _ <- assertIO(empty.select(Pg.nullif(lit(5), 5)).compile.unique(s), Option.empty[Int])
-          _ <- assertIO(empty.select(Pg.nullif(lit(5), 3)).compile.unique(s), Option(5))
+          _ <- assertIO(empty.select(_ => Pg.nullif(lit(5), lit(5))).compile.unique(s), Option.empty[Int])
+          _ <- assertIO(empty.select(_ => Pg.nullif(lit(5), lit(3))).compile.unique(s), Option(5))
         } yield ()
       }
     }
@@ -115,10 +115,10 @@ class PgFunctionSuite extends PgFixture {
     withContainers { containers =>
       session(containers).use { s =>
         for {
-          _ <- assertIO(empty.select(Pg.trim(param("  hi  "))).compile.unique(s), "hi")
-          _ <- assertIO(empty.select(Pg.ltrim(param("  hi  "))).compile.unique(s), "hi  ")
-          _ <- assertIO(empty.select(Pg.rtrim(param("  hi  "))).compile.unique(s), "  hi")
-          _ <- assertIO(empty.select(Pg.trim(param("xxhiyy"), "xy")).compile.unique(s), "hi")
+          _ <- assertIO(empty.select(_ => Pg.trim(param("  hi  "))).compile.unique(s), "hi")
+          _ <- assertIO(empty.select(_ => Pg.ltrim(param("  hi  "))).compile.unique(s), "hi  ")
+          _ <- assertIO(empty.select(_ => Pg.rtrim(param("  hi  "))).compile.unique(s), "  hi")
+          _ <- assertIO(empty.select(_ => Pg.trim(lit("xy"), param("xxhiyy"))).compile.unique(s), "hi")
         } yield ()
       }
     }
@@ -128,13 +128,13 @@ class PgFunctionSuite extends PgFixture {
     withContainers { containers =>
       session(containers).use { s =>
         for {
-          _ <- assertIO(empty.select(Pg.replace(param("a-b-c"), "-", "/")).compile.unique(s), "a/b/c")
-          _ <- assertIO(empty.select(Pg.substring(param("hello world"), 7)).compile.unique(s), "world")
-          _ <- assertIO(empty.select(Pg.substring(param("hello world"), 1, 5)).compile.unique(s), "hello")
-          _ <- assertIO(empty.select(Pg.left(param("hello"), 3)).compile.unique(s), "hel")
-          _ <- assertIO(empty.select(Pg.right(param("hello"), 3)).compile.unique(s), "llo")
-          _ <- assertIO(empty.select(Pg.repeat(param("ab"), 3)).compile.unique(s), "ababab")
-          _ <- assertIO(empty.select(Pg.reverse(param("abc"))).compile.unique(s), "cba")
+          _ <- assertIO(empty.select(_ => Pg.replace(param("a-b-c"), lit("-"), lit("/"))).compile.unique(s), "a/b/c")
+          _ <- assertIO(empty.select(_ => Pg.substring(param("hello world"), lit(7))).compile.unique(s), "world")
+          _ <- assertIO(empty.select(_ => Pg.substring(param("hello world"), lit(1), lit(5))).compile.unique(s), "hello")
+          _ <- assertIO(empty.select(_ => Pg.left(param("hello"), lit(3))).compile.unique(s), "hel")
+          _ <- assertIO(empty.select(_ => Pg.right(param("hello"), lit(3))).compile.unique(s), "llo")
+          _ <- assertIO(empty.select(_ => Pg.repeat(param("ab"), lit(3))).compile.unique(s), "ababab")
+          _ <- assertIO(empty.select(_ => Pg.reverse(param("abc"))).compile.unique(s), "cba")
         } yield ()
       }
     }
@@ -146,10 +146,10 @@ class PgFunctionSuite extends PgFixture {
         for {
           _ <-
             assertIO(
-              empty.select(Pg.regexpReplace(param("foo123bar"), "[0-9]+", "-")).compile.unique(s),
+              empty.select(_ => Pg.regexpReplace(param("foo123bar"), lit("[0-9]+"), lit("-"))).compile.unique(s),
               "foo-bar"
             )
-          _ <- assertIO(empty.select(Pg.splitPart(param("a-b-c"), "-", 2)).compile.unique(s), "b")
+          _ <- assertIO(empty.select(_ => Pg.splitPart(param("a-b-c"), lit("-"), lit(2))).compile.unique(s), "b")
         } yield ()
       }
     }
@@ -161,10 +161,10 @@ class PgFunctionSuite extends PgFixture {
     withContainers { containers =>
       session(containers).use { s =>
         for {
-          _ <- assertIO(empty.select(Pg.length(param("abc"))).compile.unique(s), 3)
-          _ <- assertIO(empty.select(Pg.charLength(param("abc"))).compile.unique(s), 3)
-          _ <- assertIO(empty.select(Pg.octetLength(param("abc"))).compile.unique(s), 3)
-          _ <- assertIO(empty.select(Pg.position("b", param("abc"))).compile.unique(s), 2)
+          _ <- assertIO(empty.select(_ => Pg.length(param("abc"))).compile.unique(s), 3)
+          _ <- assertIO(empty.select(_ => Pg.charLength(param("abc"))).compile.unique(s), 3)
+          _ <- assertIO(empty.select(_ => Pg.octetLength(param("abc"))).compile.unique(s), 3)
+          _ <- assertIO(empty.select(_ => Pg.position(lit("b"), param("abc"))).compile.unique(s), 2)
         } yield ()
       }
     }
@@ -270,10 +270,10 @@ class PgFunctionSuite extends PgFixture {
     withContainers { containers =>
       session(containers).use { s =>
         for {
-          _ <- assertIO(empty.select(Pg.initcap(param("hello world"))).compile.unique(s), "Hello World")
-          _ <- assertIO(empty.select(Pg.translate(param("abc"), "abc", "xyz")).compile.unique(s), "xyz")
-          _ <- assertIO(empty.select(Pg.lpad(param("hi"), 5)).compile.unique(s), "   hi")
-          _ <- assertIO(empty.select(Pg.rpad(param("hi"), 5, "-")).compile.unique(s), "hi---")
+          _ <- assertIO(empty.select(_ => Pg.initcap(param("hello world"))).compile.unique(s), "Hello World")
+          _ <- assertIO(empty.select(_ => Pg.translate(param("abc"), lit("abc"), lit("xyz"))).compile.unique(s), "xyz")
+          _ <- assertIO(empty.select(_ => Pg.lpad(param("hi"), lit(5))).compile.unique(s), "   hi")
+          _ <- assertIO(empty.select(_ => Pg.rpad(param("hi"), lit(5), lit("-"))).compile.unique(s), "hi---")
         } yield ()
       }
     }
@@ -283,10 +283,10 @@ class PgFunctionSuite extends PgFixture {
     withContainers { containers =>
       session(containers).use { s =>
         for {
-          h <- empty.select(Pg.md5(param("abc"))).compile.unique(s)
+          h <- empty.select(_ => Pg.md5(param("abc"))).compile.unique(s)
           _ = assertEquals(h, "900150983cd24fb0d6963f7d28e17f72")
-          _ <- assertIO(empty.select(Pg.ascii(param("A"))).compile.unique(s), 65)
-          _ <- assertIO(empty.select(Pg.chr(lit(65))).compile.unique(s), "A")
+          _ <- assertIO(empty.select(_ => Pg.ascii(param("A"))).compile.unique(s), 65)
+          _ <- assertIO(empty.select(_ => Pg.chr(lit(65))).compile.unique(s), "A")
         } yield ()
       }
     }
@@ -296,9 +296,9 @@ class PgFunctionSuite extends PgFixture {
     withContainers { containers =>
       session(containers).use { s =>
         for {
-          c <- empty.select(Pg.toChar(param(BigDecimal("1234.5")), "FM9999.00")).compile.unique(s)
+          c <- empty.select(_ => Pg.toChar(param(BigDecimal("1234.5")), lit("FM9999.00"))).compile.unique(s)
           _ = assert(c.contains("1234"), s"to_char result: $c")
-          n <- empty.select(Pg.toNumber(param("1234.50"), "9999.99")).compile.unique(s)
+          n <- empty.select(_ => Pg.toNumber(param("1234.50"), lit("9999.99"))).compile.unique(s)
           _ = assert(n > BigDecimal(1234), s"to_number result: $n")
         } yield ()
       }
@@ -309,7 +309,7 @@ class PgFunctionSuite extends PgFixture {
     withContainers { containers =>
       session(containers).use { s =>
         assertIO(
-          empty.select(_ => Pg.format("Hello, %s!", param("world"))).compile.unique(s),
+          empty.select(_ => Pg.format(lit("Hello, %s!"), param("world"))).compile.unique(s),
           "Hello, world!"
         )
       }
@@ -333,7 +333,7 @@ class PgFunctionSuite extends PgFixture {
     withContainers { containers =>
       session(containers).use { s =>
         for {
-          ts <- empty.select(Pg.dateTrunc("month", Pg.now)).compile.unique(s)
+          ts <- empty.select(_ => Pg.dateTrunc(lit("month"), Pg.now)).compile.unique(s)
           _ = assertEquals(ts.getDayOfMonth, 1)
           _ = assertEquals(ts.getHour, 0)
         } yield ()

--- a/modules/tests/src/test/scala/skunk/sharp/tests/RangesSuite.scala
+++ b/modules/tests/src/test/scala/skunk/sharp/tests/RangesSuite.scala
@@ -102,7 +102,7 @@ class RangesSuite extends PgFixture {
           ids <- bookings
             .select(b => b.id)
             .where(b => b.period.overlaps(param(probe)))
-            .where(b => b.id.in(NonEmptyList.of(10, 11, 12)))
+            .where(b => b.id.in(NonEmptyList.of(10, 11, 12).map(Param.bind(_))))
             .compile.run(s)
           _ = assertEquals(ids.toSet, Set(10, 12))
         } yield ()
@@ -130,7 +130,7 @@ class RangesSuite extends PgFixture {
           ids <- bookings
             .select(b => b.id)
             .where(b => b.period.containsElem(param(target)))
-            .where(b => b.id.in(NonEmptyList.of(20, 21)))
+            .where(b => b.id.in(NonEmptyList.of(20, 21).map(Param.bind(_))))
             .compile.run(s)
           _ = assertEquals(ids.toSet, Set(20))
         } yield ()
@@ -160,7 +160,7 @@ class RangesSuite extends PgFixture {
           ids <- bookings
             .select(b => b.id)
             .where(b => b.period.contains(param(sub)))
-            .where(b => b.id.in(NonEmptyList.of(30, 31)))
+            .where(b => b.id.in(NonEmptyList.of(30, 31).map(Param.bind(_))))
             .compile.run(s)
           _ = assertEquals(ids.toSet, Set(30))
         } yield ()
@@ -199,7 +199,7 @@ class RangesSuite extends PgFixture {
           ).compile.run(s)
           rows <- bookings
             .select(b => (b.id, Pg.rangeIsEmpty(b.period), Pg.rangeLowerInf(b.period), Pg.rangeUpperInf(b.period)))
-            .where(b => b.id.in(NonEmptyList.of(50, 51, 52)))
+            .where(b => b.id.in(NonEmptyList.of(50, 51, 52).map(Param.bind(_))))
             .compile.run(s)
             .map(_.sortBy(_._1))
           _ = assertEquals(rows(0)._2, true)  // id=50 is empty

--- a/modules/tests/src/test/scala/skunk/sharp/tests/SubquerySuite.scala
+++ b/modules/tests/src/test/scala/skunk/sharp/tests/SubquerySuite.scala
@@ -81,7 +81,7 @@ class SubquerySuite extends PgFixture {
               .alias("u")
               .select(u => u.email)
               .where(u =>
-                u.id.in(cats.data.NonEmptyList.of(uidWith, uidWO)) &&
+                u.id.in(cats.data.NonEmptyList.of(Param.bind(uidWith), Param.bind(uidWO))) &&
                   Pg.notExists(posts.select(_ => lit(1)).where(p => p.user_id ==== u.id))
               )
               .compile.run(s),

--- a/modules/tests/src/test/scala/skunk/sharp/tests/WindowFunctionSuite.scala
+++ b/modules/tests/src/test/scala/skunk/sharp/tests/WindowFunctionSuite.scala
@@ -120,7 +120,7 @@ class WindowFunctionSuite extends PgFixture {
         for {
           _    <- seed(s, pfx)
           rows <- users
-            .select(u => (u.age, Pg.lag(u.age, 1, 0).over(WindowSpec.orderBy(u.age.asc).orderBy(u.email.asc))))
+            .select(u => (u.age, Pg.lag(u.age, lit(1), lit(0)).over(WindowSpec.orderBy(u.age.asc).orderBy(u.email.asc))))
             .where(u => u.email.like(Param.bind(s"$pfx-%")))
             .orderBy(u => (u.age.asc, u.email.asc))
             .compile.run(s)


### PR DESCRIPTION
## Summary

- **`expr\"...\"` interpolator (closes #22)** — `transparent inline def expr` macro-backed string interpolator for assembling `TypedExpr` fragments from typed splices. Bare values are rejected at compile time (enforces static-by-default). Result is `RawExprBuilder[Args]`; commit the element type with `.as[T]`, `.asCodec(c)`, or `.asCodec(e)`. 16 unit tests in `ExprInterpolatorSuite`.

- **`Param.list[T](size)` + IN-list tightening** — `Param.list[T](n): Param[List[T]]` gives a single bind slot expanding to N placeholders — the plan-cache-friendly alternative to N `Param.bind` calls for fixed-size IN lists. `InRhs.reducibleIn` tightened to `F[TypedExpr[T, Void]]` (was `F[T]`) so element expressions are always explicit. 15 integration tests in `InListSizesSuite` (N=1..100, lit, Param.bind, Param.list, reuse, composition).

- **Param.bind purge from Pg* helpers (closes #74)** — all internal function helpers in `PgString`, `PgTime`, `PgArray`, `PgRange`, `PgAggregate`, `PgWindow`, `PgNumeric`, `PgNull` that previously wrapped raw `String`/`Int` literals in `Param.bind` now take `TypedExpr` args throughout. Call sites updated to `lit(v)` / `Param.bind(v)` explicitly. CompileBench verified: **0 dynamic AFs** maintained across all 5 scenarios.

## Test plan

- [x] `sbt core/test` — all unit tests pass (ExprInterpolatorSuite + updated Pg* suites)
- [x] `sbt tests/test` — all integration tests pass (InListSizesSuite N=1..100, SubquerySuite, PgFunctionSuite, etc.)
- [x] `sbt docs/mdoc` — docs snippets type-check
- [x] `sbt core/Test/runMain skunk.sharp.bench.CompileBench` — 0 dynamic AFs

🤖 Generated with [Claude Code](https://claude.com/claude-code)