### PR TITLE
Example integration tests via tapir-sttp-client + testcontainers

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -95,7 +95,14 @@ lazy val example = project
       "is.cir"                      %% "ciris"                   % cirisV,
       "io.github.arainko"           %% "ducktape"                % ducktapeV,
       "dev.rolang"                  %% "dumbo"                   % dumboV,
-      "org.typelevel"               %% "otel4s-core"             % otel4sV
+      "org.typelevel"               %% "otel4s-core"             % otel4sV,
+      "org.scalameta"                 %% "munit"                              % munitV           % Test,
+      "org.typelevel"                 %% "munit-cats-effect"                  % munitCatsEffectV % Test,
+      "com.dimafeng"                  %% "testcontainers-scala-munit"         % testcontainersV  % Test,
+      "com.dimafeng"                  %% "testcontainers-scala-postgresql"    % testcontainersV  % Test,
+      "com.softwaremill.sttp.tapir"   %% "tapir-sttp-client"                  % tapirV           % Test,
+      "com.softwaremill.sttp.client3" %% "http4s-backend"                     % "3.9.8"          % Test,
+      "io.circe"                      %% "circe-parser"                       % circeV           % Test
     )
   )
 

--- a/modules/example/src/main/resources/migrations/V1__schema.sql
+++ b/modules/example/src/main/resources/migrations/V1__schema.sql
@@ -1,3 +1,8 @@
+-- btree_gist enables btree-style operators (e.g. `=` on UUID) inside GiST indexes — required for the
+-- `EXCLUDE USING gist (room_id WITH =, period WITH &&)` constraint below. The fresh
+-- postgres:18-alpine image used by the test container does not have it loaded by default.
+CREATE EXTENSION IF NOT EXISTS btree_gist;
+
 CREATE TABLE rooms (
   id       UUID      PRIMARY KEY DEFAULT gen_random_uuid(),
   name     TEXT      NOT NULL,

--- a/modules/example/src/main/scala/skunk/sharp/example/api/Endpoints.scala
+++ b/modules/example/src/main/scala/skunk/sharp/example/api/Endpoints.scala
@@ -92,5 +92,8 @@ object Endpoints {
     val all = List(list, getById, byRoom, create, delete)
   }
 
-  val all = rooms.all ++ bookings.all
+  // `lazy` to avoid an init-cycle when a caller (e.g. a test) accesses `Endpoints.rooms.X` first: that
+  // forces `rooms.<clinit>`, which references `Endpoints.base`, which triggers `Endpoints.<clinit>`. If
+  // `all` were eager, it would dereference `rooms.all` while `rooms.<clinit>` is mid-init → NPE.
+  lazy val all: List[sttp.tapir.AnyEndpoint] = rooms.all ++ bookings.all
 }

--- a/modules/example/src/main/scala/skunk/sharp/example/repository/BookingFilter.scala
+++ b/modules/example/src/main/scala/skunk/sharp/example/repository/BookingFilter.scala
@@ -7,7 +7,8 @@ import java.util.UUID
 
 /**
  * Domain-level filter ADT for booking listing. Mirrors [[RoomFilter]] — see that file for the rationale on
- * sealed ADTs versus a wide optional-fields payload.
+ * sealed ADTs versus a wide optional-fields payload. The translation to `Where[Void]` lives in
+ * [[BookingRepository]] alongside the columns view it needs.
  *
  * Date filters operate on the `period: PgRange[LocalDate]` column via the range operators (`@>`, `&&`, lower /
  * upper accessors). The repository handles the SQL details; this layer just names the predicate.

--- a/modules/example/src/main/scala/skunk/sharp/example/repository/BookingRepository.scala
+++ b/modules/example/src/main/scala/skunk/sharp/example/repository/BookingRepository.scala
@@ -28,7 +28,7 @@ object BookingRepository {
   val live: BookingRepository = new BookingRepository {
     private val t = BookingRow.table
 
-    /** Captured columns view — see RoomRepository's `cv` for the rationale. */
+    /** Captured columns view of the bookings table — see RoomRepository's `cv` for the rationale. */
     private val cv = t.columnsView
 
     private val selectRow =
