### PR TITLE
Dynamic filters in example + allOf/anyOf combinators on Where[Void]

### DIFF
--- a/modules/core/src/main/scala/skunk/sharp/dsl/package.scala
+++ b/modules/core/src/main/scala/skunk/sharp/dsl/package.scala
@@ -110,6 +110,21 @@ package object dsl {
   // `import skunk.sharp.dsl.*` brings them into scope.
   export skunk.sharp.where.{&&, ||, and, or, not, unary_!}
 
+  /**
+   * Variadic AND-fold over `Where[Void]`. Composes naturally — nest `anyOf` inside `allOf` (or vice versa) to
+   * spell out arbitrary boolean trees: `where(_ => allOf(w1, anyOf(w2, w3), w4))`. Empty argument list folds
+   * to `WHERE TRUE` (the AND identity, optimised away by Postgres).
+   *
+   * For a runtime collection of predicates, splat into the varargs (`allOf(list*)`) — there's no separate
+   * `Foldable` overload to keep the call surface narrow.
+   */
+  def allOf(ws: skunk.sharp.where.Where[skunk.Void]*): skunk.sharp.where.Where[skunk.Void] =
+    skunk.sharp.where.Where.allOf(ws)
+
+  /** Variadic OR-fold over `Where[Void]`. Counterpart to [[allOf]]; empty list folds to `FALSE`. */
+  def anyOf(ws: skunk.sharp.where.Where[skunk.Void]*): skunk.sharp.where.Where[skunk.Void] =
+    skunk.sharp.where.Where.anyOf(ws)
+
   // ---- Schema validation ----
   val SchemaValidator: skunk.sharp.validation.SchemaValidator.type = skunk.sharp.validation.SchemaValidator
   type ValidationReport = skunk.sharp.validation.ValidationReport

--- a/modules/core/src/main/scala/skunk/sharp/where/Where.scala
+++ b/modules/core/src/main/scala/skunk/sharp/where/Where.scala
@@ -192,6 +192,49 @@ object Where {
    */
   def fromTypedExpr[A](expr: TypedExpr[Boolean, A]): TypedExpr[Boolean, A] = expr
 
+  // ---- cats-style monoidal folds for Where[Void] ----------------------------------------------
+  //
+  // `Where[Void] && Where[Void]` reduces to `Where[Void]` (since `Concat[Void, Void] = Void`), which makes a
+  // `Monoid[Where[Void]]` lawful for both AND and OR. We don't surface a single auto-discoverable `given`
+  // because two monoids on the same type would clash — instead callers either use the helpers below, or
+  // explicitly summon one of [[andMonoid]] / [[orMonoid]].
+  //
+  // Parameterised `Where[A]` (`A != Void`) intentionally has no `Semigroup` — `&&` returns `Where.Concat[A,B]`
+  // (a different type), which doesn't match the `(A, A) => A` shape. The Concat machinery exists to *thread*
+  // arg slots through the AST; collapsing them via Semigroup would defeat the typed-Args design.
+
+  /** Identity element for [[allOf]] / `andMonoid` — renders as `TRUE` and is optimised away by Postgres. */
+  lazy val trueExpr: TypedExpr[Boolean, skunk.Void]  = TypedExpr.lit(true)
+
+  /** Identity element for [[anyOf]] / `orMonoid` — renders as `FALSE`. */
+  lazy val falseExpr: TypedExpr[Boolean, skunk.Void] = TypedExpr.lit(false)
+
+  /** Monoid combining `Where[Void]`s with `AND`. Empty = `TRUE`. Not a `given` — pick explicitly. */
+  val andMonoid: cats.Monoid[TypedExpr[Boolean, skunk.Void]] =
+    new cats.Monoid[TypedExpr[Boolean, skunk.Void]] {
+      def empty: TypedExpr[Boolean, skunk.Void] = trueExpr
+      def combine(x: TypedExpr[Boolean, skunk.Void], y: TypedExpr[Boolean, skunk.Void]): TypedExpr[Boolean, skunk.Void] = x && y
+    }
+
+  /** Monoid combining `Where[Void]`s with `OR`. Empty = `FALSE`. Not a `given` — pick explicitly. */
+  val orMonoid: cats.Monoid[TypedExpr[Boolean, skunk.Void]] =
+    new cats.Monoid[TypedExpr[Boolean, skunk.Void]] {
+      def empty: TypedExpr[Boolean, skunk.Void] = falseExpr
+      def combine(x: TypedExpr[Boolean, skunk.Void], y: TypedExpr[Boolean, skunk.Void]): TypedExpr[Boolean, skunk.Void] = x || y
+    }
+
+  /**
+   * AND-fold a `Foldable` of `Where[Void]`. Empty input collapses to [[trueExpr]] (`WHERE TRUE`), so callers
+   * don't need to special-case the empty list. Non-empty input avoids prepending the identity — the result
+   * for `List(a, b, c)` is `(a AND b) AND c`, not `((TRUE AND a) AND b) AND c`.
+   */
+  def allOf[F[_]: cats.Foldable](xs: F[TypedExpr[Boolean, skunk.Void]]): TypedExpr[Boolean, skunk.Void] =
+    cats.Foldable[F].reduceLeftOption(xs)((acc, w) => acc && w).getOrElse(trueExpr)
+
+  /** OR-fold counterpart to [[allOf]]. Empty input collapses to [[falseExpr]] (`WHERE FALSE`). */
+  def anyOf[F[_]: cats.Foldable](xs: F[TypedExpr[Boolean, skunk.Void]]): TypedExpr[Boolean, skunk.Void] =
+    cats.Foldable[F].reduceLeftOption(xs)((acc, w) => acc || w).getOrElse(falseExpr)
+
 }
 
 /** Combinator extensions on `TypedExpr[Boolean, A]`. */

--- a/modules/core/src/test/scala/skunk/sharp/where/WhereSuite.scala
+++ b/modules/core/src/test/scala/skunk/sharp/where/WhereSuite.scala
@@ -118,6 +118,32 @@ class WhereSuite extends munit.FunSuite {
     assertEquals(w.fragment.sql, """"email" NOT SIMILAR TO '%.test'""")
   }
 
+  test("Where.allOf folds a List[Where[Void]] with AND (no leading TRUE for non-empty input)") {
+    val w = Where.allOf(List(
+      cols.email === lit("a@b"),
+      cols.age >= lit(18),
+      cols.age <= lit(65)
+    ))
+    assertEquals(w.fragment.sql, """(("email" = 'a@b' AND "age" >= 18) AND "age" <= 65)""")
+    val _: skunk.sharp.where.Where[skunk.Void] = w
+  }
+
+  test("Where.allOf on empty input collapses to TRUE (the AND identity)") {
+    val w = Where.allOf(List.empty[skunk.sharp.where.Where[skunk.Void]])
+    assertEquals(w.fragment.sql, "TRUE")
+  }
+
+  test("Where.anyOf folds with OR; empty input is FALSE") {
+    val w = Where.anyOf(List(cols.age === lit(10), cols.age === lit(20)))
+    assertEquals(w.fragment.sql, """("age" = 10 OR "age" = 20)""")
+    assertEquals(Where.anyOf(List.empty[skunk.sharp.where.Where[skunk.Void]]).fragment.sql, "FALSE")
+  }
+
+  test("Where.allOf works with any cats.Foldable (NonEmptyList here)") {
+    val w = Where.allOf(cats.data.NonEmptyList.of(cols.age >= lit(0), cols.age <= lit(100)))
+    assertEquals(w.fragment.sql, """("age" >= 0 AND "age" <= 100)""")
+  }
+
   test("`=== None` on a nullable column is a compile error — point users at `.isNull`") {
     import scala.compiletime.testing.*
     val result: List[Error] = typeCheckErrors("""

--- a/modules/example/src/main/scala/skunk/sharp/example/api/Dto.scala
+++ b/modules/example/src/main/scala/skunk/sharp/example/api/Dto.scala
@@ -2,6 +2,7 @@ package skunk.sharp.example.api
 
 import io.circe.Codec
 import sttp.tapir.Schema
+import sttp.tapir.EndpointIO.annotations.query
 
 import java.time.{LocalDate, OffsetDateTime}
 import java.util.UUID
@@ -29,3 +30,42 @@ case class CreateBookingRequest(
 ) derives Codec.AsObject, Schema
 
 case class ApiError(message: String) derives Codec.AsObject, Schema
+
+/**
+ * Query-parameter bundle for `GET /api/v1/rooms`. Each `@query`-annotated field maps to one query string key
+ * (the field name doubles as the param name); tapir's `EndpointInput.derived` flattens the case class into a
+ * single composed `EndpointInput`. Field types drive parsing (`Option[T]` for one-or-zero, `List[T]` for
+ * repeated keys like `?names=a&names=b`). Routes translate this DTO to a `List[RoomFilter]` via `.toFilters`.
+ */
+case class RoomFilterQuery(
+  @query minCapacity:  Option[Int],
+  @query maxCapacity:  Option[Int],
+  @query nameContains: Option[String],
+  @query names:        List[String],
+  @query ids:          List[UUID]
+)
+
+object RoomFilterQuery {
+  /** No filters supplied — handy for tests or default routing. */
+  val empty: RoomFilterQuery = RoomFilterQuery(None, None, None, Nil, Nil)
+}
+
+/**
+ * Query-parameter bundle for `GET /api/v1/bookings`. Mirrors [[RoomFilterQuery]] in shape and intent.
+ *
+ * `overlapsFrom` and `overlapsTo` are paired: only when both are present does the routing layer turn them into
+ * a single `OverlapsPeriod` filter. The half-bounded `startsOnOrAfter` / `endsOnOrBefore` are independent.
+ */
+case class BookingFilterQuery(
+  @query roomIds:            List[UUID],
+  @query bookerNameContains: Option[String],
+  @query titleContains:      Option[String],
+  @query overlapsFrom:       Option[LocalDate],
+  @query overlapsTo:         Option[LocalDate],
+  @query startsOnOrAfter:    Option[LocalDate],
+  @query endsOnOrBefore:     Option[LocalDate]
+)
+
+object BookingFilterQuery {
+  val empty: BookingFilterQuery = BookingFilterQuery(Nil, None, None, None, None, None, None)
+}

--- a/modules/example/src/main/scala/skunk/sharp/example/api/Endpoints.scala
+++ b/modules/example/src/main/scala/skunk/sharp/example/api/Endpoints.scala
@@ -12,10 +12,23 @@ object Endpoints {
   // Server logic returns Left((StatusCode.NotFound, ApiError("..."))) for 404 etc.
   private val base = endpoint.errorOut(statusCode and jsonBody[ApiError])
 
+  // Filter query bundles: each `@query`-annotated field becomes one query string key. Tapir derives a single
+  // composed `EndpointInput[FilterQuery]` so endpoints receive one typed value rather than a 5- or 7-tuple.
+  private val roomFilterInput:    EndpointInput[RoomFilterQuery]    = EndpointInput.derived[RoomFilterQuery]
+  private val bookingFilterInput: EndpointInput[BookingFilterQuery] = EndpointInput.derived[BookingFilterQuery]
+
   object rooms {
 
+    /**
+     * GET /api/v1/rooms — list with optional filters bundled in [[RoomFilterQuery]]. Absent fields drop out of
+     * the WHERE; present fields AND-combine. Repeated keys (`?names=a&names=b`) produce a non-empty list which
+     * the routing layer turns into an `IN (…)` clause.
+     */
     val list =
-      base.get.in("api" / "v1" / "rooms").out(jsonBody[List[RoomResponse]])
+      base.get
+        .in("api" / "v1" / "rooms")
+        .in(roomFilterInput)
+        .out(jsonBody[List[RoomResponse]])
 
     val getById =
       base.get
@@ -44,8 +57,16 @@ object Endpoints {
 
   object bookings {
 
+    /**
+     * GET /api/v1/bookings — list with optional filters bundled in [[BookingFilterQuery]]. `overlapsFrom` and
+     * `overlapsTo` together form an `OverlapsPeriod` filter (only applied when both are present); the
+     * one-sided `startsOnOrAfter` / `endsOnOrBefore` are independent.
+     */
     val list =
-      base.get.in("api" / "v1" / "bookings").out(jsonBody[List[BookingResponse]])
+      base.get
+        .in("api" / "v1" / "bookings")
+        .in(bookingFilterInput)
+        .out(jsonBody[List[BookingResponse]])
 
     val getById =
       base.get

--- a/modules/example/src/main/scala/skunk/sharp/example/api/Routes.scala
+++ b/modules/example/src/main/scala/skunk/sharp/example/api/Routes.scala
@@ -27,8 +27,8 @@ object Routes {
   ): HttpRoutes[IO] = {
 
     val roomEndpoints: List[ServerEndpoint[Any, IO]] = List(
-      Endpoints.rooms.list.serverLogic[IO] { _ =>
-        Stream.resource(pool).flatMap(rooms.findAll.run).map(_.toResponse).compile.toList
+      Endpoints.rooms.list.serverLogic[IO] { q =>
+        Stream.resource(pool).flatMap(rooms.findFiltered(q.toFilters).run).map(_.toResponse).compile.toList
           .map(_.asRight[Err])
           .handleErrorWith(e => internal(e.getMessage).asLeft.pure)
       },
@@ -74,8 +74,8 @@ object Routes {
     )
 
     val bookingEndpoints: List[ServerEndpoint[Any, IO]] = List(
-      Endpoints.bookings.list.serverLogic[IO] { _ =>
-        Stream.resource(pool).flatMap(bookings.findAll.run).map(_.toResponse).compile.toList
+      Endpoints.bookings.list.serverLogic[IO] { q =>
+        Stream.resource(pool).flatMap(bookings.findFiltered(q.toFilters).run).map(_.toResponse).compile.toList
           .map(_.asRight[Err])
           .handleErrorWith(e => internal(e.getMessage).asLeft.pure)
       },

--- a/modules/example/src/main/scala/skunk/sharp/example/api/Transformers.scala
+++ b/modules/example/src/main/scala/skunk/sharp/example/api/Transformers.scala
@@ -1,8 +1,11 @@
 package skunk.sharp.example.api
 
+import cats.data.NonEmptyList
+import cats.syntax.all.*
 import io.github.arainko.ducktape.*
 import skunk.sharp.data.Range
 import skunk.sharp.example.domain.{BookingRow, RoomRow}
+import skunk.sharp.example.repository.{BookingFilter, RoomFilter}
 import skunk.sharp.pg.tags.PgRange
 
 import java.time.LocalDate
@@ -39,6 +42,40 @@ object Transformers {
           Field.renamed(_.booker_name, _.bookerName),
           Field.computed(_.period, r => PgRange[LocalDate](lower = Some(r.startDate), upper = Some(r.endDate)))
         )
+
+  extension (q: RoomFilterQuery)
+
+    /**
+     * Project the query DTO onto the repository's `RoomFilter` ADT — absent fields disappear, present fields
+     * become one filter case each. Multi-value fields turn into IN-style cases via `NonEmptyList`.
+     */
+    def toFilters: List[RoomFilter] = List(
+      q.minCapacity.map(RoomFilter.CapacityAtLeast(_)),
+      q.maxCapacity.map(RoomFilter.CapacityAtMost(_)),
+      q.nameContains.map(RoomFilter.NameContains(_)),
+      NonEmptyList.fromList(q.names).map(RoomFilter.NamesIn(_)),
+      NonEmptyList.fromList(q.ids).map(RoomFilter.IdsIn(_))
+    ).flatten
+
+  extension (q: BookingFilterQuery)
+
+    /**
+     * Project the booking query DTO onto `BookingFilter`. `overlapsFrom`/`overlapsTo` are paired — the
+     * `OverlapsPeriod` filter is only emitted when both bounds are present.
+     */
+    def toFilters: List[BookingFilter] = {
+      val overlap = (q.overlapsFrom, q.overlapsTo).tupled.map { case (f, t) =>
+        BookingFilter.OverlapsPeriod(f, t)
+      }
+      List(
+        NonEmptyList.fromList(q.roomIds).map(BookingFilter.RoomsIn(_)),
+        q.bookerNameContains.map(BookingFilter.BookerNameContains(_)),
+        q.titleContains.map(BookingFilter.TitleContains(_)),
+        overlap,
+        q.startsOnOrAfter.map(BookingFilter.StartsOnOrAfter(_)),
+        q.endsOnOrBefore.map(BookingFilter.EndsOnOrBefore(_))
+      ).flatten
+    }
 
   private def rangeStart(r: PgRange[LocalDate]): LocalDate = r match {
     case Range.Bounds(Some(lo), _, _, _) => lo

--- a/modules/example/src/main/scala/skunk/sharp/example/repository/BookingFilter.scala
+++ b/modules/example/src/main/scala/skunk/sharp/example/repository/BookingFilter.scala
@@ -1,0 +1,37 @@
+package skunk.sharp.example.repository
+
+import cats.data.NonEmptyList
+
+import java.time.LocalDate
+import java.util.UUID
+
+/**
+ * Domain-level filter ADT for booking listing. Mirrors [[RoomFilter]] — see that file for the rationale on
+ * sealed ADTs versus a wide optional-fields payload.
+ *
+ * Date filters operate on the `period: PgRange[LocalDate]` column via the range operators (`@>`, `&&`, lower /
+ * upper accessors). The repository handles the SQL details; this layer just names the predicate.
+ */
+sealed trait BookingFilter
+
+object BookingFilter {
+
+  /** `room_id IN (…)` — restrict to bookings of a non-empty set of rooms. */
+  final case class RoomsIn(roomIds: NonEmptyList[UUID]) extends BookingFilter
+
+  /** `booker_name ILIKE '%substring%'`. */
+  final case class BookerNameContains(substring: String) extends BookingFilter
+
+  /** `title ILIKE '%substring%'`. */
+  final case class TitleContains(substring: String) extends BookingFilter
+
+  /** `period && [from, to)` — booking's period overlaps the requested window. */
+  final case class OverlapsPeriod(from: LocalDate, to: LocalDate) extends BookingFilter
+
+  /** `lower(period) >= date` — bookings starting on or after the date. */
+  final case class StartsOnOrAfter(date: LocalDate) extends BookingFilter
+
+  /** `upper(period) <= date` — bookings ending on or before the date. */
+  final case class EndsOnOrBefore(date: LocalDate) extends BookingFilter
+
+}

--- a/modules/example/src/main/scala/skunk/sharp/example/repository/BookingRepository.scala
+++ b/modules/example/src/main/scala/skunk/sharp/example/repository/BookingRepository.scala
@@ -15,7 +15,7 @@ import java.time.LocalDate
 import java.util.UUID
 
 trait BookingRepository {
-  def findAll: Kleisli[Stream[IO, *], Session[IO], BookingRow]
+  def findFiltered(filters: List[BookingFilter]): Kleisli[Stream[IO, *], Session[IO], BookingRow]
   def findById(id: UUID): Kleisli[IO, Session[IO], Option[BookingRow]]
   def findByRoom(roomId: UUID): Kleisli[Stream[IO, *], Session[IO], BookingRow]
   def findOverlapping(roomId: UUID, start: LocalDate, end: LocalDate): Kleisli[IO, Session[IO], List[BookingRow]]
@@ -27,6 +27,9 @@ object BookingRepository {
 
   val live: BookingRepository = new BookingRepository {
     private val t = BookingRow.table
+
+    /** Captured columns view — see RoomRepository's `cv` for the rationale. */
+    private val cv = t.columnsView
 
     private val selectRow =
       t.select(b => (b.id, b.room_id, b.booker_name, b.title, b.period, b.created_at))
@@ -65,8 +68,38 @@ object BookingRepository {
     private val deleteQ =
       t.delete.where(b => b.id === Param[UUID]).compile
 
-    def findAll: Kleisli[Stream[IO, *], Session[IO], BookingRow] =
-      findAllQ.streamKF[IO]()
+    /**
+     * Per-filter to-Where translation. The half-bounded ranges for "starts on or after" / "ends on or before"
+     * use `<@` (containedBy) against an open-ended probe range — that lets Postgres use the GiST index on
+     * `period` if one exists.
+     */
+    private def toWhere(f: BookingFilter): Where[skunk.Void] = f match {
+      case BookingFilter.RoomsIn(ids) =>
+        cv.room_id.in(ids.map(Param.bind(_)))
+
+      case BookingFilter.BookerNameContains(s) =>
+        cv.booker_name.ilike(Param.bind(s"%$s%"))
+
+      case BookingFilter.TitleContains(s) =>
+        cv.title.ilike(Param.bind(s"%$s%"))
+
+      case BookingFilter.OverlapsPeriod(from, to) =>
+        cv.period.overlaps(Param.bind(PgRange[LocalDate](lower = Some(from), upper = Some(to))))
+
+      case BookingFilter.StartsOnOrAfter(date) =>
+        // booking period sits within `[date, +∞)` — i.e. the booking starts on/after `date`.
+        cv.period.containedBy(Param.bind(PgRange[LocalDate](lower = Some(date))))
+
+      case BookingFilter.EndsOnOrBefore(date) =>
+        // booking period sits within `(−∞, date]` — i.e. the booking ends on/before `date`.
+        cv.period.containedBy(Param.bind(PgRange[LocalDate](upper = Some(date), upperInclusive = true)))
+    }
+
+    def findFiltered(filters: List[BookingFilter]): Kleisli[Stream[IO, *], Session[IO], BookingRow] =
+      if filters.isEmpty then findAllQ.streamKF[IO]()
+      else
+        selectRow.where(_ => allOf(filters.map(toWhere)*))
+          .compile.streamKF[IO]()
 
     def findById(id: UUID): Kleisli[IO, Session[IO], Option[BookingRow]] =
       findByIdQ.optionK[IO](id)

--- a/modules/example/src/main/scala/skunk/sharp/example/repository/RoomFilter.scala
+++ b/modules/example/src/main/scala/skunk/sharp/example/repository/RoomFilter.scala
@@ -1,0 +1,39 @@
+package skunk.sharp.example.repository
+
+import cats.data.NonEmptyList
+
+import java.util.UUID
+
+/**
+ * Domain-level filter ADT for room listing. Each case captures one runtime predicate the API can ask for; the
+ * repository materialises a `List[RoomFilter]` into a single `WHERE` clause by translating each case to a
+ * `Where[Void]` (values baked via `Param.bind`) and AND-folding the result.
+ *
+ * Why a sealed ADT and not just `case class RoomQuery(minCapacity: Option[Int], …)`:
+ *
+ *   - Each case stays self-contained — adding a new filter is one new `case class` and one extra arm in the
+ *     `toWhere` matcher in [[RoomRepository]], no fiddling with optional fields scattered across layers.
+ *   - The exhaustiveness check on the `match` keeps the repository honest when the ADT grows.
+ *   - Multi-value cases (`NamesIn`, `IdsIn`) are first-class — they translate to `IN (…)` (OR semantics) inside
+ *     a single AND-combined clause, which is closer to the intent than parallel optional fields would be.
+ */
+sealed trait RoomFilter
+
+object RoomFilter {
+
+  /** `capacity >= n` */
+  final case class CapacityAtLeast(n: Int) extends RoomFilter
+
+  /** `capacity <= n` */
+  final case class CapacityAtMost(n: Int) extends RoomFilter
+
+  /** `name ILIKE '%substring%'` — case-insensitive substring match. */
+  final case class NameContains(substring: String) extends RoomFilter
+
+  /** `name IN (…)` — OR-semantic exact-name match across a non-empty set. */
+  final case class NamesIn(values: NonEmptyList[String]) extends RoomFilter
+
+  /** `id IN (…)` — restrict to a non-empty set of ids. */
+  final case class IdsIn(values: NonEmptyList[UUID]) extends RoomFilter
+
+}

--- a/modules/example/src/main/scala/skunk/sharp/example/repository/RoomRepository.scala
+++ b/modules/example/src/main/scala/skunk/sharp/example/repository/RoomRepository.scala
@@ -12,7 +12,7 @@ import skunk.sharp.example.domain.RoomRow
 import java.util.UUID
 
 trait RoomRepository {
-  def findAll: Kleisli[Stream[IO, *], Session[IO], RoomRow]
+  def findFiltered(filters: List[RoomFilter]): Kleisli[Stream[IO, *], Session[IO], RoomRow]
   def findById(id: UUID): Kleisli[IO, Session[IO], Option[RoomRow]]
   def create(data: RoomRow.Create): Kleisli[IO, Session[IO], UUID]
   def patch(id: UUID, data: RoomRow.Patch): Kleisli[IO, Session[IO], Option[RoomRow]]
@@ -23,12 +23,25 @@ trait RoomRepository {
  * Static-template repository — every query that has a fixed shape is compiled exactly once at object construction.
  * Calls bind parameters and run; nothing is re-built per request.
  *
- * `.patch` is the lone exception: see [[live.patch]] for why it must stay on captured-args.
+ * Two methods earn an exception: `.patch` (variable SET list per call) and `.findFiltered` (variable WHERE shape
+ * driven by a runtime `List[RoomFilter]`). Both compile a fresh query per call and bake values via `Param.bind`,
+ * so the user-facing `Args` collapses to `Void` and there's nothing to thread at execute time.
  */
 object RoomRepository {
 
   val live: RoomRepository = new RoomRepository {
     private val t = RoomRow.table
+
+    /**
+     * The unaliased columns-view of the table, captured once. Its static type is `ColumnsView[<RoomRow.Cols>]`,
+     * so the named-tuple selectors `cv.id` / `cv.name` / `cv.capacity` resolve outside any builder lambda —
+     * which lets [[toWhere]] live as a normal method instead of being inlined inside `selectRow.where(c => …)`.
+     *
+     * Safe for the single-source unaliased shape we use here. If the relation were aliased (e.g.
+     * `t.alias("r")`), the lambda's `c` would be qualified-prefix-rendered and we'd want to use *that* view
+     * instead of this one.
+     */
+    private val cv = t.columnsView
 
     private val selectRow =
       t.select(r => (r.id, r.name, r.capacity)).to[RoomRow]
@@ -51,8 +64,26 @@ object RoomRepository {
     private val deleteQ =
       t.delete.where(r => r.id === Param[UUID]).compile
 
-    def findAll: Kleisli[Stream[IO, *], Session[IO], RoomRow] =
-      findAllQ.streamKF[IO]()
+    /**
+     * Translate one filter case to a `Where[Void]` against the captured columns view. Every arm bakes its
+     * runtime value via `Param.bind`, so the result's `Args` is `Void` — that's what makes `Where.allOf` /
+     * `Where.anyOf` (Monoid-shaped) applicable downstream.
+     */
+    private def toWhere(f: RoomFilter): Where[skunk.Void] = f match {
+      case RoomFilter.CapacityAtLeast(n) => cv.capacity >= Param.bind(n)
+      case RoomFilter.CapacityAtMost(n)  => cv.capacity <= Param.bind(n)
+      case RoomFilter.NameContains(s)    => cv.name.ilike(Param.bind(s"%$s%"))
+      case RoomFilter.NamesIn(ns)        => cv.name.in(ns.map(Param.bind(_)))
+      case RoomFilter.IdsIn(ids)         => cv.id.in(ids.map(Param.bind(_)))
+    }
+
+    def findFiltered(filters: List[RoomFilter]): Kleisli[Stream[IO, *], Session[IO], RoomRow] =
+      if filters.isEmpty then findAllQ.streamKF[IO]()  // hit the static-cache fast path
+      else
+        // `allOf` AND-folds the per-filter Wheres; empty would have rendered `WHERE TRUE` but we
+        // short-circuit above to keep the static cache.
+        selectRow.where(_ => allOf(filters.map(toWhere)*))
+          .compile.streamKF[IO]()
 
     def findById(id: UUID): Kleisli[IO, Session[IO], Option[RoomRow]] =
       findByIdQ.optionK[IO](id)


### PR DESCRIPTION
## Summary

- **`Where[Void]` folding combinators** — `Where.allOf` / `Where.anyOf` (Foldable form), `Where.andMonoid` / `Where.orMonoid` (named, not auto-given), `Where.trueExpr` / `Where.falseExpr` interned identities, plus top-level varargs `dsl.allOf(ws*)` / `dsl.anyOf(ws*)` that compose naturally — `where(_ => allOf(w1, anyOf(w2, w3), w4))`. Empty input is the monoid identity; non-empty avoids prepending it (no leading `TRUE AND …`). Limited to `Void` Args because `&&` returns `Concat[A, B]` (a different type) — Monoid shape only holds when `Concat[A,A] = A`.
- **Dynamic filters showcase in `modules/example`** — sealed `RoomFilter` / `BookingFilter` ADTs in the repo layer; tapir-annotated `RoomFilterQuery` / `BookingFilterQuery` DTOs with `@query` fields, derived into a single composed `EndpointInput`; `Transformers#toFilters` extensions project DTO → ADT (paired-field rule for `OverlapsPeriod`); repos capture the columns view as `private val cv` so `toWhere` lives as a normal method, each arm bakes via `Param.bind` (`Where[Void]`), empty short-circuits to the static `findAllQ`, non-empty folds via `allOf(filters.map(toWhere)*)`.

## Test plan

- [x] `sbt core/test` — all 510 unit tests pass (including 4 new WhereSuite tests for allOf/anyOf)
- [x] `sbt example/compile` — example module compiles clean
- [x] CompileBench unaffected (combinators only touch the user-facing fold path, not the per-compile substrate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)