@@ -69,9 +69,9 @@ object BookingRepository {
       t.delete.where(b => b.id === Param[UUID]).compile
 
     /**
-     * Per-filter to-Where translation. The half-bounded ranges for "starts on or after" / "ends on or before"
-     * use `<@` (containedBy) against an open-ended probe range — that lets Postgres use the GiST index on
-     * `period` if one exists.
+     * Translate one filter case to a `Where[Void]`. The half-bounded ranges for "starts on or after" / "ends
+     * on or before" use `<@` (containedBy) against an open-ended probe range — that lets Postgres use the
+     * GiST index on `period` if one exists.
      */
     private def toWhere(f: BookingFilter): Where[skunk.Void] = f match {
       case BookingFilter.RoomsIn(ids) =>
@@ -87,11 +87,9 @@ object BookingRepository {
         cv.period.overlaps(Param.bind(PgRange[LocalDate](lower = Some(from), upper = Some(to))))
 
       case BookingFilter.StartsOnOrAfter(date) =>
-        // booking period sits within `[date, +∞)` — i.e. the booking starts on/after `date`.
         cv.period.containedBy(Param.bind(PgRange[LocalDate](lower = Some(date))))
 
       case BookingFilter.EndsOnOrBefore(date) =>
-        // booking period sits within `(−∞, date]` — i.e. the booking ends on/before `date`.
         cv.period.containedBy(Param.bind(PgRange[LocalDate](upper = Some(date), upperInclusive = true)))
     }
 

--- a/modules/example/src/main/scala/skunk/sharp/example/repository/RoomFilter.scala
+++ b/modules/example/src/main/scala/skunk/sharp/example/repository/RoomFilter.scala
@@ -7,12 +7,13 @@ import java.util.UUID
 /**
  * Domain-level filter ADT for room listing. Each case captures one runtime predicate the API can ask for; the
  * repository materialises a `List[RoomFilter]` into a single `WHERE` clause by translating each case to a
- * `Where[Void]` (values baked via `Param.bind`) and AND-folding the result.
+ * `Where[Void]` (values baked via `Param.bind`) and AND-folding the result. The translation lives in
+ * [[RoomRepository]] alongside the columns view it needs.
  *
  * Why a sealed ADT and not just `case class RoomQuery(minCapacity: Option[Int], …)`:
  *
  *   - Each case stays self-contained — adding a new filter is one new `case class` and one extra arm in the
- *     `toWhere` matcher in [[RoomRepository]], no fiddling with optional fields scattered across layers.
+ *     repository's `toWhere` matcher, no fiddling with optional fields scattered across layers.
  *   - The exhaustiveness check on the `match` keeps the repository honest when the ADT grows.
  *   - Multi-value cases (`NamesIn`, `IdsIn`) are first-class — they translate to `IN (…)` (OR semantics) inside
  *     a single AND-combined clause, which is closer to the intent than parallel optional fields would be.

--- a/modules/example/src/main/scala/skunk/sharp/example/repository/RoomRepository.scala
+++ b/modules/example/src/main/scala/skunk/sharp/example/repository/RoomRepository.scala
@@ -33,13 +33,9 @@ object RoomRepository {
     private val t = RoomRow.table
 
     /**
-     * The unaliased columns-view of the table, captured once. Its static type is `ColumnsView[<RoomRow.Cols>]`,
-     * so the named-tuple selectors `cv.id` / `cv.name` / `cv.capacity` resolve outside any builder lambda —
-     * which lets [[toWhere]] live as a normal method instead of being inlined inside `selectRow.where(c => …)`.
-     *
-     * Safe for the single-source unaliased shape we use here. If the relation were aliased (e.g.
-     * `t.alias("r")`), the lambda's `c` would be qualified-prefix-rendered and we'd want to use *that* view
-     * instead of this one.
+     * Captured columns view, statically typed as `ColumnsView[<RoomRow.table.Cols>]` — `cv.id` / `cv.name` /
+     * `cv.capacity` resolve via the named-tuple selector. Kept on the impl so [[toWhere]] is a normal method
+     * (not nested inside a `where(c => …)` lambda). Safe for the unaliased single-source case used here.
      */
     private val cv = t.columnsView
 
@@ -65,9 +61,8 @@ object RoomRepository {
       t.delete.where(r => r.id === Param[UUID]).compile
 
     /**
-     * Translate one filter case to a `Where[Void]` against the captured columns view. Every arm bakes its
-     * runtime value via `Param.bind`, so the result's `Args` is `Void` — that's what makes `Where.allOf` /
-     * `Where.anyOf` (Monoid-shaped) applicable downstream.
+     * Translate one filter case to a `Where[Void]`. Every arm bakes its runtime value via `Param.bind`, so the
+     * result has `Args = Void` and can be AND-folded with `dsl.allOf`.
      */
     private def toWhere(f: RoomFilter): Where[skunk.Void] = f match {
       case RoomFilter.CapacityAtLeast(n) => cv.capacity >= Param.bind(n)

--- a/modules/example/src/test/scala/skunk/sharp/example/ExampleAppFixture.scala
+++ b/modules/example/src/test/scala/skunk/sharp/example/ExampleAppFixture.scala
@@ -1,0 +1,120 @@
+package skunk.sharp.example
+
+import cats.effect.{IO, Resource}
+import com.dimafeng.testcontainers.PostgreSQLContainer
+import com.dimafeng.testcontainers.munit.TestContainerForAll
+import dumbo.{ConnectionConfig, Dumbo}
+import dumbo.logging.Implicits.console
+import munit.CatsEffectSuite
+import org.http4s.HttpRoutes
+import org.http4s.client.Client
+import org.testcontainers.utility.DockerImageName
+import org.typelevel.otel4s.metrics.Meter.Implicits.given
+import org.typelevel.otel4s.trace.Tracer.Implicits.given
+import skunk.Session
+import skunk.sharp.example.api.Routes
+import skunk.sharp.example.repository.{BookingRepository, RoomRepository}
+import sttp.capabilities.fs2.Fs2Streams
+import sttp.client3.{Request, Response, SttpBackend}
+import sttp.client3.http4s.Http4sBackend
+import sttp.model.Uri as SttpUri
+import sttp.tapir.client.sttp.SttpClientInterpreter
+
+/**
+ * Integration-test fixture for the example app: spins up Postgres in a container, runs the example's own
+ * dumbo migrations, builds the live `Routes`, and exposes an in-process **sttp `SttpBackend[IO, …]`** wired
+ * to the route handler via `Http4sBackend.usingClient(Client.fromHttpApp(routes.orNotFound))`.
+ *
+ * Tests use [[SttpClientInterpreter]] to derive typed sttp requests directly from the same
+ * `Endpoints.rooms.list` / `Endpoints.bookings.list` / etc. values the server publishes — the input DTOs
+ * (`RoomFilterQuery`, `BookingFilterQuery`, `CreateRoomRequest`, …) flow through unchanged on both sides.
+ * No port is bound; everything runs in-process for speed and determinism.
+ */
+trait ExampleAppFixture extends CatsEffectSuite with TestContainerForAll {
+
+  override val containerDef: PostgreSQLContainer.Def =
+    PostgreSQLContainer.Def(
+      dockerImageName = DockerImageName.parse("postgres:18-alpine"),
+      databaseName = "skunk_sharp_example",
+      username = "skunk_sharp",
+      password = "skunk_sharp"
+    )
+
+  override def afterContainersStart(containers: containerDef.Container): Unit = {
+    super.afterContainersStart(containers)
+    val conn = ConnectionConfig(
+      host = containers.host,
+      port = containers.mappedPort(5432),
+      user = containers.username,
+      database = containers.databaseName,
+      password = Some(containers.password),
+      ssl = ConnectionConfig.SSL.None
+    )
+    import cats.effect.unsafe.implicits.global
+    Dumbo.withResourcesIn[IO]("migrations").apply(conn).runMigration.void.unsafeRunSync()
+  }
+
+  /** A skunk session pool resource against the running container. */
+  protected def sessionPool(c: containerDef.Container): Resource[IO, Resource[IO, Session[IO]]] =
+    Session
+      .Builder[IO]
+      .withHost(c.host)
+      .withPort(c.mappedPort(5432))
+      .withUserAndPassword(c.username, c.password)
+      .withDatabase(c.databaseName)
+      .pooled(8)
+
+  /**
+   * Truncate the example's tables (`bookings`, `rooms`) before each test. `TestContainerForAll` reuses one
+   * container across the suite to keep CI fast — but that means rows from one test leak into the next, so
+   * tests that assert "all rooms" or expect a specific count must run against an empty database.
+   *
+   * Uses raw `skunk.command` because the truncate has no DSL representation in this codebase yet (no
+   * `Table#truncate` extension); it's a one-shot DDL-ish maintenance op.
+   */
+  protected def truncateAll(c: containerDef.Container): IO[Unit] = {
+    import skunk.implicits.*
+    sessionPool(c).use(_.use(_.execute(sql"TRUNCATE TABLE bookings, rooms RESTART IDENTITY CASCADE".command).void))
+  }
+
+  /** Base URI used to build sttp requests — all paths are absolute against this. */
+  protected val baseUri: SttpUri = sttp.model.Uri.unsafeParse("http://test")
+
+  /** The tapir → sttp interpreter — `toRequestThrowDecodeFailures` returns a function `Input => Request`. */
+  protected val interpreter: SttpClientInterpreter = SttpClientInterpreter()
+
+  /**
+   * Build an sttp backend wired in-process to the live app's routes. Tests should use this with
+   * [[interpreter]] to derive typed requests from the published [[skunk.sharp.example.api.Endpoints]] values.
+   */
+  protected def appBackend(c: containerDef.Container): Resource[IO, SttpBackend[IO, Fs2Streams[IO]]] =
+    sessionPool(c).map { pool =>
+      val routes: HttpRoutes[IO] = Routes(pool, RoomRepository.live, BookingRepository.live)
+      val client: Client[IO]     = Client.fromHttpApp(routes.orNotFound)
+      Http4sBackend.usingClient(client)
+    }
+
+  // ---- Request execution helpers (backend as a context parameter) ---------------------------
+  //
+  // Each suite declares `given SttpBackend[…]` once (typically by binding the lambda parameter via the
+  // `case given` pattern), then calls `.sendOk` / `.sendStatus` on tapir-derived requests without
+  // threading the backend through every call.
+
+  /**
+   * Send a request whose body is a tapir-derived `Either[E, O]` and unwrap the right side, raising on the
+   * left. Use for the happy-path assertions where a non-2xx is a test failure. Tapir-derived requests have
+   * capability `Any`; the backend's `Fs2Streams[IO] & Effect[IO]` trivially conforms.
+   */
+  extension [E, O](req: Request[Either[E, O], Any])
+    protected def sendOk(using backend: SttpBackend[IO, Fs2Streams[IO]]): IO[O] =
+      req.send(backend).flatMap(_.body match {
+        case Right(o) => IO.pure(o)
+        case Left(e)  => IO.raiseError(new RuntimeException(s"request failed: $e"))
+      })
+
+  /** Send and return the full response — for status-code assertions and error-envelope inspection. */
+  extension [T](req: Request[T, Any])
+    protected def sendResp(using backend: SttpBackend[IO, Fs2Streams[IO]]): IO[Response[T]] =
+      req.send(backend)
+
+}

--- a/modules/example/src/test/scala/skunk/sharp/example/api/BookingsFilterEndpointSuite.scala
+++ b/modules/example/src/test/scala/skunk/sharp/example/api/BookingsFilterEndpointSuite.scala
@@ -1,0 +1,145 @@
+package skunk.sharp.example.api
+
+import cats.effect.IO
+import skunk.sharp.example.ExampleAppFixture
+import sttp.capabilities.fs2.Fs2Streams
+import sttp.client3.SttpBackend
+
+import java.time.LocalDate
+import java.util.UUID
+
+/**
+ * End-to-end test for `GET /api/v1/bookings`. Mirrors [[RoomsFilterEndpointSuite]] but exercises the
+ * date-range filter cases — `OverlapsPeriod` (paired bounds), `StartsOnOrAfter` / `EndsOnOrBefore`
+ * (half-bounded), `RoomsIn`, `BookerNameContains`, `TitleContains`. The repository materialises these
+ * via skunk-sharp's range operators (`&&`, `<@`); this test covers the full path back to JSON responses.
+ */
+class BookingsFilterEndpointSuite extends ExampleAppFixture {
+
+  private val createRoomReq    = interpreter.toRequestThrowDecodeFailures(Endpoints.rooms.create,    Some(baseUri))
+  private val createBookingReq = interpreter.toRequestThrowDecodeFailures(Endpoints.bookings.create, Some(baseUri))
+  private val listBookingsReq  = interpreter.toRequestThrowDecodeFailures(Endpoints.bookings.list,   Some(baseUri))
+
+  private def createRoom(name: String, capacity: Int)(using SttpBackend[IO, Fs2Streams[IO]]): IO[RoomResponse] =
+    createRoomReq(CreateRoomRequest(name, capacity)).sendOk
+
+  private def createBooking(
+    roomId: UUID, booker: String, title: String, from: LocalDate, to: LocalDate
+  )(using SttpBackend[IO, Fs2Streams[IO]]): IO[BookingResponse] =
+    createBookingReq(CreateBookingRequest(roomId, booker, title, from, to)).sendOk
+
+  private def listBookings(q: BookingFilterQuery)(using SttpBackend[IO, Fs2Streams[IO]]): IO[List[BookingResponse]] =
+    listBookingsReq(q).sendOk
+
+  test("filter bookings by `roomIds` (IN)") {
+    withContainers { containers =>
+      appBackend(containers).use { case given SttpBackend[IO, Fs2Streams[IO]] =>
+        truncateAll(containers) *> (for {
+          a <- createRoom("A", 2)
+          b <- createRoom("B", 2)
+          c <- createRoom("C", 2)
+          _ <- createBooking(a.id, "alice", "ax", LocalDate.parse("2024-01-01"), LocalDate.parse("2024-01-10"))
+          _ <- createBooking(b.id, "bob", "bx", LocalDate.parse("2024-02-01"), LocalDate.parse("2024-02-10"))
+          _ <- createBooking(c.id, "carol", "cx", LocalDate.parse("2024-03-01"), LocalDate.parse("2024-03-10"))
+          rs <- listBookings(BookingFilterQuery.empty.copy(roomIds = List(a.id, b.id)))
+          _ = assertEquals(rs.map(_.title).toSet, Set("ax", "bx"))
+        } yield ())
+      }
+    }
+  }
+
+  test("filter bookings by bookerNameContains and titleContains (case-insensitive)") {
+    withContainers { containers =>
+      appBackend(containers).use { case given SttpBackend[IO, Fs2Streams[IO]] =>
+        truncateAll(containers) *> (for {
+          r <- createRoom("only", 1)
+          _ <- createBooking(r.id, "Alice Smith", "team standup", LocalDate.parse("2024-01-01"), LocalDate.parse("2024-01-02"))
+          _ <- createBooking(r.id, "Bob Jones",   "1:1 sync",     LocalDate.parse("2024-01-03"), LocalDate.parse("2024-01-04"))
+          _ <- createBooking(r.id, "Alice Watt",  "design review",LocalDate.parse("2024-01-05"), LocalDate.parse("2024-01-06"))
+          alices <- listBookings(BookingFilterQuery.empty.copy(bookerNameContains = Some("alice")))
+          _ = assertEquals(alices.map(_.bookerName).toSet, Set("Alice Smith", "Alice Watt"))
+          syncs <- listBookings(BookingFilterQuery.empty.copy(titleContains = Some("sync")))
+          _ = assertEquals(syncs.map(_.title), List("1:1 sync"))
+        } yield ())
+      }
+    }
+  }
+
+  test("filter bookings by overlapsPeriod (paired bounds — `period && [from, to)`)") {
+    withContainers { containers =>
+      appBackend(containers).use { case given SttpBackend[IO, Fs2Streams[IO]] =>
+        truncateAll(containers) *> (for {
+          r <- createRoom("ovr", 1)
+          _ <- createBooking(r.id, "x", "ancient", LocalDate.parse("2000-01-01"), LocalDate.parse("2000-01-31"))
+          _ <- createBooking(r.id, "x", "fresh",   LocalDate.parse("2024-06-01"), LocalDate.parse("2024-06-30"))
+          _ <- createBooking(r.id, "x", "future",  LocalDate.parse("2030-01-01"), LocalDate.parse("2030-01-31"))
+          probe = BookingFilterQuery.empty.copy(
+            overlapsFrom = Some(LocalDate.parse("2024-01-01")),
+            overlapsTo   = Some(LocalDate.parse("2024-12-31"))
+          )
+          hits <- listBookings(probe)
+          _ = assertEquals(hits.map(_.title), List("fresh"))
+        } yield ())
+      }
+    }
+  }
+
+  test("filter bookings by startsOnOrAfter (half-bounded — `period <@ [date, +∞)`)") {
+    withContainers { containers =>
+      appBackend(containers).use { case given SttpBackend[IO, Fs2Streams[IO]] =>
+        truncateAll(containers) *> (for {
+          r <- createRoom("sb", 1)
+          _ <- createBooking(r.id, "x", "early",  LocalDate.parse("2024-01-01"), LocalDate.parse("2024-01-31"))
+          _ <- createBooking(r.id, "x", "middle", LocalDate.parse("2024-06-01"), LocalDate.parse("2024-06-30"))
+          _ <- createBooking(r.id, "x", "late",   LocalDate.parse("2024-12-01"), LocalDate.parse("2024-12-31"))
+          rs <- listBookings(
+                  BookingFilterQuery.empty.copy(startsOnOrAfter = Some(LocalDate.parse("2024-06-01")))
+                )
+          _ = assertEquals(rs.map(_.title).toSet, Set("middle", "late"))
+        } yield ())
+      }
+    }
+  }
+
+  test("AND-combination — roomIds + overlapsPeriod + bookerNameContains") {
+    withContainers { containers =>
+      appBackend(containers).use { case given SttpBackend[IO, Fs2Streams[IO]] =>
+        truncateAll(containers) *> (for {
+          a <- createRoom("RA", 1)
+          b <- createRoom("RB", 1)
+          // In room A: alice with booking that overlaps 2024-Q2 — match
+          _ <- createBooking(a.id, "alice", "match",       LocalDate.parse("2024-04-01"), LocalDate.parse("2024-04-15"))
+          // In room A: bob with booking that overlaps — wrong booker, no match
+          _ <- createBooking(a.id, "bob",   "wrong-booker",LocalDate.parse("2024-05-01"), LocalDate.parse("2024-05-15"))
+          // In room A: alice in Q1 — wrong period, no match
+          _ <- createBooking(a.id, "alice", "wrong-period",LocalDate.parse("2024-01-10"), LocalDate.parse("2024-01-20"))
+          // In room B: alice overlapping — wrong room, no match
+          _ <- createBooking(b.id, "alice", "wrong-room",  LocalDate.parse("2024-04-10"), LocalDate.parse("2024-04-20"))
+          rs <- listBookings(
+                  BookingFilterQuery.empty.copy(
+                    roomIds            = List(a.id),
+                    bookerNameContains = Some("alice"),
+                    overlapsFrom       = Some(LocalDate.parse("2024-04-01")),
+                    overlapsTo         = Some(LocalDate.parse("2024-06-30"))
+                  )
+                )
+          _ = assertEquals(rs.map(_.title), List("match"))
+        } yield ())
+      }
+    }
+  }
+
+  test("empty filter set returns the static `findAllQ` path — all bookings") {
+    withContainers { containers =>
+      appBackend(containers).use { case given SttpBackend[IO, Fs2Streams[IO]] =>
+        truncateAll(containers) *> (for {
+          r <- createRoom("e", 1)
+          _ <- createBooking(r.id, "x", "b1", LocalDate.parse("2024-01-01"), LocalDate.parse("2024-01-02"))
+          _ <- createBooking(r.id, "x", "b2", LocalDate.parse("2024-02-01"), LocalDate.parse("2024-02-02"))
+          all <- listBookings(BookingFilterQuery.empty)
+          _ = assertEquals(all.size, 2)
+        } yield ())
+      }
+    }
+  }
+}

--- a/modules/example/src/test/scala/skunk/sharp/example/api/RoomsFilterEndpointSuite.scala
+++ b/modules/example/src/test/scala/skunk/sharp/example/api/RoomsFilterEndpointSuite.scala
@@ -1,0 +1,144 @@
+package skunk.sharp.example.api
+
+import cats.effect.IO
+import skunk.sharp.example.ExampleAppFixture
+import sttp.capabilities.fs2.Fs2Streams
+import sttp.client3.SttpBackend
+import sttp.model.StatusCode
+
+import java.util.UUID
+
+/**
+ * End-to-end test for `GET /api/v1/rooms` with the dynamic-filter query DTO. Spins up Postgres + the live
+ * app via [[ExampleAppFixture]], creates a known fixture set of rooms via `POST`, then exercises filter
+ * combinations through tapir-derived sttp requests against the in-process backend.
+ *
+ * The point is to verify the full path: tapir's `EndpointInput.derived[RoomFilterQuery]` correctly extracts
+ * each query param shape on the *server* (`Option[T]`, repeated `List[T]`), and the *same* endpoint value
+ * on the *client* side rebuilds those query params from the typed DTO via `SttpClientInterpreter` — both
+ * sides exchange `RoomFilterQuery` values, no string-keying anywhere.
+ *
+ * The `SttpBackend` is bound as a `given` per test via `case given …` in the resource-`use` lambda; the
+ * helper methods take it as a context parameter so call sites stay close to "just call the endpoint".
+ */
+class RoomsFilterEndpointSuite extends ExampleAppFixture {
+
+  private val createRoomReq = interpreter.toRequestThrowDecodeFailures(Endpoints.rooms.create, Some(baseUri))
+  private val listReq       = interpreter.toRequestThrowDecodeFailures(Endpoints.rooms.list,   Some(baseUri))
+  private val getByIdReq    = interpreter.toRequest(Endpoints.rooms.getById,                   Some(baseUri))
+
+  private def createRoom(name: String, capacity: Int)(using SttpBackend[IO, Fs2Streams[IO]]): IO[RoomResponse] =
+    createRoomReq(CreateRoomRequest(name, capacity)).sendOk
+
+  private def listRooms(q: RoomFilterQuery)(using SttpBackend[IO, Fs2Streams[IO]]): IO[List[RoomResponse]] =
+    listReq(q).sendOk
+
+  test("filter rooms by minCapacity / maxCapacity") {
+    withContainers { containers =>
+      appBackend(containers).use { case given SttpBackend[IO, Fs2Streams[IO]] =>
+        truncateAll(containers) *> (for {
+          _ <- createRoom("small", 4)
+          _ <- createRoom("medium", 12)
+          _ <- createRoom("large", 50)
+          all <- listRooms(RoomFilterQuery.empty)
+          _ = assertEquals(all.map(_.name).toSet, Set("small", "medium", "large"))
+          big <- listRooms(RoomFilterQuery.empty.copy(minCapacity = Some(10)))
+          _ = assertEquals(big.map(_.name).toSet, Set("medium", "large"))
+          mid <- listRooms(RoomFilterQuery.empty.copy(minCapacity = Some(5), maxCapacity = Some(20)))
+          _ = assertEquals(mid.map(_.name).toSet, Set("medium"))
+        } yield ())
+      }
+    }
+  }
+
+  test("filter rooms by nameContains (ILIKE substring)") {
+    withContainers { containers =>
+      appBackend(containers).use { case given SttpBackend[IO, Fs2Streams[IO]] =>
+        truncateAll(containers) *> (for {
+          _ <- createRoom("Atrium-A", 8)
+          _ <- createRoom("Atrium-B", 8)
+          _ <- createRoom("Lounge", 4)
+          atria <- listRooms(RoomFilterQuery.empty.copy(nameContains = Some("atrium")))
+          _ = assertEquals(atria.map(_.name).toSet, Set("Atrium-A", "Atrium-B"))
+          lounges <- listRooms(RoomFilterQuery.empty.copy(nameContains = Some("lou")))
+          _ = assertEquals(lounges.map(_.name), List("Lounge"))
+        } yield ())
+      }
+    }
+  }
+
+  test("filter rooms by repeated `names` query param (IN)") {
+    withContainers { containers =>
+      appBackend(containers).use { case given SttpBackend[IO, Fs2Streams[IO]] =>
+        truncateAll(containers) *> (for {
+          _ <- createRoom("alpha", 2)
+          _ <- createRoom("beta", 2)
+          _ <- createRoom("gamma", 2)
+          rs <- listRooms(RoomFilterQuery.empty.copy(names = List("alpha", "gamma")))
+          _ = assertEquals(rs.map(_.name).toSet, Set("alpha", "gamma"))
+        } yield ())
+      }
+    }
+  }
+
+  test("filter rooms by `ids` (IN) — restrict the listing to a known UUID set") {
+    withContainers { containers =>
+      appBackend(containers).use { case given SttpBackend[IO, Fs2Streams[IO]] =>
+        truncateAll(containers) *> (for {
+          a <- createRoom("A", 1)
+          b <- createRoom("B", 2)
+          _ <- createRoom("C", 3)
+          rs <- listRooms(RoomFilterQuery.empty.copy(ids = List(a.id, b.id)))
+          _ = assertEquals(rs.map(_.name).toSet, Set("A", "B"))
+        } yield ())
+      }
+    }
+  }
+
+  test("AND-combination — minCapacity + nameContains + names list") {
+    withContainers { containers =>
+      appBackend(containers).use { case given SttpBackend[IO, Fs2Streams[IO]] =>
+        truncateAll(containers) *> (for {
+          _ <- createRoom("Hub-North", 30)
+          _ <- createRoom("Hub-South", 5)
+          _ <- createRoom("Hub-East", 30)
+          _ <- createRoom("Plaza", 40)
+          rs <- listRooms(
+                  RoomFilterQuery(
+                    minCapacity  = Some(10),
+                    maxCapacity  = None,
+                    nameContains = Some("hub"),
+                    names        = List("Hub-North", "Hub-East"),
+                    ids          = Nil
+                  )
+                )
+          _ = assertEquals(rs.map(_.name).toSet, Set("Hub-North", "Hub-East"))
+        } yield ())
+      }
+    }
+  }
+
+  test("empty filter set returns the static `findAllQ` path — all rooms") {
+    withContainers { containers =>
+      appBackend(containers).use { case given SttpBackend[IO, Fs2Streams[IO]] =>
+        truncateAll(containers) *> (for {
+          _ <- createRoom("x1", 1)
+          _ <- createRoom("x2", 1)
+          all <- listRooms(RoomFilterQuery.empty)
+          _ = assertEquals(all.size, 2)
+        } yield ())
+      }
+    }
+  }
+
+  test("404 on a missing room id surfaces as a NotFound status with the JSON error envelope") {
+    withContainers { containers =>
+      appBackend(containers).use { case given SttpBackend[IO, Fs2Streams[IO]] =>
+        truncateAll(containers) *>
+          getByIdReq(UUID.randomUUID).sendResp.map { resp =>
+            assertEquals(resp.code, StatusCode.NotFound)
+          }
+      }
+    }
+  }
+}

--- a/modules/example/src/test/scala/skunk/sharp/example/api/TransformersFilterSuite.scala
+++ b/modules/example/src/test/scala/skunk/sharp/example/api/TransformersFilterSuite.scala
@@ -1,0 +1,98 @@
+package skunk.sharp.example.api
+
+import cats.data.NonEmptyList
+import skunk.sharp.example.repository.{BookingFilter, RoomFilter}
+import Transformers.*
+
+import java.time.LocalDate
+import java.util.UUID
+
+/**
+ * Pure unit tests for the query DTO ↔ filter ADT projection. The SQL-rendering side of each filter case is
+ * already covered by core suites (`WhereSuite`, `ParamSuite`, `RangeSuite`) — what's specific to the example
+ * module is the `q.toFilters` extension's logic, especially the paired-field rule for `OverlapsPeriod`.
+ */
+class TransformersFilterSuite extends munit.FunSuite {
+
+  test("RoomFilterQuery.empty.toFilters is empty") {
+    assertEquals(RoomFilterQuery.empty.toFilters, Nil)
+  }
+
+  test("RoomFilterQuery — every field translates to its filter case") {
+    val ids = List(UUID.randomUUID, UUID.randomUUID)
+    val q = RoomFilterQuery(
+      minCapacity  = Some(10),
+      maxCapacity  = Some(50),
+      nameContains = Some("hub"),
+      names        = List("alpha", "beta"),
+      ids          = ids
+    )
+    assertEquals(
+      q.toFilters,
+      List(
+        RoomFilter.CapacityAtLeast(10),
+        RoomFilter.CapacityAtMost(50),
+        RoomFilter.NameContains("hub"),
+        RoomFilter.NamesIn(NonEmptyList.of("alpha", "beta")),
+        RoomFilter.IdsIn(NonEmptyList.fromListUnsafe(ids))
+      )
+    )
+  }
+
+  test("RoomFilterQuery — empty multi-value lists drop out (no IN clause)") {
+    val q = RoomFilterQuery(
+      minCapacity  = Some(1),
+      maxCapacity  = None,
+      nameContains = None,
+      names        = Nil,
+      ids          = Nil
+    )
+    assertEquals(q.toFilters, List(RoomFilter.CapacityAtLeast(1)))
+  }
+
+  test("BookingFilterQuery.empty.toFilters is empty") {
+    assertEquals(BookingFilterQuery.empty.toFilters, Nil)
+  }
+
+  test("BookingFilterQuery — every field translates to its filter case") {
+    val rids = List(UUID.randomUUID, UUID.randomUUID)
+    val from = LocalDate.parse("2024-01-01")
+    val to   = LocalDate.parse("2024-12-31")
+    val q = BookingFilterQuery(
+      roomIds            = rids,
+      bookerNameContains = Some("alice"),
+      titleContains      = Some("standup"),
+      overlapsFrom       = Some(from),
+      overlapsTo         = Some(to),
+      startsOnOrAfter    = Some(from),
+      endsOnOrBefore     = Some(to)
+    )
+    assertEquals(
+      q.toFilters,
+      List(
+        BookingFilter.RoomsIn(NonEmptyList.fromListUnsafe(rids)),
+        BookingFilter.BookerNameContains("alice"),
+        BookingFilter.TitleContains("standup"),
+        BookingFilter.OverlapsPeriod(from, to),
+        BookingFilter.StartsOnOrAfter(from),
+        BookingFilter.EndsOnOrBefore(to)
+      )
+    )
+  }
+
+  test("BookingFilterQuery — overlapsFrom alone (without overlapsTo) drops the OverlapsPeriod filter") {
+    val q = BookingFilterQuery.empty.copy(overlapsFrom = Some(LocalDate.parse("2024-01-01")))
+    assertEquals(q.toFilters, Nil, "single-bound overlaps must not produce an OverlapsPeriod")
+  }
+
+  test("BookingFilterQuery — overlapsTo alone drops OverlapsPeriod too") {
+    val q = BookingFilterQuery.empty.copy(overlapsTo = Some(LocalDate.parse("2024-12-31")))
+    assertEquals(q.toFilters, Nil)
+  }
+
+  test("BookingFilterQuery — half-bounded startsOnOrAfter is independent of the OverlapsPeriod pair") {
+    val date = LocalDate.parse("2024-06-15")
+    val q = BookingFilterQuery.empty.copy(startsOnOrAfter = Some(date))
+    assertEquals(q.toFilters, List(BookingFilter.StartsOnOrAfter(date)))
+  }
+}


### PR DESCRIPTION
## Summary

End-to-end integration tests for the example module's dynamic-filter endpoints:

- **`ExampleAppFixture`** — Postgres testcontainer + dumbo migrations + an in-process `SttpBackend[IO, Fs2Streams[IO]]` wired to the live `Routes` via `Http4sBackend.usingClient(Client.fromHttpApp(routes.orNotFound))`. No port binding; full handler chain. `truncateAll(c)` wipes `bookings`+`rooms` between tests so the shared container doesn't leak rows.
- **Context-parameter ergonomics**: `extension (req).sendOk` / `.sendResp` take the backend via `using`; tests bind it once with `case given SttpBackend[IO, Fs2Streams[IO]] =>` in the resource-`use` lambda.
- **`RoomsFilterEndpointSuite`** (7) — `minCapacity`/`maxCapacity`, `nameContains`, repeated `names`/`ids`, AND-combination, empty-filter `findAllQ` path, 404 envelope.
- **`BookingsFilterEndpointSuite`** (6) — `RoomsIn`, `BookerNameContains`/`TitleContains`, `OverlapsPeriod` (paired bounds → `&&`), `StartsOnOrAfter` (half-bounded → `<@`), AND-combination across all four, empty-filter path.
- **`TransformersFilterSuite`** (8) — pure DTO → ADT projection tests including the paired-field rule for `OverlapsPeriod`.

Tests use tapir's `SttpClientInterpreter` against the same `Endpoints.rooms.list` / `Endpoints.bookings.list` / `Endpoints.rooms.create` / etc. values the server publishes — both sides exchange the typed DTO directly, no string-keying.

## Refactors
- `RoomFilter.toWhere` / `BookingFilter.toWhere` moved back from the filter ADT companions into each repository's live impl, alongside its captured `cv`. Keeps the ADT pure data; SQL-rendering lives next to the columns view.
- `Endpoints.all` made `lazy val` to break a class-init cycle (test path: `Endpoints.rooms.X` → `rooms.<clinit>` → references `Endpoints.base` → `Endpoints.<clinit>` → eager `rooms.all` mid-init → NPE).
- `V1__schema.sql` prepends `CREATE EXTENSION IF NOT EXISTS btree_gist` — required for `EXCLUDE USING gist (room_id WITH =, period WITH &&)` on a fresh `postgres:18-alpine` container. Idempotent in production.

## Build
- Adds to `example` test scope: `testcontainers-scala-munit`, `testcontainers-scala-postgresql`, `tapir-sttp-client`, `sttp-client3 % http4s-backend` (3.9.8 — latest published for Scala 3), `circe-parser`.

## Test plan
- [x] `sbt example/test` — 21 tests pass (8 transformer + 7 rooms + 6 bookings), Postgres testcontainer per suite
- [x] `sbt tests/test` — 174 integration tests pass; no regression from core changes shipped earlier
- [x] `sbt example/run` (production path) — confirmed unchanged: lazy val for `Endpoints.all` is a no-op for the production access pattern that already touched `Endpoints.all` first

🤖 Generated with [Claude Code](https://claude.com/claude-code)