### PR TITLE
ci: drop scalafmt RedundantParens rewrite + reformat all sources

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -5,7 +5,11 @@ maxColumn = 120
 align.preset = more
 align.multiline = false
 
-rewrite.rules = [RedundantParens, SortImports]
+# NOTE: `RedundantParens` is intentionally NOT in this list. It strips the parens around refinement
+# types in `given X[T]: (Trait[T] { type Out = … }) = …` declarations, which the Scala 3 parser then
+# misreads as the start of a `given X with { … }` body — fails with `'with' expected, but '{' found`.
+# Several files in `dsl/` (ProjArgsOf, Cte, Join) rely on these parens.
+rewrite.rules = [SortImports]
 rewrite.redundantBraces.stringInterpolation = true
 # Prefer braces over Scala 3 optional-braces indentation.
 rewrite.scala3.convertToNewSyntax = false

--- a/build.sbt
+++ b/build.sbt
@@ -88,21 +88,21 @@ lazy val example = project
   .settings(
     name := "skunk-sharp-example",
     libraryDependencies ++= Seq(
-      "com.softwaremill.sttp.tapir" %% "tapir-http4s-server"     % tapirV,
-      "com.softwaremill.sttp.tapir" %% "tapir-swagger-ui-bundle" % tapirV,
-      "com.softwaremill.sttp.tapir" %% "tapir-json-circe"        % tapirV,
-      "org.http4s"                  %% "http4s-ember-server"     % http4sV,
-      "is.cir"                      %% "ciris"                   % cirisV,
-      "io.github.arainko"           %% "ducktape"                % ducktapeV,
-      "dev.rolang"                  %% "dumbo"                   % dumboV,
-      "org.typelevel"               %% "otel4s-core"             % otel4sV,
-      "org.scalameta"                 %% "munit"                              % munitV           % Test,
-      "org.typelevel"                 %% "munit-cats-effect"                  % munitCatsEffectV % Test,
-      "com.dimafeng"                  %% "testcontainers-scala-munit"         % testcontainersV  % Test,
-      "com.dimafeng"                  %% "testcontainers-scala-postgresql"    % testcontainersV  % Test,
-      "com.softwaremill.sttp.tapir"   %% "tapir-sttp-client"                  % tapirV           % Test,
-      "com.softwaremill.sttp.client3" %% "http4s-backend"                     % "3.9.8"          % Test,
-      "io.circe"                      %% "circe-parser"                       % circeV           % Test
+      "com.softwaremill.sttp.tapir"   %% "tapir-http4s-server"             % tapirV,
+      "com.softwaremill.sttp.tapir"   %% "tapir-swagger-ui-bundle"         % tapirV,
+      "com.softwaremill.sttp.tapir"   %% "tapir-json-circe"                % tapirV,
+      "org.http4s"                    %% "http4s-ember-server"             % http4sV,
+      "is.cir"                        %% "ciris"                           % cirisV,
+      "io.github.arainko"             %% "ducktape"                        % ducktapeV,
+      "dev.rolang"                    %% "dumbo"                           % dumboV,
+      "org.typelevel"                 %% "otel4s-core"                     % otel4sV,
+      "org.scalameta"                 %% "munit"                           % munitV           % Test,
+      "org.typelevel"                 %% "munit-cats-effect"               % munitCatsEffectV % Test,
+      "com.dimafeng"                  %% "testcontainers-scala-munit"      % testcontainersV  % Test,
+      "com.dimafeng"                  %% "testcontainers-scala-postgresql" % testcontainersV  % Test,
+      "com.softwaremill.sttp.tapir"   %% "tapir-sttp-client"               % tapirV           % Test,
+      "com.softwaremill.sttp.client3" %% "http4s-backend"                  % "3.9.8"          % Test,
+      "io.circe"                      %% "circe-parser"                    % circeV           % Test
     )
   )
 

--- a/modules/core/src/main/scala/skunk/sharp/Interpolator.scala
+++ b/modules/core/src/main/scala/skunk/sharp/Interpolator.scala
@@ -1,21 +1,18 @@
 package skunk.sharp
 
 /**
- * `expr"..."` — a typed SQL string interpolator that weaves literal SQL with [[TypedExpr]] interpolations,
- * producing a [[RawExprBuilder]] you commit to a result type via `.as[T]` / `.asCodec(codec)` /
- * `.asCodec(e: TypedExpr[T, ?])`.
+ * `expr"..."` — a typed SQL string interpolator that weaves literal SQL with [[TypedExpr]] interpolations, producing a
+ * [[RawExprBuilder]] you commit to a result type via `.as[T]` / `.asCodec(codec)` / `.asCodec(e: TypedExpr[T, ?])`.
  *
- * **Static-by-default**: every interpolation must be a `TypedExpr` — column refs, `Param[T]` (deferred),
- * `lit(v)` (compile-time literal), or `Param.bind(v)` (explicit bake). Bare runtime values are rejected at
- * compile time, mirroring the `=== / := / between / like` operators. This forces the caller to make the
- * binding decision explicit.
+ * **Static-by-default**: every interpolation must be a `TypedExpr` — column refs, `Param[T]` (deferred), `lit(v)`
+ * (compile-time literal), or `Param.bind(v)` (explicit bake). Bare runtime values are rejected at compile time,
+ * mirroring the `=== / := / between / like` operators. This forces the caller to make the binding decision explicit.
  *
- * Each interpolation contributes its `Args` slot to the result; the visible `Args` type is the smart-flat
- * concat over every slot (see `Where.FoldConcat`), matching how every other typed-args builder folds N
- * inputs.
+ * Each interpolation contributes its `Args` slot to the result; the visible `Args` type is the smart-flat concat over
+ * every slot (see `Where.FoldConcat`), matching how every other typed-args builder folds N inputs.
  *
- * Use `.asCodec(e)` (passing one of the spliced TypedExprs) to reuse that expression's exact codec — the
- * common shape for tag-preserving function helpers — instead of writing `.asCodec(e.codec)`.
+ * Use `.asCodec(e)` (passing one of the spliced TypedExprs) to reuse that expression's exact codec — the common shape
+ * for tag-preserving function helpers — instead of writing `.asCodec(e.codec)`.
  *
  * {{{
  *   val ageGte18: TypedExpr[Boolean, Int] =
@@ -29,12 +26,13 @@ package skunk.sharp
  *     expr"upper($emailCol)".asCodec(emailCol)
  * }}}
  *
- * **Inline-def usage caveat**: Scala 3 `transparent inline` doesn't refine return types in inline-def
- * bodies, so `expr"…"` cannot replace function helpers like `lpad`/`rpad` whose abstract type vars need to
- * thread through the chained `.asCodec(...)` call. Use `expr"…"` in concrete user code; for
- * variadic-typed function helpers in extension modules, build the expression manually (the existing
- * `PgFunction.unary`/`binary`/`naryTypedFold` substrate is the right tool there).
+ * **Inline-def usage caveat**: Scala 3 `transparent inline` doesn't refine return types in inline-def bodies, so
+ * `expr"…"` cannot replace function helpers like `lpad`/`rpad` whose abstract type vars need to thread through the
+ * chained `.asCodec(...)` call. Use `expr"…"` in concrete user code; for variadic-typed function helpers in extension
+ * modules, build the expression manually (the existing `PgFunction.unary`/`binary`/`naryTypedFold` substrate is the
+ * right tool there).
  */
 extension (inline sc: StringContext)
+
   transparent inline def expr(inline args: Any*): RawExprBuilder[?] =
     ${ skunk.sharp.internal.ExprMacro.impl('sc, 'args) }

--- a/modules/core/src/main/scala/skunk/sharp/Param.scala
+++ b/modules/core/src/main/scala/skunk/sharp/Param.scala
@@ -45,9 +45,8 @@ object Param {
   def of[T](codec: Codec[T]): Param[T] = new Param[T](codec)
 
   /**
-   * A `Param[List[T]]` for a fixed-size list — useful for `IN` lists where you want **one** prepared
-   * statement per size and a single `List[T]` bind at execute time, instead of N separate `Param.bind`s
-   * baked at builder-build time.
+   * A `Param[List[T]]` for a fixed-size list — useful for `IN` lists where you want **one** prepared statement per size
+   * and a single `List[T]` bind at execute time, instead of N separate `Param.bind`s baked at builder-build time.
    *
    * {{{
    *   val byIds = users.select.where(u => u.id.in(Param.list[UUID](3))).compile
@@ -56,20 +55,24 @@ object Param {
    *   byIds.run(session)(List(uid1, uid2, uid3))
    * }}}
    *
-   * The result fragment expands to N comma-separated `$N` placeholders sharing one prepared statement.
-   * Bind a list of exactly `size` elements at execute time — skunk raises if the list length disagrees.
+   * The result fragment expands to N comma-separated `$N` placeholders sharing one prepared statement. Bind a list of
+   * exactly `size` elements at execute time — skunk raises if the list length disagrees.
    *
-   * For lists whose size varies between calls, either rebuild the query per size (different prepared
-   * statement each time) or reach for `col === ANY(Param[Arr[T]])` (single statement, single array bind).
+   * For lists whose size varies between calls, either rebuild the query per size (different prepared statement each
+   * time) or reach for `col === ANY(Param[Arr[T]])` (single statement, single array bind).
    */
   def list[T](size: Int)(using pf: PgTypeFor[T]): Param[List[T]] = {
-    val inner = pf.codec
-    val enc   = inner.list(size)
+    val inner                 = pf.codec
+    val enc                   = inner.list(size)
     val codec: Codec[List[T]] = new Codec[List[T]] {
-      override def encode(xs: List[T]): List[Option[skunk.data.Encoded]] = enc.encode(xs)
+      override def encode(xs: List[T]): List[Option[skunk.data.Encoded]]                               = enc.encode(xs)
       override def decode(offset: Int, ss: List[Option[String]]): Either[skunk.Decoder.Error, List[T]] =
-        Left(skunk.Decoder.Error(offset, size, "Param.list[T] is bind-only — IN-list parameters can't appear in a SELECT projection."))
-      override val types: List[skunk.data.Type] = enc.types
+        Left(skunk.Decoder.Error(
+          offset,
+          size,
+          "Param.list[T] is bind-only — IN-list parameters can't appear in a SELECT projection."
+        ))
+      override val types: List[skunk.data.Type]      = enc.types
       override val sql: cats.data.State[Int, String] = enc.sql
     }
     Param.of(codec)

--- a/modules/core/src/main/scala/skunk/sharp/RawExprBuilder.scala
+++ b/modules/core/src/main/scala/skunk/sharp/RawExprBuilder.scala
@@ -4,10 +4,10 @@ import skunk.{Codec, Fragment}
 import skunk.sharp.pg.PgTypeFor
 
 /**
- * Intermediate stage of the [[expr]] string interpolator. The interpolator weaves the literal SQL parts and the
- * `$col` / `$value` interpolations into a single typed `Fragment[Args]`, but does not know the Scala type the
- * resulting expression decodes to. Callers commit a result type via either [[as]] (resolves `PgTypeFor[T]`'s
- * canonical codec) or [[asCodec]] (explicit `Codec[T]` — useful when reusing an input expression's codec, e.g.
+ * Intermediate stage of the [[expr]] string interpolator. The interpolator weaves the literal SQL parts and the `$col`
+ * / `$value` interpolations into a single typed `Fragment[Args]`, but does not know the Scala type the resulting
+ * expression decodes to. Callers commit a result type via either [[as]] (resolves `PgTypeFor[T]`'s canonical codec) or
+ * [[asCodec]] (explicit `Codec[T]` — useful when reusing an input expression's codec, e.g.
  * `expr"lower($e)".asCodec(e.codec)`).
  */
 final class RawExprBuilder[Args](val fragment: Fragment[Args]) {
@@ -21,9 +21,8 @@ final class RawExprBuilder[Args](val fragment: Fragment[Args]) {
     TypedExpr(fragment, codec)
 
   /**
-   * Commit the result type as `T`, reusing an existing `TypedExpr`'s codec. The common shape for tag- /
-   * type-preserving functions where the result codec is the input expression's codec — replaces
-   * `.asCodec(e.codec)` with `.asCodec(e)`.
+   * Commit the result type as `T`, reusing an existing `TypedExpr`'s codec. The common shape for tag- / type-preserving
+   * functions where the result codec is the input expression's codec — replaces `.asCodec(e.codec)` with `.asCodec(e)`.
    */
   def asCodec[T](e: TypedExpr[T, ?]): TypedExpr[T, Args] =
     TypedExpr(fragment, e.codec)

--- a/modules/core/src/main/scala/skunk/sharp/dsl/CaseExpr.scala
+++ b/modules/core/src/main/scala/skunk/sharp/dsl/CaseExpr.scala
@@ -4,19 +4,19 @@ import skunk.{Codec, Encoder, Fragment, Void}
 import skunk.sharp.TypedExpr
 
 /**
- * `CASE WHEN … THEN … [ELSE …] END` — the universal conditional primitive. Usable in SELECT projections,
- * WHERE, ORDER BY, UPDATE SET right-hand sides, GROUP BY — anywhere a [[TypedExpr]] is accepted.
+ * `CASE WHEN … THEN … [ELSE …] END` — the universal conditional primitive. Usable in SELECT projections, WHERE, ORDER
+ * BY, UPDATE SET right-hand sides, GROUP BY — anywhere a [[TypedExpr]] is accepted.
  *
- * Branch predicates and bodies may carry their own `Args` (e.g. `Param[T]`). `CaseWhen` carries `Items <:
- * Tuple` accumulating each `(cond, branch)` pair as `TypedExpr[Boolean, A1] *: TypedExpr[T, A2] *: …`;
- * `.otherwise` / `.end` summon [[ProjArgsOf]] over the full item list (with ELSE appended for `.otherwise`)
- * to derive the result's typed `Args`. Branches with all `Args = Void` collapse cleanly to `Void`.
+ * Branch predicates and bodies may carry their own `Args` (e.g. `Param[T]`). `CaseWhen` carries `Items <: Tuple`
+ * accumulating each `(cond, branch)` pair as `TypedExpr[Boolean, A1] *: TypedExpr[T, A2] *: …`; `.otherwise` / `.end`
+ * summon [[ProjArgsOf]] over the full item list (with ELSE appended for `.otherwise`) to derive the result's typed
+ * `Args`. Branches with all `Args = Void` collapse cleanly to `Void`.
  *
  * Terminate with `.otherwise(elseBranch)` (returns `TypedExpr[T, OutA]`) or `.end` (returns
  * `TypedExpr[Option[T], OutA]`).
  */
 final class CaseWhen[T, Items <: Tuple] private[sharp] (
-  private[sharp] val branches:    List[(TypedExpr[Boolean, ?], TypedExpr[T, ?])],
+  private[sharp] val branches: List[(TypedExpr[Boolean, ?], TypedExpr[T, ?])],
   private[sharp] val branchCodec: Codec[T]
 ) {
 
@@ -35,21 +35,24 @@ final class CaseWhen[T, Items <: Tuple] private[sharp] (
   def end[OutA](using pa: ProjArgsOf.Aux[Items, OutA]): TypedExpr[Option[T], OutA] = {
     val coercedBranches = branches.map { case (c, b) => (c, b.asInstanceOf[TypedExpr[Option[T], ?]]) }
     renderCaseWhen[Option[T], OutA](
-      coercedBranches, None, branchCodec.opt, pa.project.asInstanceOf[Any => List[Any]]
+      coercedBranches,
+      None,
+      branchCodec.opt,
+      pa.project.asInstanceOf[Any => List[Any]]
     )
   }
 
 }
 
 /**
- * Build the CASE expression's parts list and a custom encoder that walks the typed slots in render
- * order — `[cond1, branch1, cond2, branch2, ..., (elseBranch?)]` — dispatching the user-supplied `OutA`
- * value through the [[ProjArgsOf]]-derived projector.
+ * Build the CASE expression's parts list and a custom encoder that walks the typed slots in render order —
+ * `[cond1, branch1, cond2, branch2, ..., (elseBranch?)]` — dispatching the user-supplied `OutA` value through the
+ * [[ProjArgsOf]]-derived projector.
  */
 private def renderCaseWhen[R, OutA](
-  branches:  List[(TypedExpr[Boolean, ?], TypedExpr[R, ?])],
-  elseOpt:   Option[TypedExpr[R, ?]],
-  codec0:    Codec[R],
+  branches: List[(TypedExpr[Boolean, ?], TypedExpr[R, ?])],
+  elseOpt: Option[TypedExpr[R, ?]],
+  codec0: Codec[R],
   projector: Any => List[Any]
 ): TypedExpr[R, OutA] = {
   val typedItems: List[Fragment[?]] =

--- a/modules/core/src/main/scala/skunk/sharp/dsl/Compiled.scala
+++ b/modules/core/src/main/scala/skunk/sharp/dsl/Compiled.scala
@@ -8,23 +8,23 @@ import skunk.data.Completion
 import skunk.sharp.where.Where
 
 /**
- * The compiled form of a query builder — a typed `Fragment[Args]` plus a row codec, with no values bound. Every
- * DSL verb (`select`, `insert`, `update`, `delete`, plus their `RETURNING` variants) reduces to one of these
- * two types at `.compile` time. All session-facing operations (`run`, `unique`, `option`, `stream`, `cursor`,
- * `prepared`) live as extensions on these types — defined once, available everywhere, mirroring
- * [[skunk.Session]]'s own row-fetching surface.
+ * The compiled form of a query builder — a typed `Fragment[Args]` plus a row codec, with no values bound. Every DSL
+ * verb (`select`, `insert`, `update`, `delete`, plus their `RETURNING` variants) reduces to one of these two types at
+ * `.compile` time. All session-facing operations (`run`, `unique`, `option`, `stream`, `cursor`, `prepared`) live as
+ * extensions on these types — defined once, available everywhere, mirroring [[skunk.Session]]'s own row-fetching
+ * surface.
  *
  * Internal representation is a typed `skunk.Fragment[Args]`. Argument values are supplied at execute time —
  * `q.run(session)(args)` for non-`Void` `Args`, plain `q.run(session)` for `Args = skunk.Void`. The same
- * `QueryTemplate` value can be reused with many different argument tuples; that's the whole point of building
- * the SQL once and re-binding values.
+ * `QueryTemplate` value can be reused with many different argument tuples; that's the whole point of building the SQL
+ * once and re-binding values.
  *
- * For subquery composition (embedding into an outer query) use `AsSubquery` — it sees the typed inner
- * `Fragment[Args]` and threads it into the outer's args slot.
+ * For subquery composition (embedding into an outer query) use `AsSubquery` — it sees the typed inner `Fragment[Args]`
+ * and threads it into the outer's args slot.
  */
 final class QueryTemplate[Args, R] private (
   val fragment: Fragment[Args],
-  val codec:    Codec[R]
+  val codec: Codec[R]
 ) {
 
   /** Typed skunk `Query[Args, R]` — suitable for `session.prepare(q.typedQuery)` to reuse with arg values. */
@@ -34,8 +34,8 @@ final class QueryTemplate[Args, R] private (
   def compile: QueryTemplate[Args, R] = this
 
   /**
-   * Map the row shape into a case class `T` whose `MirroredElemTypes` align with `R`. Works for plain-tuple
-   * projections (e.g. from `.returningTuple`) and named-tuple projections (e.g. from `.returningAll`) — the
+   * Map the row shape into a case class `T` whose `MirroredElemTypes` align with `R`. Works for plain-tuple projections
+   * (e.g. from `.returningTuple`) and named-tuple projections (e.g. from `.returningAll`) — the
    * [[QueryTemplateMapping.Unwrap]] match type strips named-tuple labels before the comparison.
    */
   def to[T <: Product](using
@@ -48,6 +48,7 @@ final class QueryTemplate[Args, R] private (
     )
     QueryTemplate.mk[Args, T](fragment, mapped)
   }
+
 }
 
 object QueryTemplate {
@@ -58,11 +59,12 @@ object QueryTemplate {
 
   /**
    * Bridge for call sites that have an `AppliedFragment` (its args are already baked) and need to surface as a
-   * `QueryTemplate[Void, R]`. Used by the few remaining AF-based code paths (e.g. `SetOpQuery.compile`); typed
-   * builders should call [[mk]] directly with their `Fragment[Args]`.
+   * `QueryTemplate[Void, R]`. Used by the few remaining AF-based code paths (e.g. `SetOpQuery.compile`); typed builders
+   * should call [[mk]] directly with their `Fragment[Args]`.
    */
   def fromApplied[R](af: AppliedFragment, codec: Codec[R]): QueryTemplate[Void, R] =
     new QueryTemplate[Void, R](skunk.sharp.TypedExpr.liftAfToVoid(af), codec)
+
 }
 
 /** The compiled form of a statement that does not return rows (INSERT/UPDATE/DELETE without RETURNING). */
@@ -84,6 +86,7 @@ object CommandTemplate {
 
   def fromApplied(af: AppliedFragment): CommandTemplate[Void] =
     new CommandTemplate[Void](skunk.sharp.TypedExpr.liftAfToVoid(af))
+
 }
 
 /** Strip named-tuple labels for the `to[T]` match-type unification on [[QueryTemplate]]. */
@@ -92,12 +95,13 @@ object QueryTemplateMapping {
   type Unwrap[R] = R match
     case scala.NamedTuple.NamedTuple[?, v] => v
     case _                                 => R
+
 }
 
 /**
  * Session-facing operations for queries. Mirror [[skunk.Session]]'s own row-fetching API. `args` is the typed
- * captured-parameter tuple — supplied at execute time, not at builder-build time. For `Args = Void`-shaped
- * templates see the extension block below for argless overloads.
+ * captured-parameter tuple — supplied at execute time, not at builder-build time. For `Args = Void`-shaped templates
+ * see the extension block below for argless overloads.
  */
 extension [Args, R](q: QueryTemplate[Args, R]) {
 
@@ -147,11 +151,11 @@ extension [Args, R](q: QueryTemplate[Args, R]) {
 }
 
 /**
- * Argless overloads for `Args = Void`-shaped templates — no `args` parameter at execute time. Routes through
- * Skunk's extended-protocol execute (`session.execute(q)(Void)`) **not** the simple-protocol `execute(q)` —
- * Void here means "encoder takes Void at execute" which may still emit baked values via `contramap` (e.g.
- * INSERT with values baked via `Param.bind`). The simple protocol can't bind any params; the extended one
- * does. The few truly-no-params cases pay one extra round trip but are still correct.
+ * Argless overloads for `Args = Void`-shaped templates — no `args` parameter at execute time. Routes through Skunk's
+ * extended-protocol execute (`session.execute(q)(Void)`) **not** the simple-protocol `execute(q)` — Void here means
+ * "encoder takes Void at execute" which may still emit baked values via `contramap` (e.g. INSERT with values baked via
+ * `Param.bind`). The simple protocol can't bind any params; the extended one does. The few truly-no-params cases pay
+ * one extra round trip but are still correct.
  */
 extension [R](q: QueryTemplate[Void, R]) {
 
@@ -223,11 +227,11 @@ extension (c: CommandTemplate[Void]) {
  *   - a [[SetOpQuery]] built from chained `UNION` / `INTERSECT` / `EXCEPT`,
  *   - a literal [[Values]] table.
  *
- * `Args` exposes the inner subquery's typed parameters so they thread into the outer composition wherever the
- * subquery is embedded — in `Pg.exists(inner)`, `col.in(inner)`, scalar `.asExpr`, set-op operands, etc.
+ * `Args` exposes the inner subquery's typed parameters so they thread into the outer composition wherever the subquery
+ * is embedded — in `Pg.exists(inner)`, `col.in(inner)`, scalar `.asExpr`, set-op operands, etc.
  *
- * Codec extraction (`codec`) is expected to be cheap — no SQL rendered. `fragment` is allowed to compile the
- * inner query (cheap for builders, no extra cost over `.compile`).
+ * Codec extraction (`codec`) is expected to be cheap — no SQL rendered. `fragment` is allowed to compile the inner
+ * query (cheap for builders, no extra cost over `.compile`).
  */
 sealed trait AsSubquery[Q, T, Args] {
   def codec(q: Q): Codec[T]
@@ -238,33 +242,65 @@ object AsSubquery {
 
   given identity[Args, T]: AsSubquery[QueryTemplate[Args, T], T, Args] =
     new AsSubquery[QueryTemplate[Args, T], T, Args] {
-      def codec(q: QueryTemplate[Args, T]): Codec[T]       = q.codec
+      def codec(q: QueryTemplate[Args, T]): Codec[T]          = q.codec
       def fragment(q: QueryTemplate[Args, T]): Fragment[Args] = q.fragment
     }
 
   inline given fromProjected[
-    Ss <: Tuple, Proj <: Tuple, Groups <: Tuple, DistinctOn <: Tuple, Orders <: Tuple,
-    SA, OnA, CArgs, DA, PA, GA, OA, WA, HA, T
+    Ss <: Tuple,
+    Proj <: Tuple,
+    Groups <: Tuple,
+    DistinctOn <: Tuple,
+    Orders <: Tuple,
+    SA,
+    OnA,
+    CArgs,
+    DA,
+    PA,
+    GA,
+    OA,
+    WA,
+    HA,
+    T
   ](using
-    ev:      skunk.sharp.GroupCoverage[Proj, Groups],
-    sbOf:    skunk.sharp.dsl.SourceBodyArgsOf.Aux[Ss, SA],
-    bff:     skunk.sharp.dsl.SourceBodyArgsProj[Ss],
-    onSum:   skunk.sharp.dsl.SourceOnArgsOf.Aux[Ss, OnA],
-    onProj:  skunk.sharp.dsl.SourceOnArgsProj[Ss],
-    cteSum:  skunk.sharp.dsl.CteArgsOf.Aux[Ss, CArgs],
+    ev: skunk.sharp.GroupCoverage[Proj, Groups],
+    sbOf: skunk.sharp.dsl.SourceBodyArgsOf.Aux[Ss, SA],
+    bff: skunk.sharp.dsl.SourceBodyArgsProj[Ss],
+    onSum: skunk.sharp.dsl.SourceOnArgsOf.Aux[Ss, OnA],
+    onProj: skunk.sharp.dsl.SourceOnArgsProj[Ss],
+    cteSum: skunk.sharp.dsl.CteArgsOf.Aux[Ss, CArgs],
     cteProj: skunk.sharp.dsl.CteArgsProj[Ss],
-    d:       skunk.sharp.dsl.ProjArgsOf.Aux[DistinctOn, DA],
-    pa:      skunk.sharp.dsl.ProjArgsOf.Aux[Proj, PA],
-    g:       skunk.sharp.dsl.ProjArgsOf.Aux[Groups, GA],
-    o:       skunk.sharp.dsl.ProjArgsOf.Aux[Orders, OA]
+    d: skunk.sharp.dsl.ProjArgsOf.Aux[DistinctOn, DA],
+    pa: skunk.sharp.dsl.ProjArgsOf.Aux[Proj, PA],
+    g: skunk.sharp.dsl.ProjArgsOf.Aux[Groups, GA],
+    o: skunk.sharp.dsl.ProjArgsOf.Aux[Orders, OA]
   ): AsSubquery[
     ProjectedSelect[Ss, Proj, Groups, DistinctOn, Orders, WA, HA, T],
     T,
-    Where.Concat[Where.Concat[Where.Concat[Where.Concat[Where.Concat[Where.Concat[Where.Concat[Where.Concat[CArgs, DA], PA], SA], OnA], WA], GA], HA], OA]
+    Where.Concat[Where.Concat[Where.Concat[
+      Where.Concat[Where.Concat[Where.Concat[Where.Concat[Where.Concat[CArgs, DA], PA], SA], OnA], WA],
+      GA
+    ], HA], OA]
   ] = {
-    type Out = Where.Concat[Where.Concat[Where.Concat[Where.Concat[Where.Concat[Where.Concat[Where.Concat[Where.Concat[CArgs, DA], PA], SA], OnA], WA], GA], HA], OA]
+    type Out = Where.Concat[Where.Concat[Where.Concat[
+      Where.Concat[Where.Concat[Where.Concat[Where.Concat[Where.Concat[CArgs, DA], PA], SA], OnA], WA],
+      GA
+    ], HA], OA]
     val frag: ProjectedSelect[Ss, Proj, Groups, DistinctOn, Orders, WA, HA, T] => Fragment[Out] =
-      q => q.compile[SA, OnA, CArgs, DA, PA, GA, OA](using ev, sbOf, bff, onSum, onProj, cteSum, cteProj, d, pa, g, o).fragment
+      q =>
+        q.compile[SA, OnA, CArgs, DA, PA, GA, OA](using
+          ev,
+          sbOf,
+          bff,
+          onSum,
+          onProj,
+          cteSum,
+          cteProj,
+          d,
+          pa,
+          g,
+          o
+        ).fragment
     new ProjectedAsSubquery[Ss, Proj, Groups, DistinctOn, Orders, WA, HA, T, Out](frag)
   }
 
@@ -272,13 +308,17 @@ object AsSubquery {
    * Whole-row SelectBuilder → subquery of NamedRow. Relies on the same `IsSingleSource` evidence `.compile` uses.
    */
   inline given fromSelectBuilder[Ss <: Tuple, GroupsT <: Tuple, SA, GA, CArgs, WA, HA, C <: Tuple, R](using
-    ev:      IsSingleSource.Aux[Ss, C],
-    sbOf:    skunk.sharp.dsl.SourceBodyArgsOf.Aux[Ss, SA],
-    cteSum:  skunk.sharp.dsl.CteArgsOf.Aux[Ss, CArgs],
+    ev: IsSingleSource.Aux[Ss, C],
+    sbOf: skunk.sharp.dsl.SourceBodyArgsOf.Aux[Ss, SA],
+    cteSum: skunk.sharp.dsl.CteArgsOf.Aux[Ss, CArgs],
     cteProj: skunk.sharp.dsl.CteArgsProj[Ss],
-    g:       skunk.sharp.dsl.ProjArgsOf.Aux[GroupsT, GA],
-    eq:      R =:= skunk.sharp.NamedRowOf[C]
-  ): AsSubquery[SelectBuilder[Ss, GroupsT, WA, HA], R, Where.Concat[Where.Concat[Where.Concat[Where.Concat[CArgs, SA], WA], GA], HA]] = {
+    g: skunk.sharp.dsl.ProjArgsOf.Aux[GroupsT, GA],
+    eq: R =:= skunk.sharp.NamedRowOf[C]
+  ): AsSubquery[
+    SelectBuilder[Ss, GroupsT, WA, HA],
+    R,
+    Where.Concat[Where.Concat[Where.Concat[Where.Concat[CArgs, SA], WA], GA], HA]
+  ] = {
     type Out = Where.Concat[Where.Concat[Where.Concat[Where.Concat[CArgs, SA], WA], GA], HA]
     val frag: SelectBuilder[Ss, GroupsT, WA, HA] => Fragment[Out] =
       b => b.compile[SA, GA, CArgs](using ev, sbOf, cteSum, cteProj, g).fragment
@@ -286,32 +326,42 @@ object AsSubquery {
   }
 
   /**
-   * Named-class instances for the inline `fromProjected` / `fromSelectBuilder` givens. Avoids E197
-   * (anonymous class duplicated at each inline summon site) — the class definition is shared, only
-   * the captured `frag` lambda differs per summon.
+   * Named-class instances for the inline `fromProjected` / `fromSelectBuilder` givens. Avoids E197 (anonymous class
+   * duplicated at each inline summon site) — the class definition is shared, only the captured `frag` lambda differs
+   * per summon.
    */
   private[dsl] final class ProjectedAsSubquery[
-    Ss <: Tuple, Proj <: Tuple, Groups <: Tuple, DistinctOn <: Tuple, Orders <: Tuple, WA, HA, T, Out
+    Ss <: Tuple,
+    Proj <: Tuple,
+    Groups <: Tuple,
+    DistinctOn <: Tuple,
+    Orders <: Tuple,
+    WA,
+    HA,
+    T,
+    Out
   ](frag: ProjectedSelect[Ss, Proj, Groups, DistinctOn, Orders, WA, HA, T] => Fragment[Out])
-    extends AsSubquery[ProjectedSelect[Ss, Proj, Groups, DistinctOn, Orders, WA, HA, T], T, Out] {
-    def codec(q:    ProjectedSelect[Ss, Proj, Groups, DistinctOn, Orders, WA, HA, T]): Codec[T]    = q.codec
+      extends AsSubquery[ProjectedSelect[Ss, Proj, Groups, DistinctOn, Orders, WA, HA, T], T, Out] {
+    def codec(q: ProjectedSelect[Ss, Proj, Groups, DistinctOn, Orders, WA, HA, T]): Codec[T]         = q.codec
     def fragment(q: ProjectedSelect[Ss, Proj, Groups, DistinctOn, Orders, WA, HA, T]): Fragment[Out] = frag(q)
   }
 
   private[dsl] final class SelectBuilderAsSubquery[Ss <: Tuple, GroupsT <: Tuple, WA, HA, R, Out](
     frag: SelectBuilder[Ss, GroupsT, WA, HA] => Fragment[Out]
   ) extends AsSubquery[SelectBuilder[Ss, GroupsT, WA, HA], R, Out] {
+
     def codec(b: SelectBuilder[Ss, GroupsT, WA, HA]): Codec[R] = {
       val entries = b.sources.toList.asInstanceOf[List[SourceEntry[?, ?, ?, ?, ?]]]
       skunk.sharp.internal.RowCodecs.rowCodec(entries.head.effectiveCols).asInstanceOf[Codec[R]]
     }
+
     def fragment(b: SelectBuilder[Ss, GroupsT, WA, HA]): Fragment[Out] = frag(b)
   }
 
   given fromSetOp[A, T]: AsSubquery[SetOpQuery[A, T], T, A] =
     new AsSubquery[SetOpQuery[A, T], T, A] {
-      def codec(q: SetOpQuery[A, T]): Codec[T]            = q.codec
-      def fragment(q: SetOpQuery[A, T]): Fragment[A]      = q.renderFn()
+      def codec(q: SetOpQuery[A, T]): Codec[T]       = q.codec
+      def fragment(q: SetOpQuery[A, T]): Fragment[A] = q.renderFn()
     }
 
   /**
@@ -320,7 +370,7 @@ object AsSubquery {
    */
   given fromValues[Cols <: Tuple, Row <: scala.NamedTuple.AnyNamedTuple]: AsSubquery[Values[Cols, Row], Row, Void] =
     new AsSubquery[Values[Cols, Row], Row, Void] {
-      def codec(v: Values[Cols, Row]): Codec[Row] = v.codec
+      def codec(v: Values[Cols, Row]): Codec[Row]        = v.codec
       def fragment(v: Values[Cols, Row]): Fragment[Void] =
         skunk.sharp.TypedExpr.liftAfToVoid(v.render)
     }

--- a/modules/core/src/main/scala/skunk/sharp/dsl/Cte.scala
+++ b/modules/core/src/main/scala/skunk/sharp/dsl/Cte.scala
@@ -34,7 +34,12 @@ private[dsl] trait IsCte {
  * not appear as deps — they must be referenced directly in the outer query's FROM (enforced at [[cte]] time via
  * [[CteDepsAllVoid]]).
  */
-final class CteRelation[Cols <: Tuple, Name <: String & Singleton, Alias_ <: String & Singleton, BodyArgsT] @scala.annotation.publicInBinary private[sharp] (
+final class CteRelation[
+  Cols <: Tuple,
+  Name <: String & Singleton,
+  Alias_ <: String & Singleton,
+  BodyArgsT
+] @scala.annotation.publicInBinary private[sharp] (
   val cteName: Name,
   val aliasName: Alias_,
   private[sharp] val body: () => Fragment[BodyArgsT],
@@ -43,7 +48,7 @@ final class CteRelation[Cols <: Tuple, Name <: String & Singleton, Alias_ <: Str
 ) extends Relation[Cols] with IsCte {
   type Alias    = Alias_
   type Mode     = AliasMode.Explicit
-  type BodyArgs = skunk.Void  // FROM-site contribution; the typed body args bind at the WITH preamble.
+  type BodyArgs = skunk.Void // FROM-site contribution; the typed body args bind at the WITH preamble.
 
   /** Typed inner-body args — surfaced in outer compile via [[CteArgs]] / [[CteArgsProj]]. */
   type CteBody = BodyArgsT
@@ -77,9 +82,9 @@ inline def cte[Ss <: Tuple, GroupsT <: Tuple, WA, HA, N <: String & Singleton, S
   name: N,
   query: SelectBuilder[Ss, GroupsT, WA, HA]
 )(using
-  ev:    IsSingleSource[Ss],
-  sbOf:  SourceBodyArgsOf.Aux[Ss, SArgs],
-  g:     ProjArgsOf.Aux[GroupsT, GArgs],
+  ev: IsSingleSource[Ss],
+  sbOf: SourceBodyArgsOf.Aux[Ss, SArgs],
+  g: ProjArgsOf.Aux[GroupsT, GArgs],
   noTypedDeps: CteDepsAllVoid[Ss]
 ): CteRelation[ev.Cols, N, N, Where.Concat[Where.Concat[Where.Concat[SArgs, WA], GArgs], HA]] = {
   type Combined = Where.Concat[Where.Concat[Where.Concat[SArgs, WA], GArgs], HA]
@@ -105,27 +110,48 @@ inline def cte[Ss <: Tuple, GroupsT <: Tuple, WA, HA, N <: String & Singleton, S
  *   totals.innerJoin(users).on(r => r.totals.user_id ==== r.users.id).select(r => (r.users.email, r.totals.total)).compile
  * }}}
  */
-inline def cte[Ss <: Tuple, Proj <: Tuple, Groups <: Tuple, DA <: Tuple, OA <: Tuple, WA, HA, Row, N <: String & Singleton,
-        SA, OnA, DA2, PA, GA, OA2](
+inline def cte[
+  Ss <: Tuple,
+  Proj <: Tuple,
+  Groups <: Tuple,
+  DA <: Tuple,
+  OA <: Tuple,
+  WA,
+  HA,
+  Row,
+  N <: String & Singleton,
+  SA,
+  OnA,
+  DA2,
+  PA,
+  GA,
+  OA2
+](
   name: N,
   query: ProjectedSelect[Ss, Proj, Groups, DA, OA, WA, HA, Row]
 )(using
-  gc:     GroupCoverage[Proj, Groups],
+  gc: GroupCoverage[Proj, Groups],
   @scala.annotation.unused np: AllNamedProj[Proj],
-  sbOf:   SourceBodyArgsOf.Aux[Ss, SA],
-  bff:    SourceBodyArgsProj[Ss],
-  onSum:  SourceOnArgsOf.Aux[Ss, OnA],
+  sbOf: SourceBodyArgsOf.Aux[Ss, SA],
+  bff: SourceBodyArgsProj[Ss],
+  onSum: SourceOnArgsOf.Aux[Ss, OnA],
   onProj: SourceOnArgsProj[Ss],
-  d:      ProjArgsOf.Aux[DA, DA2],
-  pa:     ProjArgsOf.Aux[Proj, PA],
-  gp:     ProjArgsOf.Aux[Groups, GA],
-  o:      ProjArgsOf.Aux[OA, OA2],
+  d: ProjArgsOf.Aux[DA, DA2],
+  pa: ProjArgsOf.Aux[Proj, PA],
+  gp: ProjArgsOf.Aux[Groups, GA],
+  o: ProjArgsOf.Aux[OA, OA2],
   noTypedDeps: CteDepsAllVoid[Ss]
-): CteRelation[ProjCols[Proj], N, N, Where.Concat[Where.Concat[Where.Concat[Where.Concat[Where.Concat[Where.Concat[Where.Concat[DA2, PA], SA], OnA], WA], GA], HA], OA2]] = {
-  type Combined = Where.Concat[Where.Concat[Where.Concat[Where.Concat[Where.Concat[Where.Concat[Where.Concat[DA2, PA], SA], OnA], WA], GA], HA], OA2]
-  val entries = query.sources.toList.asInstanceOf[List[SourceEntry[?, ?, ?, ?, ?]]]
-  val deps    = directCtes(entries)
-  val cols    = buildProjectedCols(query.projections).asInstanceOf[ProjCols[Proj]]
+): CteRelation[ProjCols[Proj], N, N, Where.Concat[
+  Where.Concat[Where.Concat[Where.Concat[Where.Concat[Where.Concat[Where.Concat[DA2, PA], SA], OnA], WA], GA], HA],
+  OA2
+]] = {
+  type Combined = Where.Concat[
+    Where.Concat[Where.Concat[Where.Concat[Where.Concat[Where.Concat[Where.Concat[DA2, PA], SA], OnA], WA], GA], HA],
+    OA2
+  ]
+  val entries                             = query.sources.toList.asInstanceOf[List[SourceEntry[?, ?, ?, ?, ?]]]
+  val deps                                = directCtes(entries)
+  val cols                                = buildProjectedCols(query.projections).asInstanceOf[ProjCols[Proj]]
   val bodyThunk: () => Fragment[Combined] = () =>
     query.compileBodyFragment[SA, OnA, DA2, PA, GA, OA2](using gc, sbOf, bff, onSum, onProj, d, pa, gp, o)
   new CteRelation[ProjCols[Proj], N, N, Combined](name, name, bodyThunk, deps, cols)
@@ -145,8 +171,8 @@ private[dsl] def directCtes(entries: List[SourceEntry[?, ?, ?, ?, ?]]): List[Cte
  * (earliest dependency first). Duplicate names are visited only once.
  */
 private[dsl] def collectCtesInOrder(entries: List[SourceEntry[?, ?, ?, ?, ?]]): List[CteRelation[?, ?, ?, ?]] = {
-  val result                               = scala.collection.mutable.ListBuffer.empty[CteRelation[?, ?, ?, ?]]
-  val visited                              = scala.collection.mutable.LinkedHashSet.empty[String]
+  val result                                  = scala.collection.mutable.ListBuffer.empty[CteRelation[?, ?, ?, ?]]
+  val visited                                 = scala.collection.mutable.LinkedHashSet.empty[String]
   def visit(c: CteRelation[?, ?, ?, ?]): Unit =
     if (!visited.contains(c.cteName)) {
       visited += c.cteName
@@ -162,8 +188,8 @@ private[dsl] def collectCtesInOrder(entries: List[SourceEntry[?, ?, ?, ?, ?]]): 
  * `Right` slot; structural keywords (`WITH `, `AS (`, `)`, `, `, trailing space) are `Left` AppliedFragments. Returns
  * an empty list when `ctes` is empty so callers can prepend without any `WITH ` chunk.
  *
- * The slot order matches the dep-walk order: dep CTEs before their dependents. The outer compile's `slotValues`
- * IArray must place per-CTE body args in this same order, ahead of all body slots.
+ * The slot order matches the dep-walk order: dep CTEs before their dependents. The outer compile's `slotValues` IArray
+ * must place per-CTE body args in this same order, ahead of all body slots.
  */
 private[dsl] def renderWithPreambleParts(ctes: List[CteRelation[?, ?, ?, ?]]): List[SelectBuilder.BodyPart] = {
   if (ctes.isEmpty) Nil
@@ -191,7 +217,7 @@ private[dsl] def renderWithPreambleParts(ctes: List[CteRelation[?, ?, ?, ?]]): L
  */
 private[dsl] type GetCteBody[R] = R match {
   case CteRelation[_, _, _, ba] => ba
-  case _                     => skunk.Void
+  case _                        => skunk.Void
 }
 
 /**
@@ -200,13 +226,13 @@ private[dsl] type GetCteBody[R] = R match {
  * [[CteDepsAllVoid]] at `cte()` construction), so they don't appear here.
  */
 type CteArgs[Ss <: Tuple] = Ss match {
-  case EmptyTuple                          => skunk.Void
+  case EmptyTuple                         => skunk.Void
   case SourceEntry[r, ?, ?, ?, ?] *: tail => Where.Concat[GetCteBody[r], CteArgs[tail]]
 }
 
 /**
- * Typeclass wrapper around [[CteArgs]] — provides the standard `Aux[Ss, O]` shape so the compile path can summon it
- * as a using parameter and bind the combined `CArgs` type without writing the match type inline.
+ * Typeclass wrapper around [[CteArgs]] — provides the standard `Aux[Ss, O]` shape so the compile path can summon it as
+ * a using parameter and bind the combined `CArgs` type without writing the match type inline.
  */
 trait CteArgsOf[Ss <: Tuple] {
   type Out
@@ -217,6 +243,7 @@ object CteArgsOf {
 
   given compute[Ss <: Tuple]: (CteArgsOf[Ss] { type Out = CteArgs[Ss] }) =
     new CteArgsOf[Ss] { type Out = CteArgs[Ss] }
+
 }
 
 /**
@@ -243,14 +270,23 @@ object CteArgsProj {
 
 }
 
-private[dsl] final class CteArgsConsProj[R <: Relation[C0], C0 <: Tuple, C <: Tuple, A <: String & Singleton, OA, T <: Tuple](
+private[dsl] final class CteArgsConsProj[
+  R <: Relation[C0],
+  C0 <: Tuple,
+  C <: Tuple,
+  A <: String & Singleton,
+  OA,
+  T <: Tuple
+](
   rest: CteArgsProj[T],
   proj: Where.Concat[GetCteBody[R], CteArgs[T]] => (GetCteBody[R], CteArgs[T])
 ) extends CteArgsProj[SourceEntry[R, C0, C, A, OA] *: T] {
+
   def project(combined: Any): List[Any] = {
     val (h, t) = proj(combined.asInstanceOf[Where.Concat[GetCteBody[R], CteArgs[T]]])
     h :: rest.project(t)
   }
+
 }
 
 /**
@@ -273,8 +309,8 @@ object CteDepsAllVoid {
 
 /**
  * Per-CTE body args: maps a list of `CteRelation[?, ?, ?, ?]` (in dep order) to a `List[Any]` of body-args values to
- * inject at the WITH preamble's Right slots. Each entry is the value paired with that CTE's Right-slot Fragment.
- * Plain (Void) bodies pass `Void`; typed bodies pass the captured args from the outer query's combined `CteArgs`.
+ * inject at the WITH preamble's Right slots. Each entry is the value paired with that CTE's Right-slot Fragment. Plain
+ * (Void) bodies pass `Void`; typed bodies pass the captured args from the outer query's combined `CteArgs`.
  *
  * The outer compile builds `cteSlotValues` by walking `collectCtesInOrder(entries)` and matching each CTE against the
  * direct-ref list (whose body args are projected via [[CteArgsProj]]). CTEs appearing only as transitive deps map to

--- a/modules/core/src/main/scala/skunk/sharp/dsl/Delete.scala
+++ b/modules/core/src/main/scala/skunk/sharp/dsl/Delete.scala
@@ -63,19 +63,31 @@ final class DeleteBuilder[Cols <: Tuple, Name <: String & Singleton] private[sha
 
 }
 
-final class DeleteReady[Cols <: Tuple, Name <: String & Singleton, Args] @scala.annotation.publicInBinary private[sharp] (
+final class DeleteReady[
+  Cols <: Tuple,
+  Name <: String & Singleton,
+  Args
+] @scala.annotation.publicInBinary private[sharp] (
   private[sharp] val table: Table[Cols, Name],
   private[sharp] val whereOpt: Option[Fragment[?]]
 ) {
 
   inline def where[A](f: ColumnsView[Cols] => Where[A]): DeleteReady[Cols, Name, Where.Concat[Args, A]] = {
     val pred     = f(table.columnsView)
-    val combined = SelectBuilder.andInto[Args, A](whereOpt.asInstanceOf[Option[Fragment[Args]]], pred, c => Where.projectConcat[Args, A](c))
+    val combined = SelectBuilder.andInto[Args, A](
+      whereOpt.asInstanceOf[Option[Fragment[Args]]],
+      pred,
+      c => Where.projectConcat[Args, A](c)
+    )
     new DeleteReady[Cols, Name, Where.Concat[Args, A]](table, Some(combined))
   }
 
   inline def whereRaw(af: AppliedFragment): DeleteReady[Cols, Name, ?] = {
-    val combined = SelectBuilder.andRawInto[Args](whereOpt.asInstanceOf[Option[Fragment[Args]]], af, c => Where.projectConcat[Args, Void](c))
+    val combined = SelectBuilder.andRawInto[Args](
+      whereOpt.asInstanceOf[Option[Fragment[Args]]],
+      af,
+      c => Where.projectConcat[Args, Void](c)
+    )
     new DeleteReady[Cols, Name, Any](table, Some(combined))
   }
 
@@ -88,7 +100,8 @@ final class DeleteReady[Cols <: Tuple, Name <: String & Singleton, Args] @scala.
     buf.toList
   }
 
-  inline def compile: CommandTemplate[Args] = MutationAssembly.command[Args, Void](deleteParts).asInstanceOf[CommandTemplate[Args]]
+  inline def compile: CommandTemplate[Args] =
+    MutationAssembly.command[Args, Void](deleteParts).asInstanceOf[CommandTemplate[Args]]
 
   inline def returning[T, A](f: ColumnsView[Cols] => TypedExpr[T, A]): QueryTemplate[Where.Concat[Args, A], T] = {
     val expr = f(table.columnsView)
@@ -135,8 +148,8 @@ final class DeleteReady[Cols <: Tuple, Name <: String & Singleton, Args] @scala.
 
 /**
  * Shared command/RETURNING assembly for mutation builders (DELETE / UPDATE / INSERT). Routes through
- * [[SelectBuilder.assembleN]] for the typed Fragment[Args] composition, then wraps as either a
- * [[CommandTemplate]] or [[QueryTemplate]].
+ * [[SelectBuilder.assembleN]] for the typed Fragment[Args] composition, then wraps as either a [[CommandTemplate]] or
+ * [[QueryTemplate]].
  */
 private[dsl] object MutationAssembly {
 
@@ -159,7 +172,7 @@ private[dsl] object MutationAssembly {
     codec: Codec[R]
   ): QueryTemplate[Where.Concat[Where.Concat[A1, A2], RetArgs], R] = {
     type Out = Where.Concat[Where.Concat[A1, A2], RetArgs]
-    val parts: List[BodyPart] = base ++ List[BodyPart](SelectBuilder.bake(RawConstants.RETURNING), Right(ret))
+    val parts: List[BodyPart]          = base ++ List[BodyPart](SelectBuilder.bake(RawConstants.RETURNING), Right(ret))
     val slotValues: Out => IArray[Any] = args => {
       val (a12, retArgs) = Where.projectConcat[Where.Concat[A1, A2], RetArgs](args)
       val (a1, a2)       = Where.projectConcat[A1, A2](a12)
@@ -177,7 +190,7 @@ private[dsl] object MutationAssembly {
     codec: Codec[R]
   ): QueryTemplate[Where.Concat[A1, RetArgs], R] = {
     type Out = Where.Concat[A1, RetArgs]
-    val parts: List[BodyPart] = base ++ List[BodyPart](SelectBuilder.bake(RawConstants.RETURNING), Right(ret))
+    val parts: List[BodyPart]          = base ++ List[BodyPart](SelectBuilder.bake(RawConstants.RETURNING), Right(ret))
     val slotValues: Out => IArray[Any] = args => {
       val (a1, retArgs) = Where.projectConcat[A1, RetArgs](args)
       IArray[Any](a1, retArgs)
@@ -223,7 +236,12 @@ final class DeleteUsingBuilder[Cols <: Tuple, Name <: String & Singleton, Ss <: 
 
 }
 
-final class DeleteUsingReady[Cols <: Tuple, Name <: String & Singleton, Ss <: Tuple, Args] @scala.annotation.publicInBinary private[sharp] (
+final class DeleteUsingReady[
+  Cols <: Tuple,
+  Name <: String & Singleton,
+  Ss <: Tuple,
+  Args
+] @scala.annotation.publicInBinary private[sharp] (
   private[sharp] val table: Table[Cols, Name],
   private[sharp] val sources: Ss,
   private[sharp] val whereOpt: Option[Fragment[?]]
@@ -232,21 +250,29 @@ final class DeleteUsingReady[Cols <: Tuple, Name <: String & Singleton, Ss <: Tu
   inline def where[A](f: JoinedView[Ss] => Where[A]): DeleteUsingReady[Cols, Name, Ss, Where.Concat[Args, A]] = {
     val view     = buildJoinedView(sources)
     val pred     = f(view)
-    val combined = SelectBuilder.andInto[Args, A](whereOpt.asInstanceOf[Option[Fragment[Args]]], pred, c => Where.projectConcat[Args, A](c))
+    val combined = SelectBuilder.andInto[Args, A](
+      whereOpt.asInstanceOf[Option[Fragment[Args]]],
+      pred,
+      c => Where.projectConcat[Args, A](c)
+    )
     new DeleteUsingReady[Cols, Name, Ss, Where.Concat[Args, A]](table, sources, Some(combined))
   }
 
   inline def whereRaw(af: AppliedFragment): DeleteUsingReady[Cols, Name, Ss, ?] = {
-    val combined = SelectBuilder.andRawInto[Args](whereOpt.asInstanceOf[Option[Fragment[Args]]], af, c => Where.projectConcat[Args, Void](c))
+    val combined = SelectBuilder.andRawInto[Args](
+      whereOpt.asInstanceOf[Option[Fragment[Args]]],
+      af,
+      c => Where.projectConcat[Args, Void](c)
+    )
     new DeleteUsingReady[Cols, Name, Ss, Any](table, sources, Some(combined))
   }
 
   /**
-   * DELETE … USING <tail sources> WHERE — emits per-source body Right slots so typed-subquery USING sources
-   * thread their inner Args into the outer command's args.
+   * DELETE … USING <tail sources> WHERE — emits per-source body Right slots so typed-subquery USING sources thread
+   * their inner Args into the outer command's args.
    */
   private def bodyParts: List[BodyPart] = {
-    val buf = scala.collection.mutable.ListBuffer[BodyPart](SelectBuilder.bake(table.deleteFromHeader))
+    val buf          = scala.collection.mutable.ListBuffer[BodyPart](SelectBuilder.bake(table.deleteFromHeader))
     val usingEntries = sources.toList.asInstanceOf[List[SourceEntry[?, ?, ?, ?, ?]]].tail
     if (usingEntries.nonEmpty) {
       buf += SelectBuilder.bake(RawConstants.USING)
@@ -272,13 +298,13 @@ final class DeleteUsingReady[Cols <: Tuple, Name <: String & Singleton, Ss <: Tu
   // Concat-chain: SArgs ⊕ Args (WHERE).
   inline def compile[SArgs](using
     sbOf: SourceBodyArgsOf.Aux[Ss, SArgs],
-    bff:  SourceBodyArgsProj[Ss]
+    bff: SourceBodyArgsProj[Ss]
   ): CommandTemplate[Where.Concat[SArgs, Args]] = {
     type Out = Where.Concat[SArgs, Args]
     val slotValues: Out => IArray[Any] = args => {
       val (sArgs, wArgs) = Where.projectConcat[SArgs, Args](args)
       val perTailBody    = usingTailBodyArgs(bff, sArgs)
-      val out = scala.collection.mutable.ArrayBuffer.empty[Any]
+      val out            = scala.collection.mutable.ArrayBuffer.empty[Any]
       perTailBody.foreach(out += _)
       out += wArgs
       IArray.from(out)
@@ -289,17 +315,18 @@ final class DeleteUsingReady[Cols <: Tuple, Name <: String & Singleton, Ss <: Tu
 
   // Concat-chain: SArgs ⊕ Args (WHERE) ⊕ A (RETURNING).
   inline def returning[T, A, SArgs](f: JoinedView[Ss] => TypedExpr[T, A])(using
-    sbOf:  SourceBodyArgsOf.Aux[Ss, SArgs],
-    bff:   SourceBodyArgsProj[Ss]
+    sbOf: SourceBodyArgsOf.Aux[Ss, SArgs],
+    bff: SourceBodyArgsProj[Ss]
   ): QueryTemplate[Where.Concat[Where.Concat[SArgs, Args], A], T] = {
-    val expr = f(buildJoinedView(sources))
-    val parts: List[BodyPart] = bodyParts ++ List[BodyPart](SelectBuilder.bake(RawConstants.RETURNING), Right(expr.fragment))
+    val expr                  = f(buildJoinedView(sources))
+    val parts: List[BodyPart] = bodyParts ++
+      List[BodyPart](SelectBuilder.bake(RawConstants.RETURNING), Right(expr.fragment))
     type Out = Where.Concat[Where.Concat[SArgs, Args], A]
     val slotValues: Out => IArray[Any] = args => {
       val (swAcc, retArgs) = Where.projectConcat[Where.Concat[SArgs, Args], A](args)
       val (sArgs, wArgs)   = Where.projectConcat[SArgs, Args](swAcc)
       val perTailBody      = usingTailBodyArgs(bff, sArgs)
-      val out = scala.collection.mutable.ArrayBuffer.empty[Any]
+      val out              = scala.collection.mutable.ArrayBuffer.empty[Any]
       perTailBody.foreach(out += _)
       out += wArgs
       out += retArgs
@@ -309,9 +336,9 @@ final class DeleteUsingReady[Cols <: Tuple, Name <: String & Singleton, Ss <: Tu
   }
 
   inline def returningTuple[T <: NonEmptyTuple, SArgs, TOut](f: JoinedView[Ss] => T)(using
-    pa:   ProjArgsOf.Aux[T, TOut],
+    pa: ProjArgsOf.Aux[T, TOut],
     sbOf: SourceBodyArgsOf.Aux[Ss, SArgs],
-    bff:  SourceBodyArgsProj[Ss]
+    bff: SourceBodyArgsProj[Ss]
   ): QueryTemplate[Where.Concat[Where.Concat[SArgs, Args], TOut], ExprOutputs[T]] = {
     val exprs    = f(buildJoinedView(sources)).toList.asInstanceOf[List[TypedExpr[?, ?]]]
     val codec    = tupleCodec(exprs.map(_.codec)).asInstanceOf[Codec[ExprOutputs[T]]]
@@ -322,9 +349,9 @@ final class DeleteUsingReady[Cols <: Tuple, Name <: String & Singleton, Ss <: Tu
   }
 
   inline def returningNamed[NT <: scala.NamedTuple.AnyNamedTuple, SArgs, TOut](f: JoinedView[Ss] => NT)(using
-    pa:   ProjArgsOf.Aux[scala.NamedTuple.DropNames[NT], TOut],
+    pa: ProjArgsOf.Aux[scala.NamedTuple.DropNames[NT], TOut],
     sbOf: SourceBodyArgsOf.Aux[Ss, SArgs],
-    bff:  SourceBodyArgsProj[Ss]
+    bff: SourceBodyArgsProj[Ss]
   ): QueryTemplate[
     Where.Concat[Where.Concat[SArgs, Args], TOut],
     scala.NamedTuple.NamedTuple[scala.NamedTuple.Names[NT], ExprOutputs[scala.NamedTuple.DropNames[NT]]]
@@ -343,7 +370,7 @@ final class DeleteUsingReady[Cols <: Tuple, Name <: String & Singleton, Ss <: Tu
 
   inline def returningAll[SArgs](using
     sbOf: SourceBodyArgsOf.Aux[Ss, SArgs],
-    bff:  SourceBodyArgsProj[Ss]
+    bff: SourceBodyArgsProj[Ss]
   ): QueryTemplate[Where.Concat[SArgs, Args], NamedRowOf[Cols]] = {
     val exprs =
       table.columns.toList.asInstanceOf[List[Column[?, ?, ?, ?]]].map(c =>

--- a/modules/core/src/main/scala/skunk/sharp/dsl/Insert.scala
+++ b/modules/core/src/main/scala/skunk/sharp/dsl/Insert.scala
@@ -15,16 +15,16 @@ import scala.deriving.Mirror
 /**
  * INSERT builder.
  *
- *   - `users.insert((email = "x", age = 18))` (named tuple) / `users.insert(caseClassInstance)` — single-row,
- *     values baked via [[Param.bind]], `Args = Void`.
+ *   - `users.insert((email = "x", age = 18))` (named tuple) / `users.insert(caseClassInstance)` — single-row, values
+ *     baked via [[Param.bind]], `Args = Void`.
  *   - `users.insert.values(row, more*)` / `users.insert.values(reducible)` — batch, values baked, `Args = Void`.
  *   - `users.insert.from(query)` — `INSERT … SELECT`, `Args` threads from the inner subquery.
  *
- * The typed projection-then-values flow (`.into(u => (u.email, u.age)).values((email = Param[String], …))`)
- * for `CommandTemplate[(String, Int)]`-shaped templates is not yet shipped: it requires a per-field Args
- * reduction typeclass to make the result Args concrete (otherwise `.values(typed)` returns `Args = ?` and
- * users can't ascribe a typed template, defeating the purpose). Tracked as roadmap; until then, use the
- * SELECT-side `Param[T]` story for prepared-template re-binding and bake INSERT values directly.
+ * The typed projection-then-values flow (`.into(u => (u.email, u.age)).values((email = Param[String], …))`) for
+ * `CommandTemplate[(String, Int)]`-shaped templates is not yet shipped: it requires a per-field Args reduction
+ * typeclass to make the result Args concrete (otherwise `.values(typed)` returns `Args = ?` and users can't ascribe a
+ * typed template, defeating the purpose). Tracked as roadmap; until then, use the SELECT-side `Param[T]` story for
+ * prepared-template re-binding and bake INSERT values directly.
  */
 final class InsertBuilder[Cols <: Tuple] private[sharp] (private[sharp] val table: Table[Cols, ?]) {
 
@@ -68,7 +68,9 @@ final class InsertBuilder[Cols <: Tuple] private[sharp] (private[sharp] val tabl
     InsertCommand.buildMany[Cols](table, names, rs, AppliedFragment.empty)
   }
 
-  inline def values[F[_]: Reducible, T <: Product](rows: F[T])(using m: Mirror.ProductOf[T]): InsertCommand[Cols, Void, Void] = {
+  inline def values[F[_]: Reducible, T <: Product](rows: F[T])(using
+    m: Mirror.ProductOf[T]
+  ): InsertCommand[Cols, Void, Void] = {
     CompileChecks.requireAllNamesInCols[Cols, m.MirroredElemLabels]
     CompileChecks.requireCoversRequired[Cols, m.MirroredElemLabels]
     CompileChecks.requireValueTypesMatch[Cols, m.MirroredElemLabels, m.MirroredElemTypes]
@@ -101,8 +103,8 @@ object InsertSource {
   final case class TypedRow(fragment: Fragment[?]) extends InsertSource
 
   /**
-   * A single typed-Args row fragment — values are user-supplied at execute time via the typed `Args` slot.
-   * Goes through the `Right` (typed) side of [[SelectBuilder.assemble]] so the encoder threads.
+   * A single typed-Args row fragment — values are user-supplied at execute time via the typed `Args` slot. Goes through
+   * the `Right` (typed) side of [[SelectBuilder.assemble]] so the encoder threads.
    */
   final case class TypedRowParams(fragment: Fragment[?]) extends InsertSource
 
@@ -116,21 +118,21 @@ object InsertSource {
 /**
  * An assembled INSERT statement.
  *
- * `Args` is the captured-parameter type from the INSERT source (Void for value-baked inserts, or the row
- * tuple for `.withParams`). `CA` is the captured-parameter type from the `ON CONFLICT DO UPDATE SET`
- * clause (Void when there is no typed Param in the conflict clause).
+ * `Args` is the captured-parameter type from the INSERT source (Void for value-baked inserts, or the row tuple for
+ * `.withParams`). `CA` is the captured-parameter type from the `ON CONFLICT DO UPDATE SET` clause (Void when there is
+ * no typed Param in the conflict clause).
  *
  * The conflict clause is stored as two parts:
- *  - `conflictHeaderAf` — the static SQL prefix (e.g. `" ON CONFLICT (id) DO UPDATE SET "` or
- *    `" ON CONFLICT DO NOTHING"` or the entire baked clause for the Tuple-form DO UPDATE).
- *  - `conflictSets` — the typed SET fragment (`CA`). `emptyVoidSlot` when the conflict clause is static.
+ *   - `conflictHeaderAf` — the static SQL prefix (e.g. `" ON CONFLICT (id) DO UPDATE SET "` or
+ *     `" ON CONFLICT DO NOTHING"` or the entire baked clause for the Tuple-form DO UPDATE).
+ *   - `conflictSets` — the typed SET fragment (`CA`). `emptyVoidSlot` when the conflict clause is static.
  *
  * `insertParts` always emits exactly **two** `Right` slots in order:
  *   - Slot 0 (A1 = Args): the INSERT source. `emptyVoidSlot` for value-baked sources.
  *   - Slot 1 (A2 = CA): `conflictSets`. `emptyVoidSlot` when no typed conflict.
  *
- * The fixed-slot layout means `command[Args, CA]` and `withReturningTyped[Args, CA, ...]` dispatch
- * correctly for all combinations of baked/typed source and baked/typed conflict.
+ * The fixed-slot layout means `command[Args, CA]` and `withReturningTyped[Args, CA, ...]` dispatch correctly for all
+ * combinations of baked/typed source and baked/typed conflict.
  */
 final class InsertCommand[Cols <: Tuple, Args, CA] private[sharp] (
   private[sharp] val table: Table[Cols, ?],
@@ -164,23 +166,24 @@ final class InsertCommand[Cols <: Tuple, Args, CA] private[sharp] (
       case InsertSource.TypedRow(f) =>
         buf += SelectBuilder.bake(RawConstants.VALUES)
         buf += SelectBuilder.bake(f.asInstanceOf[Fragment[Void]].apply(Void))
-        buf += Right(SelectBuilder.emptyVoidSlot)  // A1 = Void placeholder (row already in Left)
+        buf += Right(SelectBuilder.emptyVoidSlot) // A1 = Void placeholder (row already in Left)
       case InsertSource.TypedRowParams(f) =>
         buf += SelectBuilder.bake(RawConstants.VALUES)
-        buf += Right(f)                            // A1 = Args
+        buf += Right(f) // A1 = Args
       case InsertSource.ManyRows(rows) =>
         buf += SelectBuilder.bake(TypedExpr.raw("VALUES "))
         buf += SelectBuilder.bake(TypedExpr.joined(rows, ", "))
-        buf += Right(SelectBuilder.emptyVoidSlot)  // A1 = Void placeholder
+        buf += Right(SelectBuilder.emptyVoidSlot) // A1 = Void placeholder
       case InsertSource.FromQuery(frag) =>
-        buf += Right(frag)                         // A1 = Args
+        buf += Right(frag) // A1 = Args
     }
     if (conflictHeaderAf ne AppliedFragment.empty) buf += SelectBuilder.bake(conflictHeaderAf)
-    buf += Right(conflictSets)                     // A2 = CA (or emptyVoid when no typed conflict)
+    buf += Right(conflictSets) // A2 = CA (or emptyVoid when no typed conflict)
     buf.toList
   }
 
-  inline def returning[T, A](f: ColumnsView[Cols] => TypedExpr[T, A]): QueryTemplate[Where.Concat[Where.Concat[Args, CA], A], T] = {
+  inline def returning[T, A](f: ColumnsView[Cols] => TypedExpr[T, A])
+    : QueryTemplate[Where.Concat[Where.Concat[Args, CA], A], T] = {
     val expr = f(table.columnsView)
     MutationAssembly.withReturningTyped[Args, CA, A, T](insertParts, expr.fragment, expr.codec)
   }
@@ -265,8 +268,8 @@ object InsertCommand {
     new InsertCommand[Cols, Args, CA](table, projected, source, conflictHeaderAf, conflictSets)
 
   /**
-   * Single-row insert from `Param[T]` placeholders — Args = the row tuple. The row encoder is built from
-   * each Param's codec; user supplies the tuple at execute time.
+   * Single-row insert from `Param[T]` placeholders — Args = the row tuple. The row encoder is built from each Param's
+   * codec; user supplies the tuple at execute time.
    */
   private[sharp] def buildSingleParams[Cols <: Tuple, Args](
     table: Table[Cols, ?],
@@ -274,7 +277,7 @@ object InsertCommand {
     params: List[Param[?]],
     conflictHeaderAf: AppliedFragment
   ): InsertCommand[Cols, Args, Void] = {
-    val projected = lookupProjected(table, names)
+    val projected            = lookupProjected(table, names)
     val perRow: Codec[Tuple] = tupleCodec(params.map(_.codec))
     val rowEnc               = perRow.values
     val frag: Fragment[Args] = Fragment(List(Right(rowEnc.sql)), rowEnc.asInstanceOf[Encoder[Args]], Origin.unknown)
@@ -288,12 +291,12 @@ object InsertCommand {
     values: List[Any],
     conflictHeaderAf: AppliedFragment
   ): InsertCommand[Cols, Void, Void] = {
-    val projected = lookupProjected(table, names)
-    val perRow: Codec[Tuple] = tupleCodec(projected.map(_.codec))
-    val rowEnc               = perRow.values
-    val values0: Tuple = Tuple.fromArray(values.toArray[Any])
+    val projected              = lookupProjected(table, names)
+    val perRow: Codec[Tuple]   = tupleCodec(projected.map(_.codec))
+    val rowEnc                 = perRow.values
+    val values0: Tuple         = Tuple.fromArray(values.toArray[Any])
     val voidEnc: Encoder[Void] = rowEnc.contramap[Void](_ => values0)
-    val frag: Fragment[Void] = Fragment(List(Right(rowEnc.sql)), voidEnc, Origin.unknown)
+    val frag: Fragment[Void]   = Fragment(List(Right(rowEnc.sql)), voidEnc, Origin.unknown)
     mk(table, projected, InsertSource.TypedRow(frag), conflictHeaderAf, SelectBuilder.emptyVoidSlot)
   }
 
@@ -304,9 +307,9 @@ object InsertCommand {
     rows: List[List[Any]],
     conflictHeaderAf: AppliedFragment
   ): InsertCommand[Cols, Void, Void] = {
-    val projected = lookupProjected(table, names)
-    val perRow: Codec[Tuple] = tupleCodec(projected.map(_.codec))
-    val rowEnc               = perRow.values
+    val projected                = lookupProjected(table, names)
+    val perRow: Codec[Tuple]     = tupleCodec(projected.map(_.codec))
+    val rowEnc                   = perRow.values
     val rowFrag: Fragment[Tuple] =
       Fragment(parts = List(Right(rowEnc.sql)), encoder = rowEnc, origin = Origin.unknown)
     val applied = rows.map(r => rowFrag(Tuple.fromArray(r.toArray[Any])))
@@ -319,7 +322,13 @@ object InsertCommand {
     fragment: Fragment[Args],
     conflictHeaderAf: AppliedFragment
   ): InsertCommand[Cols, Args, Void] =
-    mk(table, lookupProjected(table, names), InsertSource.FromQuery(fragment), conflictHeaderAf, SelectBuilder.emptyVoidSlot)
+    mk(
+      table,
+      lookupProjected(table, names),
+      InsertSource.FromQuery(fragment),
+      conflictHeaderAf,
+      SelectBuilder.emptyVoidSlot
+    )
 
   private def lookupProjected[Cols <: Tuple](
     table: Table[Cols, ?],
@@ -336,8 +345,8 @@ object InsertCommand {
 }
 
 /**
- * Continuation after `.onConflict(col)`. Holds a Void-CA base command so that `doUpdate[CA]` can return
- * a fresh `InsertCommand[Cols, Args, CA]` with the correct CA type.
+ * Continuation after `.onConflict(col)`. Holds a Void-CA base command so that `doUpdate[CA]` can return a fresh
+ * `InsertCommand[Cols, Args, CA]` with the correct CA type.
  */
 final class OnConflictBuilder[Cols <: Tuple, Args] private[sharp] (
   private val cmd: InsertCommand[Cols, Args, Void],
@@ -345,8 +354,10 @@ final class OnConflictBuilder[Cols <: Tuple, Args] private[sharp] (
 ) {
 
   private def quotedCols: String = cols.map(c => s""""$c"""").mkString(", ")
+
   private def doNothingHeader: AppliedFragment =
     TypedExpr.raw(s" ON CONFLICT ($quotedCols) DO NOTHING")
+
   private def doUpdateHeader: AppliedFragment =
     TypedExpr.raw(s" ON CONFLICT ($quotedCols) DO UPDATE SET ")
 
@@ -354,27 +365,29 @@ final class OnConflictBuilder[Cols <: Tuple, Args] private[sharp] (
     InsertCommand.mk(cmd.table, cmd.projected, cmd.source, doNothingHeader, SelectBuilder.emptyVoidSlot)
 
   /**
-   * Typed SET — the lambda returns a single `SetAssignment[?, CA]` (possibly `&`-chained). `CA` propagates
-   * to `InsertCommand` and surfaces in `.compile`'s `CommandTemplate[Concat[Args, CA]]`. Use [[Param]] in
-   * the RHS to defer values to execute time; baked RHS values (`:= "x"`) yield `CA = Void`.
+   * Typed SET — the lambda returns a single `SetAssignment[?, CA]` (possibly `&`-chained). `CA` propagates to
+   * `InsertCommand` and surfaces in `.compile`'s `CommandTemplate[Concat[Args, CA]]`. Use [[Param]] in the RHS to defer
+   * values to execute time; baked RHS values (`:= "x"`) yield `CA = Void`.
    *
-   * For multiple baked-value assignments, the Tuple overload (`.doUpdate(c => (c.a := "x", c.b := 1))`)
-   * is safer: it pre-applies all values into `Left(AF)` to avoid a product-encoder issue that would arise
-   * when two baked encoders are combined via `&`.
+   * For multiple baked-value assignments, the Tuple overload (`.doUpdate(c => (c.a := "x", c.b := 1))`) is safer: it
+   * pre-applies all values into `Left(AF)` to avoid a product-encoder issue that would arise when two baked encoders
+   * are combined via `&`.
    */
   def doUpdate[CA](f: ColumnsView[Cols] => SetAssignment[?, CA]): InsertCommand[Cols, Args, CA] = {
     val sa = f(ColumnsView(cmd.tableColumns))
     InsertCommand.mk(
-      cmd.table, cmd.projected, cmd.source,
+      cmd.table,
+      cmd.projected,
+      cmd.source,
       doUpdateHeader,
       sa.fragment.asInstanceOf[Fragment[CA]]
     )
   }
 
   /**
-   * Tuple SET — multiple baked-value assignments. All SET RHS values are pre-applied into `Left(AF)`,
-   * so `CA = Void` and the conflict contributes no runtime parameters. The baked clause (header +
-   * pre-applied SET values) is stored as a single `Left(AppliedFragment)`.
+   * Tuple SET — multiple baked-value assignments. All SET RHS values are pre-applied into `Left(AF)`, so `CA = Void`
+   * and the conflict contributes no runtime parameters. The baked clause (header + pre-applied SET values) is stored as
+   * a single `Left(AppliedFragment)`.
    */
   @targetName("doUpdateTuple")
   def doUpdate(f: ColumnsView[Cols] => Tuple): InsertCommand[Cols, Args, Void] = {
@@ -382,7 +395,9 @@ final class OnConflictBuilder[Cols <: Tuple, Args] private[sharp] (
     val raw    = f(view).toList.asInstanceOf[List[SetAssignment[?, ?]]]
     val setsAF = TypedExpr.joined(raw.map(sa => sa.fragment.asInstanceOf[Fragment[Void]].apply(Void)), ", ")
     InsertCommand.mk(
-      cmd.table, cmd.projected, cmd.source,
+      cmd.table,
+      cmd.projected,
+      cmd.source,
       doUpdateHeader |+| setsAF,
       SelectBuilder.emptyVoidSlot
     )
@@ -398,7 +413,9 @@ final class OnConflictBuilder[Cols <: Tuple, Args] private[sharp] (
     val excluded = ColumnsView.qualifiedRaw(cmd.tableColumns, "excluded")
     val sa       = f(target, excluded)
     InsertCommand.mk(
-      cmd.table, cmd.projected, cmd.source,
+      cmd.table,
+      cmd.projected,
+      cmd.source,
       doUpdateHeader,
       sa.fragment.asInstanceOf[Fragment[CA]]
     )
@@ -416,7 +433,9 @@ final class OnConflictBuilder[Cols <: Tuple, Args] private[sharp] (
     val raw      = f(target, excluded).toList.asInstanceOf[List[SetAssignment[?, ?]]]
     val setsAF   = TypedExpr.joined(raw.map(sa => sa.fragment.asInstanceOf[Fragment[Void]].apply(Void)), ", ")
     InsertCommand.mk(
-      cmd.table, cmd.projected, cmd.source,
+      cmd.table,
+      cmd.projected,
+      cmd.source,
       doUpdateHeader |+| setsAF,
       SelectBuilder.emptyVoidSlot
     )
@@ -431,15 +450,15 @@ extension [Cols <: Tuple, Name <: String & Singleton](table: Table[Cols, Name]) 
 
 /** Strip the `Param[_]` wrapper from each tuple element: `(Param[A], Param[B]) → (A, B)`. */
 type StripParams[T <: Tuple] <: Tuple = T match {
-  case EmptyTuple        => EmptyTuple
-  case Param[t] *: tail  => t *: StripParams[tail]
+  case EmptyTuple       => EmptyTuple
+  case Param[t] *: tail => t *: StripParams[tail]
 }
 
 extension [Cols <: Tuple](b: InsertBuilder[Cols]) {
 
   /**
-   * Typed-Args INSERT: every named-tuple field is a `Param[T]`, and the resulting `CommandTemplate`'s
-   * `Args` is the row tuple (`StripParams[…]`). Values are supplied at execute via `cmd.run(s)(args)`.
+   * Typed-Args INSERT: every named-tuple field is a `Param[T]`, and the resulting `CommandTemplate`'s `Args` is the row
+   * tuple (`StripParams[…]`). Values are supplied at execute via `cmd.run(s)(args)`.
    *
    * {{{
    *   val create: CommandTemplate[(UUID, String, Int)] =
@@ -448,8 +467,8 @@ extension [Cols <: Tuple](b: InsertBuilder[Cols]) {
    *   _    <- prep.execute((uid, "x@y", 30))
    * }}}
    *
-   * Compile checks: every field name exists on `Cols` and every required (non-defaulted) column is covered.
-   * The runtime walk extracts each `Param[T]`'s codec to build the row encoder.
+   * Compile checks: every field name exists on `Cols` and every required (non-defaulted) column is covered. The runtime
+   * walk extracts each `Param[T]`'s codec to build the row encoder.
    */
   inline def withParams[R <: NamedTuple.AnyNamedTuple](
     row: R
@@ -464,7 +483,12 @@ extension [Cols <: Tuple](b: InsertBuilder[Cols]) {
           s"skunk-sharp: .withParams expects every field to be a Param[T]; got: $other (${other.getClass.getName})"
         )
     }
-    InsertCommand.buildSingleParams[Cols, StripParams[NamedTuple.DropNames[R]]](b.table, names, params, AppliedFragment.empty)
+    InsertCommand.buildSingleParams[Cols, StripParams[NamedTuple.DropNames[R]]](
+      b.table,
+      names,
+      params,
+      AppliedFragment.empty
+    )
   }
 
 }

--- a/modules/core/src/main/scala/skunk/sharp/dsl/Join.scala
+++ b/modules/core/src/main/scala/skunk/sharp/dsl/Join.scala
@@ -43,19 +43,20 @@ import scala.NamedTuple
  */
 extension [Cols <: Tuple](r: Relation[Cols]) {
 
-  def alias[A <: String & Singleton](a: A): TypedBodyRelation[Cols, skunk.Void] { type Alias = A; type Mode = AliasMode.Explicit } = {
+  def alias[A <: String & Singleton](a: A)
+    : TypedBodyRelation[Cols, skunk.Void] { type Alias = A; type Mode = AliasMode.Explicit } = {
     val underlying = r
     val newAlias   = a
     new TypedBodyRelation[Cols, skunk.Void] {
       type Alias = A
       type Mode  = AliasMode.Explicit
-      val currentAlias: A                 = newAlias
-      def name: String                    = underlying.name
-      def columns: Cols                   = underlying.columns
-      def schema: Option[String]          = underlying.schema
-      def expectedTableType: String       = underlying.expectedTableType
-      override def hasFromClause: Boolean = underlying.hasFromClause
-      override def qualifiedName: String  = underlying.qualifiedName
+      val currentAlias: A                                       = newAlias
+      def name: String                                          = underlying.name
+      def columns: Cols                                         = underlying.columns
+      def schema: Option[String]                                = underlying.schema
+      def expectedTableType: String                             = underlying.expectedTableType
+      override def hasFromClause: Boolean                       = underlying.hasFromClause
+      override def qualifiedName: String                        = underlying.qualifiedName
       override def fromFragmentWith(x: String): AppliedFragment = underlying.fromFragmentWith(x)
     }
   }
@@ -83,17 +84,17 @@ extension [Cols <: Tuple](r: Relation[Cols]) {
 extension [Ss <: Tuple, GroupsT <: Tuple, WA, HA](sb: SelectBuilder[Ss, GroupsT, WA, HA]) {
 
   inline def alias[A <: String & Singleton, SArgs, GArgs](a: A)(using
-    ev:   IsSingleSource[Ss],
+    ev: IsSingleSource[Ss],
     sbOf: SourceBodyArgsOf.Aux[Ss, SArgs],
-    g:    ProjArgsOf.Aux[GroupsT, GArgs]
+    g: ProjArgsOf.Aux[GroupsT, GArgs]
   ): TypedBodyRelation[ev.Cols, Where.Concat[Where.Concat[Where.Concat[SArgs, WA], GArgs], HA]] {
     type Alias    = A
     type Mode     = AliasMode.Explicit
     type BodyArgs = Where.Concat[Where.Concat[Where.Concat[SArgs, WA], GArgs], HA]
   } = {
     type CombinedArgs = Where.Concat[Where.Concat[Where.Concat[SArgs, WA], GArgs], HA]
-    val newAlias  = a
-    val cols      = sb.sources.toList.asInstanceOf[List[SourceEntry[?, ?, ?, ?, ?]]].head.effectiveCols.asInstanceOf[ev.Cols]
+    val newAlias = a
+    val cols = sb.sources.toList.asInstanceOf[List[SourceEntry[?, ?, ?, ?, ?]]].head.effectiveCols.asInstanceOf[ev.Cols]
     val innerFrag: Fragment[CombinedArgs] =
       sb.compileBodyFragment[SArgs, GArgs](using ev, sbOf, g)
     new SelectAliasedRelation[ev.Cols, CombinedArgs, A](newAlias, cols, innerFrag).asInstanceOf[
@@ -108,23 +109,25 @@ extension [Ss <: Tuple, GroupsT <: Tuple, WA, HA](sb: SelectBuilder[Ss, GroupsT,
 }
 
 private[dsl] final class SelectAliasedRelation[Cols0 <: Tuple, CombinedArgs, A <: String & Singleton](
-  newAlias:  A,
-  cols0:     Cols0,
+  newAlias: A,
+  cols0: Cols0,
   innerFrag: Fragment[CombinedArgs]
 ) extends TypedBodyRelation[Cols0, CombinedArgs] {
   type Alias = A
   type Mode  = AliasMode.Explicit
   override def bodyFragmentOpt: Option[Fragment[?]]            = Some(innerFrag)
   override lazy val starProjFromAfOpt: Option[AppliedFragment] = None
-  val currentAlias: A           = newAlias
-  val name: String              = newAlias
-  val schema: Option[String]    = None
-  val columns: Cols0            = cols0
-  val expectedTableType: String = ""
+  val currentAlias: A                                          = newAlias
+  val name: String                                             = newAlias
+  val schema: Option[String]                                   = None
+  val columns: Cols0                                           = cols0
+  val expectedTableType: String                                = ""
+
   override def fromFragmentWith(x: String): AppliedFragment =
     throw new UnsupportedOperationException(
       "skunk-sharp internal: fromFragmentWith called on a typed subquery relation — aliasedFromEntryParts should handle this"
     )
+
 }
 
 /**
@@ -151,29 +154,38 @@ private[dsl] final class SelectAliasedRelation[Cols0 <: Tuple, CombinedArgs, A <
 extension [Ss <: Tuple, Proj <: Tuple, Groups <: Tuple, DA <: Tuple, OA <: Tuple, WA, HA, Row](
   ps: ProjectedSelect[Ss, Proj, Groups, DA, OA, WA, HA, Row]
 )(using
-  gc:  GroupCoverage[Proj, Groups],
+  gc: GroupCoverage[Proj, Groups],
   @scala.annotation.unused np: AllNamedProj[Proj]
 ) {
 
   // Concat-chain evidences (left-fold over slot order):
   // DA2 ⊕ PA ⊕ SA ⊕ OnA ⊕ WA ⊕ GA ⊕ HA ⊕ OA2 — each name spells the accumulator at that step.
   inline def alias[A <: String & Singleton, SA, OnA, DA2, PA, GA, OA2](a: A)(using
-    sbOf:   SourceBodyArgsOf.Aux[Ss, SA],
-    bff:    SourceBodyArgsProj[Ss],
-    onSum:  SourceOnArgsOf.Aux[Ss, OnA],
+    sbOf: SourceBodyArgsOf.Aux[Ss, SA],
+    bff: SourceBodyArgsProj[Ss],
+    onSum: SourceOnArgsOf.Aux[Ss, OnA],
     onProj: SourceOnArgsProj[Ss],
-    d:      ProjArgsOf.Aux[DA, DA2],
-    pa:     ProjArgsOf.Aux[Proj, PA],
-    g:      ProjArgsOf.Aux[Groups, GA],
-    o:      ProjArgsOf.Aux[OA, OA2]
-  ): TypedBodyRelation[ProjCols[Proj], Where.Concat[Where.Concat[Where.Concat[Where.Concat[Where.Concat[Where.Concat[Where.Concat[DA2, PA], SA], OnA], WA], GA], HA], OA2]] {
+    d: ProjArgsOf.Aux[DA, DA2],
+    pa: ProjArgsOf.Aux[Proj, PA],
+    g: ProjArgsOf.Aux[Groups, GA],
+    o: ProjArgsOf.Aux[OA, OA2]
+  ): TypedBodyRelation[ProjCols[Proj], Where.Concat[
+    Where.Concat[Where.Concat[Where.Concat[Where.Concat[Where.Concat[Where.Concat[DA2, PA], SA], OnA], WA], GA], HA],
+    OA2
+  ]] {
     type Alias    = A
     type Mode     = AliasMode.Explicit
-    type BodyArgs = Where.Concat[Where.Concat[Where.Concat[Where.Concat[Where.Concat[Where.Concat[Where.Concat[DA2, PA], SA], OnA], WA], GA], HA], OA2]
+    type BodyArgs = Where.Concat[
+      Where.Concat[Where.Concat[Where.Concat[Where.Concat[Where.Concat[Where.Concat[DA2, PA], SA], OnA], WA], GA], HA],
+      OA2
+    ]
   } = {
-    type CombinedArgs = Where.Concat[Where.Concat[Where.Concat[Where.Concat[Where.Concat[Where.Concat[Where.Concat[DA2, PA], SA], OnA], WA], GA], HA], OA2]
-    val newAlias = a
-    val cols     = buildProjectedCols(ps.projections).asInstanceOf[ProjCols[Proj]]
+    type CombinedArgs = Where.Concat[
+      Where.Concat[Where.Concat[Where.Concat[Where.Concat[Where.Concat[Where.Concat[DA2, PA], SA], OnA], WA], GA], HA],
+      OA2
+    ]
+    val newAlias                          = a
+    val cols                              = buildProjectedCols(ps.projections).asInstanceOf[ProjCols[Proj]]
     val innerFrag: Fragment[CombinedArgs] =
       ps.compileBodyFragment[SA, OnA, DA2, PA, GA, OA2](using gc, sbOf, bff, onSum, onProj, d, pa, g, o)
     new SelectAliasedRelation[ProjCols[Proj], CombinedArgs, A](newAlias, cols, innerFrag).asInstanceOf[
@@ -259,9 +271,9 @@ extension [Cols <: Tuple, Row <: scala.NamedTuple.AnyNamedTuple](v: Values[Cols,
  * detect it and emit the WITH preamble regardless of how many alias layers are applied. Useful for CTE self-joins:
  * `c.alias("a").innerJoin(c.alias("b")).on(...)`.
  *
- * Returns a new [[CteRelation]] with the same `cteName`, body, deps, and `BodyArgs` — only the `Alias_` type
- * parameter changes. This is essential for typed-args CTEs: re-aliasing preserves the body's `BA` at the type
- * level so the outer compile's [[CteArgs]] still picks it up.
+ * Returns a new [[CteRelation]] with the same `cteName`, body, deps, and `BodyArgs` — only the `Alias_` type parameter
+ * changes. This is essential for typed-args CTEs: re-aliasing preserves the body's `BA` at the type level so the outer
+ * compile's [[CteArgs]] still picks it up.
  *
  * Lives here because Scala 3 requires overloaded extensions to share a single top-level definition group.
  */
@@ -292,10 +304,10 @@ enum JoinKind(val sql: String) {
 
   /**
    * Pre-rendered ` <kind> ` and ` <kind> LATERAL ` AppliedFragments — interned once per enum case so the SELECT
-   * compiler can splice the join keyword as a single shared instance instead of `s"…"`-interpolating + allocating
-   * a fresh `Fragment` + `AppliedFragment` per source per compile.
+   * compiler can splice the join keyword as a single shared instance instead of `s"…"`-interpolating + allocating a
+   * fresh `Fragment` + `AppliedFragment` per source per compile.
    */
-  val keywordAf:        skunk.AppliedFragment = skunk.sharp.internal.RawConstants.intern(s" $sql ")
+  val keywordAf: skunk.AppliedFragment        = skunk.sharp.internal.RawConstants.intern(s" $sql ")
   val lateralKeywordAf: skunk.AppliedFragment = skunk.sharp.internal.RawConstants.intern(s" $sql LATERAL ")
 }
 
@@ -347,7 +359,7 @@ private[sharp] def nullabilifyCols(cols: Tuple): Tuple = {
  * flipped column types in its `.where` / `.select` views.
  */
 type NullabilifySources[Ss <: Tuple] <: Tuple = Ss match {
-  case EmptyTuple                            => EmptyTuple
+  case EmptyTuple                           => EmptyTuple
   case SourceEntry[r, c0, c, a, oa] *: tail =>
     SourceEntry[r, c0, NullableCols[c], a, oa] *: NullabilifySources[tail]
 }
@@ -482,18 +494,18 @@ final class SourceEntry[
 )
 
 /**
- * Aliases tuple: one alias literal per committed source. Pattern-matches `SourceEntry[?, ?, ?, a, ?]` directly in the `*:`
- * arm — going through a separate `AliasOf` helper breaks reduction when `Ss` is constructed through multiple steps
+ * Aliases tuple: one alias literal per committed source. Pattern-matches `SourceEntry[?, ?, ?, a, ?]` directly in the
+ * `*:` arm — going through a separate `AliasOf` helper breaks reduction when `Ss` is constructed through multiple steps
  * because the inner match type stays abstract.
  */
 type AliasesOf[Ss <: Tuple] <: Tuple = Ss match {
-  case EmptyTuple                   => EmptyTuple
+  case EmptyTuple                      => EmptyTuple
   case SourceEntry[?, ?, ?, a, ?] *: t => a *: AliasesOf[t]
 }
 
 /** Views tuple: `ColumnsView[EffectiveCols]` per committed source. */
 type EffectiveViewsOf[Ss <: Tuple] <: Tuple = Ss match {
-  case EmptyTuple                   => EmptyTuple
+  case EmptyTuple                      => EmptyTuple
   case SourceEntry[?, ?, c, ?, ?] *: t => ColumnsView[c] *: EffectiveViewsOf[t]
 }
 
@@ -503,13 +515,13 @@ type JoinedView[Ss <: Tuple] =
 
 /** Aliases tuple for the `.on`-time view — committed aliases + pending alias (appended). */
 type OnAliases[Ss <: Tuple, AR <: String & Singleton] <: Tuple = Ss match {
-  case EmptyTuple                   => AR *: EmptyTuple
+  case EmptyTuple                      => AR *: EmptyTuple
   case SourceEntry[?, ?, ?, a, ?] *: t => a *: OnAliases[t, AR]
 }
 
 /** Views tuple for the `.on`-time view — committed effective views + pending original view (appended). */
 type OnViews[Ss <: Tuple, CR0 <: Tuple] <: Tuple = Ss match {
-  case EmptyTuple                   => ColumnsView[CR0] *: EmptyTuple
+  case EmptyTuple                      => ColumnsView[CR0] *: EmptyTuple
   case SourceEntry[?, ?, c, ?, ?] *: t => ColumnsView[c] *: OnViews[t, CR0]
 }
 
@@ -577,17 +589,17 @@ final class IncompleteJoin[
    * *original* cols — `ON` is evaluated before `NULL`-padding happens. Transitions to [[SelectBuilder]] with the
    * (possibly nullabilified) committed sources plus the pending source appended.
    *
-   * The predicate's typed `Args` (`A`) is captured as the new source's `OnArgs` type member — outer `.compile`
-   * picks it up via [[SourceOnArgsProj]] and surfaces it in the outer [[QueryTemplate]]'s `Args` so any [[Param]]
-   * in an ON predicate composes statically with WHERE / GROUP BY / HAVING args. Plain column-to-column
-   * comparisons (`r.a.id ==== r.b.user_id`) keep `A = Void` and the slot collapses to `Void`.
+   * The predicate's typed `Args` (`A`) is captured as the new source's `OnArgs` type member — outer `.compile` picks it
+   * up via [[SourceOnArgsProj]] and surfaces it in the outer [[QueryTemplate]]'s `Args` so any [[Param]] in an ON
+   * predicate composes statically with WHERE / GROUP BY / HAVING args. Plain column-to-column comparisons (`r.a.id ====
+   * r.b.user_id`) keep `A = Void` and the slot collapses to `Void`.
    */
   def on[A](
     f: OnView[Ss, CR0, AR] => skunk.sharp.TypedExpr[Boolean, A]
   ): SelectBuilder[Tuple.Append[SsFinal, SourceEntry[RR, CR0, CR, AR, A]], EmptyTuple, skunk.Void, skunk.Void] = {
-    val rawPred = f(buildOnView[Ss, CR0, AR](sources, pendingOriginalCols, pendingAlias))
+    val rawPred        = f(buildOnView[Ss, CR0, AR](sources, pendingOriginalCols, pendingAlias))
     val pred: Where[A] = rawPred
-    val entry = new SourceEntry[RR, CR0, CR, AR, A](
+    val entry          = new SourceEntry[RR, CR0, CR, AR, A](
       pendingRelation,
       pendingAlias,
       pendingOriginalCols,
@@ -601,7 +613,12 @@ final class IncompleteJoin[
       case _                              => sources
     }
     val nextSources = (finalCommitted :* entry).asInstanceOf[Tuple.Append[SsFinal, SourceEntry[RR, CR0, CR, AR, A]]]
-    new SelectBuilder[Tuple.Append[SsFinal, SourceEntry[RR, CR0, CR, AR, A]], EmptyTuple, skunk.Void, skunk.Void](nextSources)
+    new SelectBuilder[
+      Tuple.Append[SsFinal, SourceEntry[RR, CR0, CR, AR, A]],
+      EmptyTuple,
+      skunk.Void,
+      skunk.Void
+    ](nextSources)
   }
 
 }
@@ -611,15 +628,15 @@ final class IncompleteJoin[
 /**
  * Build the FROM body parts for a source, producing a `List[BodyPart]`:
  *
- *  - **SRF source** (`IsSrf`): emits `Left("func("), Right(argsFrag), Left(") AS \"alias\" (\"col\")")`. The
- *    `Right(argsFrag)` slot carries the typed function-call args — `Param`s in `generate_series(start, stop)`
- *    or `unnest(arr)` thread into the outer query's Args.
- *  - **Typed subquery** (`bodyFragmentOpt = Some(frag)`): emits `Left("("), Right(innerFrag), Left(") AS alias")`.
- *    The `Right(innerFrag)` slot carries the typed inner `Fragment[BodyArgs]` — the assembler threads it as a
- *    positional slot in the outer query's Args chain.
- *  - **Plain source** (table / view / CTE, `bodyFragmentOpt = None`): emits `Left(fromFragmentWith(alias)),
- *    Right(emptyVoidSlot)`. The `Right(emptyVoidSlot)` is a positional placeholder (no SQL, no encode) so the
- *    source-body slot index stays stable regardless of whether the source is plain or typed.
+ *   - **SRF source** (`IsSrf`): emits `Left("func("), Right(argsFrag), Left(") AS \"alias\" (\"col\")")`. The
+ *     `Right(argsFrag)` slot carries the typed function-call args — `Param`s in `generate_series(start, stop)` or
+ *     `unnest(arr)` thread into the outer query's Args.
+ *   - **Typed subquery** (`bodyFragmentOpt = Some(frag)`): emits `Left("("), Right(innerFrag), Left(") AS alias")`. The
+ *     `Right(innerFrag)` slot carries the typed inner `Fragment[BodyArgs]` — the assembler threads it as a positional
+ *     slot in the outer query's Args chain.
+ *   - **Plain source** (table / view / CTE, `bodyFragmentOpt = None`): emits `Left(fromFragmentWith(alias)),
+ *     Right(emptyVoidSlot)`. The `Right(emptyVoidSlot)` is a positional placeholder (no SQL, no encode) so the
+ *     source-body slot index stays stable regardless of whether the source is plain or typed.
  */
 private[sharp] def aliasedFromEntryParts(s: SourceEntry[?, ?, ?, ?, ?]): List[SelectBuilder.BodyPart] =
   s.relation match {
@@ -646,9 +663,9 @@ private[sharp] def aliasedFromEntryParts(s: SourceEntry[?, ?, ?, ?, ?]): List[Se
   }
 
 /**
- * Marker trait for set-returning-function relations (`generate_series`, `unnest`, …). Carries the function
- * name, typed args fragment, and output column name so [[aliasedFromEntryParts]] can render the strict SRF
- * shape `func(args) AS "alias" ("col")` (no outer parens — Postgres rejects `(func(args)) AS …`).
+ * Marker trait for set-returning-function relations (`generate_series`, `unnest`, …). Carries the function name, typed
+ * args fragment, and output column name so [[aliasedFromEntryParts]] can render the strict SRF shape
+ * `func(args) AS "alias" ("col")` (no outer parens — Postgres rejects `(func(args)) AS …`).
  */
 private[sharp] trait IsSrf {
   def srfFuncName: String
@@ -659,12 +676,12 @@ private[sharp] trait IsSrf {
 // ---- SourceBodyArgs match type + SourceBodyArgsOf typeclass -----------------------------------
 
 /**
- * Extract the `BodyArgs` type from a relation. Matches on [[TypedBodyRelation]] (which carries `BA` as
- * a direct class type parameter — not a type-member projection) before falling back to `skunk.Void` for
- * all plain relations (`Table`, `View`, CTE, re-aliased wrappers) which don't extend `TypedBodyRelation`.
+ * Extract the `BodyArgs` type from a relation. Matches on [[TypedBodyRelation]] (which carries `BA` as a direct class
+ * type parameter — not a type-member projection) before falling back to `skunk.Void` for all plain relations (`Table`,
+ * `View`, CTE, re-aliased wrappers) which don't extend `TypedBodyRelation`.
  *
- * Using a helper match type (rather than `R#BodyArgs`) avoids the Scala 3 limitation that disallows
- * type-member projections (`#`) on pattern-bound type variables in match type bodies.
+ * Using a helper match type (rather than `R#BodyArgs`) avoids the Scala 3 limitation that disallows type-member
+ * projections (`#`) on pattern-bound type variables in match type bodies.
  */
 private[dsl] type GetBodyArgs[R] = R match {
   case TypedBodyRelation[_, ba] => ba
@@ -672,21 +689,21 @@ private[dsl] type GetBodyArgs[R] = R match {
 }
 
 /**
- * Combined `BodyArgs` accumulator across all sources — a [[Where.Concat]] right-fold over per-source
- * `GetBodyArgs[r]`. Plain relations contribute `Void` (collapsed away); typed subquery relations contribute
- * their inner combined args. Used as the SELECT compile path's `SArgs` slot.
+ * Combined `BodyArgs` accumulator across all sources — a [[Where.Concat]] right-fold over per-source `GetBodyArgs[r]`.
+ * Plain relations contribute `Void` (collapsed away); typed subquery relations contribute their inner combined args.
+ * Used as the SELECT compile path's `SArgs` slot.
  */
 type SourceBodyArgs[Ss <: Tuple] = Ss match {
-  case EmptyTuple                      => skunk.Void
+  case EmptyTuple                         => skunk.Void
   case SourceEntry[r, ?, ?, ?, ?] *: tail => Where.Concat[GetBodyArgs[r], SourceBodyArgs[tail]]
 }
 
 /**
- * Project a combined [[SourceBodyArgs]] value back into a per-source list of body-args values. Mirrors the
- * fold structure of `SourceBodyArgs[Ss]`: at each `cons` step, peel one source's `BodyArgs` off the front via
+ * Project a combined [[SourceBodyArgs]] value back into a per-source list of body-args values. Mirrors the fold
+ * structure of `SourceBodyArgs[Ss]`: at each `cons` step, peel one source's `BodyArgs` off the front via
  * [[Where.projectConcat]] and recurse on the tail. The resulting `List[Any]` has one entry per source — `Void` for
- * plain sources, the typed inner-args value for typed-subquery sources — feeding the `IArray[Any]` that
- * `assembleN` consumes positionally.
+ * plain sources, the typed inner-args value for typed-subquery sources — feeding the `IArray[Any]` that `assembleN`
+ * consumes positionally.
  */
 sealed trait SourceBodyArgsProj[Ss <: Tuple] {
   def project(combined: Any): List[Any]
@@ -708,19 +725,28 @@ object SourceBodyArgsProj {
 
 }
 
-private[dsl] final class SourceBodyArgsConsProj[R <: Relation[C0], C0 <: Tuple, C <: Tuple, A <: String & Singleton, OA, T <: Tuple](
+private[dsl] final class SourceBodyArgsConsProj[
+  R <: Relation[C0],
+  C0 <: Tuple,
+  C <: Tuple,
+  A <: String & Singleton,
+  OA,
+  T <: Tuple
+](
   rest: SourceBodyArgsProj[T],
   proj: Where.Concat[GetBodyArgs[R], SourceBodyArgs[T]] => (GetBodyArgs[R], SourceBodyArgs[T])
 ) extends SourceBodyArgsProj[SourceEntry[R, C0, C, A, OA] *: T] {
+
   def project(combined: Any): List[Any] = {
     val (h, t) = proj(combined.asInstanceOf[Where.Concat[GetBodyArgs[R], SourceBodyArgs[T]]])
     h :: rest.project(t)
   }
+
 }
 
 /**
- * Combined ON-predicate args accumulator — a [[Where.Concat]] right-fold over per-source `OnArgs`. Sources whose
- * ON predicate is absent (head source, CROSS joins) carry `Void` and collapse out.
+ * Combined ON-predicate args accumulator — a [[Where.Concat]] right-fold over per-source `OnArgs`. Sources whose ON
+ * predicate is absent (head source, CROSS joins) carry `Void` and collapse out.
  */
 type SourceOnArgs[Ss <: Tuple] = Ss match {
   case EmptyTuple                          => skunk.Void
@@ -728,8 +754,8 @@ type SourceOnArgs[Ss <: Tuple] = Ss match {
 }
 
 /**
- * Typeclass wrapper around [[SourceOnArgs]] — gives the standard `Aux[Ss, O]` shape so the compile path can
- * summon it as a using parameter and read out the combined `OnA` type without writing the match type inline.
+ * Typeclass wrapper around [[SourceOnArgs]] — gives the standard `Aux[Ss, O]` shape so the compile path can summon it
+ * as a using parameter and read out the combined `OnA` type without writing the match type inline.
  */
 trait SourceOnArgsOf[Ss <: Tuple] {
   type Out
@@ -740,11 +766,12 @@ object SourceOnArgsOf {
 
   given compute[Ss <: Tuple]: (SourceOnArgsOf[Ss] { type Out = SourceOnArgs[Ss] }) =
     new SourceOnArgsOf[Ss] { type Out = SourceOnArgs[Ss] }
+
 }
 
 /**
- * Project a combined [[SourceOnArgs]] value back into a per-source list of ON-pred-args values, in source order.
- * Used by the SELECT compile path to fill the per-source ON slot in the IArray that `assembleN` consumes.
+ * Project a combined [[SourceOnArgs]] value back into a per-source list of ON-pred-args values, in source order. Used
+ * by the SELECT compile path to fill the per-source ON slot in the IArray that `assembleN` consumes.
  */
 sealed trait SourceOnArgsProj[Ss <: Tuple] {
   def project(combined: Any): List[Any]
@@ -766,21 +793,30 @@ object SourceOnArgsProj {
 
 }
 
-private[dsl] final class SourceOnArgsConsProj[R <: Relation[C0], C0 <: Tuple, C <: Tuple, A <: String & Singleton, OA, T <: Tuple](
+private[dsl] final class SourceOnArgsConsProj[
+  R <: Relation[C0],
+  C0 <: Tuple,
+  C <: Tuple,
+  A <: String & Singleton,
+  OA,
+  T <: Tuple
+](
   rest: SourceOnArgsProj[T],
   proj: Where.Concat[OA, SourceOnArgs[T]] => (OA, SourceOnArgs[T])
 ) extends SourceOnArgsProj[SourceEntry[R, C0, C, A, OA] *: T] {
+
   def project(combined: Any): List[Any] = {
     val (h, t) = proj(combined.asInstanceOf[Where.Concat[OA, SourceOnArgs[T]]])
     h :: rest.project(t)
   }
+
 }
 
 /**
  * Typeclass wrapper around [[SourceBodyArgs]] — gives the standard `Aux[Ss, O]` pattern expected by
- * [[SelectBuilder.compile]], [[SelectBuilder.compileBodyFragment]], and the `.alias` extensions.
- * A single `given compute` always provides `Out = SourceBodyArgs[Ss]`, which the Scala 3 compiler
- * reduces to a concrete type when `Ss` is known.
+ * [[SelectBuilder.compile]], [[SelectBuilder.compileBodyFragment]], and the `.alias` extensions. A single
+ * `given compute` always provides `Out = SourceBodyArgs[Ss]`, which the Scala 3 compiler reduces to a concrete type
+ * when `Ss` is known.
  */
 trait SourceBodyArgsOf[Ss <: Tuple] {
   type Out
@@ -891,13 +927,23 @@ extension [L, RL <: Relation[CL], CL <: Tuple, AL <: String & Singleton, ML <: A
   def crossJoin[R, RR <: Relation[CR], CR <: Tuple, AR <: String & Singleton, MR <: AliasMode](right: R)(using
     aR: AsRelation.Aux[R, RR, CR, AR, MR],
     aliasCheck: AliasNotUsed[AR, AL *: EmptyTuple]
-  ): SelectBuilder[(SourceEntry[RL, CL, CL, AL, Void], SourceEntry[RR, CR, CR, AR, Void]), EmptyTuple, skunk.Void, skunk.Void] = {
+  ): SelectBuilder[
+    (SourceEntry[RL, CL, CL, AL, Void], SourceEntry[RR, CR, CR, AR, Void]),
+    EmptyTuple,
+    skunk.Void,
+    skunk.Void
+  ] = {
     val baseEntry = makeBaseEntry[L, RL, CL, AL, ML](aL, left)
     val rel       = aR(right)
     val rCols     = rel.columns.asInstanceOf[CR]
     val rEntry    =
       new SourceEntry[RR, CR, CR, AR, Void](rel, aR.aliasValue(right), rCols, rCols, JoinKind.Cross, None)
-    new SelectBuilder[(SourceEntry[RL, CL, CL, AL, Void], SourceEntry[RR, CR, CR, AR, Void]), EmptyTuple, skunk.Void, skunk.Void]((baseEntry, rEntry))
+    new SelectBuilder[
+      (SourceEntry[RL, CL, CL, AL, Void], SourceEntry[RR, CR, CR, AR, Void]),
+      EmptyTuple,
+      skunk.Void,
+      skunk.Void
+    ]((baseEntry, rEntry))
   }
 
   // ---- LATERAL joins ---------------------------------------------------------------------------
@@ -977,7 +1023,12 @@ extension [L, RL <: Relation[CL], CL <: Tuple, AL <: String & Singleton, ML <: A
   )(using
     aR: AsRelation.Aux[T, RR, CR, AR, MR],
     aliasCheck: AliasNotUsed[AR, AL *: EmptyTuple]
-  ): SelectBuilder[(SourceEntry[RL, CL, CL, AL, Void], SourceEntry[RR, CR, CR, AR, Void]), EmptyTuple, skunk.Void, skunk.Void] = {
+  ): SelectBuilder[
+    (SourceEntry[RL, CL, CL, AL, Void], SourceEntry[RR, CR, CR, AR, Void]),
+    EmptyTuple,
+    skunk.Void,
+    skunk.Void
+  ] = {
     val baseEntry = makeBaseEntry[L, RL, CL, AL, ML](aL, left)
     val outer     = ColumnsView.qualified(baseEntry.effectiveCols, baseEntry.alias)
     val t         = fn(outer)
@@ -993,7 +1044,12 @@ extension [L, RL <: Relation[CL], CL <: Tuple, AL <: String & Singleton, ML <: A
         None,
         isLateral = true
       )
-    new SelectBuilder[(SourceEntry[RL, CL, CL, AL, Void], SourceEntry[RR, CR, CR, AR, Void]), EmptyTuple, skunk.Void, skunk.Void]((baseEntry, rEntry))
+    new SelectBuilder[
+      (SourceEntry[RL, CL, CL, AL, Void], SourceEntry[RR, CR, CR, AR, Void]),
+      EmptyTuple,
+      skunk.Void,
+      skunk.Void
+    ]((baseEntry, rEntry))
   }
 
 }

--- a/modules/core/src/main/scala/skunk/sharp/dsl/ProjArgsOf.scala
+++ b/modules/core/src/main/scala/skunk/sharp/dsl/ProjArgsOf.scala
@@ -5,18 +5,15 @@ import skunk.sharp.TypedExpr
 import skunk.sharp.where.Where
 
 /**
- * Typeclass that computes the runtime `Out` type for a projection-shaped value `T` and provides a
- * runtime projector that turns an `Out` value into a list of per-item values (one per inner
- * `TypedExpr` slot in render order).
+ * Typeclass that computes the runtime `Out` type for a projection-shaped value `T` and provides a runtime projector
+ * that turns an `Out` value into a list of per-item values (one per inner `TypedExpr` slot in render order).
  *
- * Lets us compute the typed `Args` for SELECT projections, GROUP BY / ORDER BY / DISTINCT ON, and
- * other multi-item DSL positions WITHOUT relying on match types — given-resolution priority
- * disambiguates `NamedTuple` vs regular `Tuple` vs single `TypedExpr` cases, where match types
- * stumble on Scala 3.8's NamedTuple opaque-type disjointness rules.
+ * Lets us compute the typed `Args` for SELECT projections, GROUP BY / ORDER BY / DISTINCT ON, and other multi-item DSL
+ * positions WITHOUT relying on match types — given-resolution priority disambiguates `NamedTuple` vs regular `Tuple` vs
+ * single `TypedExpr` cases, where match types stumble on Scala 3.8's NamedTuple opaque-type disjointness rules.
  *
- * `T` is contravariant so a `ProjArgsOf[TypedExpr[T, A]]` instance also serves a `TypedColumn[T, N, S]`
- * (which extends `TypedExpr`). Without contravariance, given resolution would need an explicit
- * instance for every `TypedExpr` subtype.
+ * `T` is contravariant so a `ProjArgsOf[TypedExpr[T, A]]` instance also serves a `TypedColumn[T, N, S]` (which extends
+ * `TypedExpr`). Without contravariance, given resolution would need an explicit instance for every `TypedExpr` subtype.
  *
  * Given priority chain:
  *
@@ -24,9 +21,8 @@ import skunk.sharp.where.Where
  *   - Medium: multi-item tuple cons `H *: T` (folds via [[Where.Concat]]).
  *   - Low: any `TypedExpr[T, A]` — leaf case, `Out = A`.
  *
- * `Out` is the right-fold of `Where.Concat` over per-item `Args` — the same shape as
- * [[Where.FoldConcat]] for plain tuples — but computed via given resolution rather than match-type
- * reduction, so named tuples work too.
+ * `Out` is the right-fold of `Where.Concat` over per-item `Args` — the same shape as [[Where.FoldConcat]] for plain
+ * tuples — but computed via given resolution rather than match-type reduction, so named tuples work too.
  */
 trait ProjArgsOf[-T] {
   type Out
@@ -70,12 +66,12 @@ trait ProjArgsOfMedPrio extends ProjArgsOfLowPrio {
 
   /**
    * Multi-item tuple cons: right-fold via [[Where.Concat]] (drops Void slots). `inline given` so the
-   * `Where.projectConcat` dispatch reduces with concrete `HOut` / `TOut` at the summon site.
-   * Uses [[ConsTupleProj]] (named class) to avoid "anonymous class duplicated at each inline site".
+   * `Where.projectConcat` dispatch reduces with concrete `HOut` / `TOut` at the summon site. Uses [[ConsTupleProj]]
+   * (named class) to avoid "anonymous class duplicated at each inline site".
    */
   inline given consTuple[H, T <: NonEmptyTuple, HOut, TOut](using
-    h:  ProjArgsOf[H] { type Out = HOut },
-    t:  ProjArgsOf[T] { type Out = TOut }
+    h: ProjArgsOf[H] { type Out = HOut },
+    t: ProjArgsOf[T] { type Out = TOut }
   ): (ProjArgsOf[H *: T] { type Out = Where.Concat[HOut, TOut] }) = {
     val proj: Where.Concat[HOut, TOut] => (HOut, TOut) = c => Where.projectConcat[HOut, TOut](c)
     new ConsTupleProj[H, T, Where.Concat[HOut, TOut], HOut, TOut](h, t, proj)
@@ -84,22 +80,24 @@ trait ProjArgsOfMedPrio extends ProjArgsOfLowPrio {
 }
 
 private[dsl] final class ConsTupleProj[H, T <: NonEmptyTuple, CombOut, HOut, TOut](
-  h:    ProjArgsOf[H] { type Out = HOut },
-  t:    ProjArgsOf[T] { type Out = TOut },
+  h: ProjArgsOf[H] { type Out = HOut },
+  t: ProjArgsOf[T] { type Out = TOut },
   proj: CombOut => (HOut, TOut)
 ) extends ProjArgsOf[H *: T] {
   type Out = CombOut
+
   def project(c: Out): List[Any] = {
     val (a, b) = proj(c)
     h.project(a) ++ t.project(b)
   }
+
 }
 
 trait ProjArgsOfLowPrio {
 
   /**
-   * Leaf case: `TypedExpr[T, A]` (covers `TypedColumn` via contravariance). `Out = A` — the inner
-   * Args slot. The runtime projector emits `List(c)` — a single value to feed the underlying encoder.
+   * Leaf case: `TypedExpr[T, A]` (covers `TypedColumn` via contravariance). `Out = A` — the inner Args slot. The
+   * runtime projector emits `List(c)` — a single value to feed the underlying encoder.
    */
   given typedExpr[T, A]: (ProjArgsOf[TypedExpr[T, A]] { type Out = A }) =
     new ProjArgsOf[TypedExpr[T, A]] {
@@ -108,8 +106,8 @@ trait ProjArgsOfLowPrio {
     }
 
   /**
-   * Leaf case for `OrderBy[A]` (`expr.asc` / `.desc` / `.nullsFirst` / `.nullsLast` wrappers). Same
-   * shape as the [[typedExpr]] leaf: `Out = A`.
+   * Leaf case for `OrderBy[A]` (`expr.asc` / `.desc` / `.nullsFirst` / `.nullsLast` wrappers). Same shape as the
+   * [[typedExpr]] leaf: `Out = A`.
    */
   given orderByLeaf[A]: (ProjArgsOf[skunk.sharp.dsl.OrderBy[A]] { type Out = A }) =
     new ProjArgsOf[skunk.sharp.dsl.OrderBy[A]] {

--- a/modules/core/src/main/scala/skunk/sharp/dsl/Select.scala
+++ b/modules/core/src/main/scala/skunk/sharp/dsl/Select.scala
@@ -7,16 +7,16 @@ import skunk.sharp.where.Where
 import skunk.util.Origin
 
 /**
- * Unified SELECT builder — one class for single-source, JOINed, or CROSS-joined queries. Threads two
- * captured-args type parameters end-to-end:
+ * Unified SELECT builder — one class for single-source, JOINed, or CROSS-joined queries. Threads two captured-args type
+ * parameters end-to-end:
  *
  *   - `WArgs` is the cumulative WHERE args tuple. Starts at `skunk.Void` (no WHERE captured), grows via
  *     `Where.Concat[WArgs, A]` as each `.where(_ => Where[A])` lambda contributes more bound parameters.
  *   - `HArgs` is the cumulative HAVING args tuple. Same shape, threaded by `.having(...)` calls.
  *
  * `.compile` produces a `QueryTemplate[Where.Concat[WArgs, HArgs], Row]` — the visible `Args` is the full
- * captured-parameter tuple in SQL render order (WHERE args first, HAVING args second), with `Void`
- * placeholders normalised away by the [[Where.Concat]] match type.
+ * captured-parameter tuple in SQL render order (WHERE args first, HAVING args second), with `Void` placeholders
+ * normalised away by the [[Where.Concat]] match type.
  */
 final class SelectBuilder[Ss <: Tuple, Groups <: Tuple, WArgs, HArgs] @scala.annotation.publicInBinary private[sharp] (
   private[sharp] val sources: Ss,
@@ -60,13 +60,21 @@ final class SelectBuilder[Ss <: Tuple, Groups <: Tuple, WArgs, HArgs] @scala.ann
   /** AND in a typed predicate — `WArgs` extends via `Where.Concat`. */
   inline def where[A](f: SelectView[Ss] => Where[A]): SelectBuilder[Ss, Groups, Where.Concat[WArgs, A], HArgs] = {
     val pred     = f(view)
-    val combined = SelectBuilder.andInto[WArgs, A](whereOpt.asInstanceOf[Option[Fragment[WArgs]]], pred, c => Where.projectConcat[WArgs, A](c))
+    val combined = SelectBuilder.andInto[WArgs, A](
+      whereOpt.asInstanceOf[Option[Fragment[WArgs]]],
+      pred,
+      c => Where.projectConcat[WArgs, A](c)
+    )
     cp[Where.Concat[WArgs, A], HArgs](whereOpt = Some(combined))
   }
 
   /** Escape hatch — widens `WArgs` to `?`. */
   inline def whereRaw(af: AppliedFragment): SelectBuilder[Ss, Groups, ?, HArgs] = {
-    val combined = SelectBuilder.andRawInto[WArgs](whereOpt.asInstanceOf[Option[Fragment[WArgs]]], af, c => Where.projectConcat[WArgs, Void](c))
+    val combined = SelectBuilder.andRawInto[WArgs](
+      whereOpt.asInstanceOf[Option[Fragment[WArgs]]],
+      af,
+      c => Where.projectConcat[WArgs, Void](c)
+    )
     cp[Any, HArgs](whereOpt = Some(combined))
   }
 
@@ -74,15 +82,15 @@ final class SelectBuilder[Ss <: Tuple, Groups <: Tuple, WArgs, HArgs] @scala.ann
   def orderBy(f: SelectView[Ss] => OrderBy[?] | Tuple): SelectBuilder[Ss, Groups, WArgs, HArgs] = {
     val fresh = (f(view): Any) match {
       case ob: OrderBy[?] => List(ob)
-      case t: Tuple    => t.toList.asInstanceOf[List[OrderBy[?]]]
+      case t: Tuple       => t.toList.asInstanceOf[List[OrderBy[?]]]
     }
     cp[WArgs, HArgs](orderBys = orderBys ++ fresh)
   }
 
   /**
    * `GROUP BY …` on a pre-projection builder. `Groups` accumulates the projection shape via
-   * `Tuple.Concat[Groups, NormProj[G]]`, so a downstream `.select` carries the typed `GArgs` through
-   * to `ProjectedSelect.compile`.
+   * `Tuple.Concat[Groups, NormProj[G]]`, so a downstream `.select` carries the typed `GArgs` through to
+   * `ProjectedSelect.compile`.
    */
   transparent inline def groupBy[G](inline f: SelectView[Ss] => G)
     : SelectBuilder[Ss, Tuple.Concat[Groups, NormProj[G]], WArgs, HArgs] = {
@@ -108,13 +116,21 @@ final class SelectBuilder[Ss <: Tuple, Groups <: Tuple, WArgs, HArgs] @scala.ann
   /** `HAVING <typed-predicate>`. */
   inline def having[H](f: SelectView[Ss] => Where[H]): SelectBuilder[Ss, Groups, WArgs, Where.Concat[HArgs, H]] = {
     val pred     = f(view)
-    val combined = SelectBuilder.andInto[HArgs, H](havingOpt.asInstanceOf[Option[Fragment[HArgs]]], pred, c => Where.projectConcat[HArgs, H](c))
+    val combined = SelectBuilder.andInto[HArgs, H](
+      havingOpt.asInstanceOf[Option[Fragment[HArgs]]],
+      pred,
+      c => Where.projectConcat[HArgs, H](c)
+    )
     cp[WArgs, Where.Concat[HArgs, H]](havingOpt = Some(combined))
   }
 
   /** Escape hatch HAVING — widens `HArgs` to `?`. */
   inline def havingRaw(af: AppliedFragment): SelectBuilder[Ss, Groups, WArgs, ?] = {
-    val combined = SelectBuilder.andRawInto[HArgs](havingOpt.asInstanceOf[Option[Fragment[HArgs]]], af, c => Where.projectConcat[HArgs, Void](c))
+    val combined = SelectBuilder.andRawInto[HArgs](
+      havingOpt.asInstanceOf[Option[Fragment[HArgs]]],
+      af,
+      c => Where.projectConcat[HArgs, Void](c)
+    )
     cp[WArgs, Any](havingOpt = Some(combined))
   }
 
@@ -285,20 +301,19 @@ final class SelectBuilder[Ss <: Tuple, Groups <: Tuple, WArgs, HArgs] @scala.ann
   // ---- Projection -------------------------------------------------------------------------------
 
   /**
-   * SELECT projection. Dispatches at compile time on the user's projection shape via
-   * `compiletime.erasedValue`:
+   * SELECT projection. Dispatches at compile time on the user's projection shape via `compiletime.erasedValue`:
    *
    *   - **single `TypedExpr`** (`u => u.email` or `u => Pg.power(u.age, Param[Double])`): `Proj` becomes
    *     `X *: EmptyTuple`, `Row` is the expression's value type.
-   *   - **named tuple** (`u => (email = u.email, age = u.age)`): `Proj` is the underlying value tuple
-   *     (via [[scala.NamedTuple.DropNames]]), `Row` is the named tuple of the projected values.
+   *   - **named tuple** (`u => (email = u.email, age = u.age)`): `Proj` is the underlying value tuple (via
+   *     [[scala.NamedTuple.DropNames]]), `Row` is the named tuple of the projected values.
    *   - **plain tuple** (`u => (u.id, u.email)`): `Proj` is `X & Tuple`, `Row` is `ExprOutputs[X]`.
    *
-   * `erasedValue` lets us discriminate `NamedTuple` vs regular `Tuple` vs single `TypedExpr` cleanly —
-   * the equivalent match-type discriminator hits Scala 3.8's NamedTuple-vs-Tuple disjointness blocker.
+   * `erasedValue` lets us discriminate `NamedTuple` vs regular `Tuple` vs single `TypedExpr` cleanly — the equivalent
+   * match-type discriminator hits Scala 3.8's NamedTuple-vs-Tuple disjointness blocker.
    *
-   * `Proj` becomes a concrete type per branch, so `compile()`'s `ProjArgsOf[Proj]` summon resolves and
-   * Param-bearing projections thread their Args into the QueryTemplate's user-visible `Args`.
+   * `Proj` becomes a concrete type per branch, so `compile()`'s `ProjArgsOf[Proj]` summon resolves and Param-bearing
+   * projections thread their Args into the QueryTemplate's user-visible `Args`.
    */
   transparent inline def select[X](inline f: SelectView[Ss] => X) = {
     val v = view
@@ -380,66 +395,70 @@ final class SelectBuilder[Ss <: Tuple, Groups <: Tuple, WArgs, HArgs] @scala.ann
   ) = select[X](f)
 
   /**
-   * Whole-row `.compile` — only on single-source builders. Threads `CArgs` (CTE preamble), `SArgs` (from any
-   * inner subquery body), `WArgs` (WHERE), `GArgs` (GROUP BY via [[ProjArgsOf]]), and `HArgs` (HAVING) in
-   * render order: `[CArgs, SArgs, WArgs, GArgs, HArgs]`. The combined `Args` collapses Void slots and
-   * flattens via `Where.Concat`, so a query with one Param[T] returns `QueryTemplate[T, Row]`, two Params
-   * `QueryTemplate[(T1, T2), Row]`, and so on at the user site.
+   * Whole-row `.compile` — only on single-source builders. Threads `CArgs` (CTE preamble), `SArgs` (from any inner
+   * subquery body), `WArgs` (WHERE), `GArgs` (GROUP BY via [[ProjArgsOf]]), and `HArgs` (HAVING) in render order:
+   * `[CArgs, SArgs, WArgs, GArgs, HArgs]`. The combined `Args` collapses Void slots and flattens via `Where.Concat`, so
+   * a query with one Param[T] returns `QueryTemplate[T, Row]`, two Params `QueryTemplate[(T1, T2), Row]`, and so on at
+   * the user site.
    */
   // Concat-chain evidences are named after the accumulator they peel from at slot-extraction time. The
   // chain is built left-to-right (CArgs, SArgs, WArgs, GArgs, HArgs); `slotValues` unwraps it
   // outermost-first via repeated `Where.projectConcat`, recovering each slot's value to feed into
   // `IArray[Any]` for `assembleN`.
   inline def compile[SArgs, GArgs, CArgs](using
-    ev:      IsSingleSource[Ss],
-    sbOf:    SourceBodyArgsOf.Aux[Ss, SArgs],
-    cteSum:  CteArgsOf.Aux[Ss, CArgs],
+    ev: IsSingleSource[Ss],
+    sbOf: SourceBodyArgsOf.Aux[Ss, SArgs],
+    cteSum: CteArgsOf.Aux[Ss, CArgs],
     cteProj: CteArgsProj[Ss],
-    g:       ProjArgsOf.Aux[Groups, GArgs]
-  ): QueryTemplate[Where.Concat[Where.Concat[Where.Concat[Where.Concat[CArgs, SArgs], WArgs], GArgs], HArgs], NamedRowOf[ev.Cols]] = {
-    val entries = sources.toList.asInstanceOf[List[SourceEntry[?, ?, ?, ?, ?]]]
-    val head    = entries.head
-    val ctes    = collectCtesInOrder(entries)
-    val rawGroupProjector = g.project.asInstanceOf[Any => List[Any]]
+    g: ProjArgsOf.Aux[Groups, GArgs]
+  ): QueryTemplate[
+    Where.Concat[Where.Concat[Where.Concat[Where.Concat[CArgs, SArgs], WArgs], GArgs], HArgs],
+    NamedRowOf[ev.Cols]
+  ] = {
+    val entries                          = sources.toList.asInstanceOf[List[SourceEntry[?, ?, ?, ?, ?]]]
+    val head                             = entries.head
+    val ctes                             = collectCtesInOrder(entries)
+    val rawGroupProjector                = g.project.asInstanceOf[Any => List[Any]]
     val groupProjector: Any => List[Any] = a => {
       val xs = rawGroupProjector(a)
       if (xs.size == groupBys.size) xs else List.fill(groupBys.size)(Void)
     }
     type Out = Where.Concat[Where.Concat[Where.Concat[Where.Concat[CArgs, SArgs], WArgs], GArgs], HArgs]
     val slotValues: Out => IArray[Any] = args => {
-      val (cswgAcc, hArgs) = Where.projectConcat[Where.Concat[Where.Concat[Where.Concat[CArgs, SArgs], WArgs], GArgs], HArgs](args)
-      val (cswAcc, gArgs)  = Where.projectConcat[Where.Concat[Where.Concat[CArgs, SArgs], WArgs], GArgs](cswgAcc)
-      val (csAcc, wArgs)   = Where.projectConcat[Where.Concat[CArgs, SArgs], WArgs](cswAcc)
-      val (cArgs, sArgs)   = Where.projectConcat[CArgs, SArgs](csAcc)
+      val (cswgAcc, hArgs) =
+        Where.projectConcat[Where.Concat[Where.Concat[Where.Concat[CArgs, SArgs], WArgs], GArgs], HArgs](args)
+      val (cswAcc, gArgs) = Where.projectConcat[Where.Concat[Where.Concat[CArgs, SArgs], WArgs], GArgs](cswgAcc)
+      val (csAcc, wArgs)  = Where.projectConcat[Where.Concat[CArgs, SArgs], WArgs](cswAcc)
+      val (cArgs, sArgs)  = Where.projectConcat[CArgs, SArgs](csAcc)
       buildCteAndSlotIArrayWithEntries(entries, cteProj, cArgs, ctes, IArray[Any](sArgs, wArgs, gArgs, hArgs))
     }
     SelectBuilder.assembleN[Out, NamedRowOf[ev.Cols]](
-      bodyParts  = compileBodyParts(head, groupProjector),
-      ctes       = ctes,
-      codec      = rowCodec(head.effectiveCols).asInstanceOf[Codec[NamedRowOf[ev.Cols]]],
+      bodyParts = compileBodyParts(head, groupProjector),
+      ctes = ctes,
+      codec = rowCodec(head.effectiveCols).asInstanceOf[Codec[NamedRowOf[ev.Cols]]],
       slotValues = slotValues
     )
   }
 
   /**
-   * Produces a typed `Fragment[CombinedArgs]` for the SELECT body **without** any CTE preamble.
-   * Used by [[SelectBuilder.alias]] to capture the inner query fragment and surface its `Args` in
-   * the outer `BodyArgs` of the resulting subquery relation.
+   * Produces a typed `Fragment[CombinedArgs]` for the SELECT body **without** any CTE preamble. Used by
+   * [[SelectBuilder.alias]] to capture the inner query fragment and surface its `Args` in the outer `BodyArgs` of the
+   * resulting subquery relation.
    *
    * Slot order: `[SArgs=0, WArgs=1, GArgs=2, HArgs=3]`.
    */
   private[dsl] inline def compileBodyFragment[SArgs, GArgs](using
-    ev:   IsSingleSource[Ss],
+    ev: IsSingleSource[Ss],
     sbOf: SourceBodyArgsOf.Aux[Ss, SArgs],
-    g:    ProjArgsOf.Aux[Groups, GArgs]
+    g: ProjArgsOf.Aux[Groups, GArgs]
   ): Fragment[Where.Concat[Where.Concat[Where.Concat[SArgs, WArgs], GArgs], HArgs]] = {
     // No CTE preamble emitted here — `compileBodyFragment` is used by `.alias` (subquery body) and `cte()`
     // (CTE body) to capture the SELECT body alone. CTEs collected at this nesting level surface in the outer
     // query's preamble. Direct CteRelation refs in this body still bind at FROM-site as Void (their args
     // belong to the outer query's WITH preamble slot, not this body's args).
-    val entries = sources.toList.asInstanceOf[List[SourceEntry[?, ?, ?, ?, ?]]]
-    val head    = entries.head
-    val rawGroupProjector = g.project.asInstanceOf[Any => List[Any]]
+    val entries                          = sources.toList.asInstanceOf[List[SourceEntry[?, ?, ?, ?, ?]]]
+    val head                             = entries.head
+    val rawGroupProjector                = g.project.asInstanceOf[Any => List[Any]]
     val groupProjector: Any => List[Any] = a => {
       val xs = rawGroupProjector(a)
       if (xs.size == groupBys.size) xs else List.fill(groupBys.size)(Void)
@@ -452,9 +471,9 @@ final class SelectBuilder[Ss <: Tuple, Groups <: Tuple, WArgs, HArgs] @scala.ann
       IArray[Any](sArgs, wArgs, gArgs, hArgs)
     }
     SelectBuilder.assembleN[Out, NamedRowOf[ev.Cols]](
-      bodyParts  = compileBodyParts(head, groupProjector),
-      ctes       = Nil,
-      codec      = rowCodec(head.effectiveCols).asInstanceOf[Codec[NamedRowOf[ev.Cols]]],
+      bodyParts = compileBodyParts(head, groupProjector),
+      ctes = Nil,
+      codec = rowCodec(head.effectiveCols).asInstanceOf[Codec[NamedRowOf[ev.Cols]]],
       slotValues = slotValues
     ).fragment
   }
@@ -551,13 +570,15 @@ object SelectBuilder {
   // ---- AND-into helpers (typed and raw) --------------------------------------------------------
 
   /**
-   * `proj` re-pairs the `Where.Concat[Slot, A]` runtime value back into `(Slot, A)` for the combined product
-   * encoder's contramap — call site materialises it as `c => Where.projectConcat[Slot, A](c)` where `Slot`/`A`
-   * are concrete (so the inline dispatch reduces). Passing as a parameter keeps `andInto` itself non-inline
-   * — otherwise every chained `.where(...)` would need to be inline too.
+   * `proj` re-pairs the `Where.Concat[Slot, A]` runtime value back into `(Slot, A)` for the combined product encoder's
+   * contramap — call site materialises it as `c => Where.projectConcat[Slot, A](c)` where `Slot`/`A` are concrete (so
+   * the inline dispatch reduces). Passing as a parameter keeps `andInto` itself non-inline — otherwise every chained
+   * `.where(...)` would need to be inline too.
    */
   private[dsl] def andInto[Slot, A](
-    slot: Option[Fragment[Slot]], pred: Where[A], proj: Where.Concat[Slot, A] => (Slot, A)
+    slot: Option[Fragment[Slot]],
+    pred: Where[A],
+    proj: Where.Concat[Slot, A] => (Slot, A)
   ): Fragment[Where.Concat[Slot, A]] =
     slot match {
       case None    => pred.fragment.asInstanceOf[Fragment[Where.Concat[Slot, A]]]
@@ -573,9 +594,9 @@ object SelectBuilder {
     }
 
   /**
-   * Prepend a static SQL prefix to a typed fragment, preserving its `Args` type. Used to attach `" ON "` (or
-   * similar static keywords) to a typed predicate fragment so the combined unit can still be threaded through
-   * `assembleN`'s typed-slot machinery rather than baked at Void.
+   * Prepend a static SQL prefix to a typed fragment, preserving its `Args` type. Used to attach `" ON "` (or similar
+   * static keywords) to a typed predicate fragment so the combined unit can still be threaded through `assembleN`'s
+   * typed-slot machinery rather than baked at Void.
    */
   private[dsl] def prefixedFrag[A](prefix: AppliedFragment, body: Fragment[A]): Fragment[A] = {
     val parts = prefix.fragment.parts ++ body.parts
@@ -584,7 +605,9 @@ object SelectBuilder {
 
   /** AND a pre-applied raw `AppliedFragment` into a slot — bakes its args via contramap (treats raw as Void-args). */
   private[dsl] def andRawInto[Slot](
-    slot: Option[Fragment[Slot]], af: AppliedFragment, proj: Where.Concat[Slot, Void] => (Slot, Void)
+    slot: Option[Fragment[Slot]],
+    af: AppliedFragment,
+    proj: Where.Concat[Slot, Void] => (Slot, Void)
   ): Fragment[Where.Concat[Slot, Void]] = {
     val rawFrag: Fragment[Void] = TypedExpr.liftAfToVoid(af)
     slot match {
@@ -606,39 +629,41 @@ object SelectBuilder {
     val voidLeft  = a eq Void.codec
     val voidRight = b eq Void.codec
     if (voidLeft && voidRight) Void.codec.asInstanceOf[Encoder[Any]]
-    else if (voidLeft)         b.asInstanceOf[Encoder[Any]]
-    else if (voidRight)        a.asInstanceOf[Encoder[Any]]
-    else                       a.asInstanceOf[Encoder[Any]].product(b.asInstanceOf[Encoder[Any]]).asInstanceOf[Encoder[Any]]
+    else if (voidLeft) b.asInstanceOf[Encoder[Any]]
+    else if (voidRight) a.asInstanceOf[Encoder[Any]]
+    else a.asInstanceOf[Encoder[Any]].product(b.asInstanceOf[Encoder[Any]]).asInstanceOf[Encoder[Any]]
   }
 
   /**
-   * Body-part. `Left(f)` is a `Fragment[Void]` whose encoder is already-baked (its argument flows via
-   * contramap, typically a structural piece like " WHERE ", a header, or a row of values applied via
-   * `Param.bind`). `Right(f)` is a typed `Fragment[A]` slot whose encoder takes a typed `A` at execute
-   * time (typically a WHERE/HAVING predicate built from `Param[T]`).
+   * Body-part. `Left(f)` is a `Fragment[Void]` whose encoder is already-baked (its argument flows via contramap,
+   * typically a structural piece like " WHERE ", a header, or a row of values applied via `Param.bind`). `Right(f)` is
+   * a typed `Fragment[A]` slot whose encoder takes a typed `A` at execute time (typically a WHERE/HAVING predicate
+   * built from `Param[T]`).
    *
-   * Splitting baked from typed at this level lets [[assembleN]] produce a final encoder that contramaps
-   * the user-claimed `Args` correctly: the baked side is encoded with `Void` (its values flow via the
-   * fragment's own contramap); the typed side receives the user's `Args` via `slotValues`.
+   * Splitting baked from typed at this level lets [[assembleN]] produce a final encoder that contramaps the
+   * user-claimed `Args` correctly: the baked side is encoded with `Void` (its values flow via the fragment's own
+   * contramap); the typed side receives the user's `Args` via `slotValues`.
    */
   private[dsl] type BodyPart = Either[Fragment[Void], Fragment[?]]
 
-  /** Convert a pre-applied `AppliedFragment` into a `BodyPart` (Left). For static AFs whose encoder is
-   * already `Void.codec`, [[TypedExpr.liftAfToVoid]] returns the underlying `Fragment[Void]` directly
-   * with no allocation; for dynamic AFs it constructs a contramapped `Fragment[Void]` once. */
+  /**
+   * Convert a pre-applied `AppliedFragment` into a `BodyPart` (Left). For static AFs whose encoder is already
+   * `Void.codec`, [[TypedExpr.liftAfToVoid]] returns the underlying `Fragment[Void]` directly with no allocation; for
+   * dynamic AFs it constructs a contramapped `Fragment[Void]` once.
+   */
   private[dsl] inline def bake(af: AppliedFragment): BodyPart =
     Left(TypedExpr.liftAfToVoid(af))
 
   /** Build the body-parts list for a SELECT or projected SELECT in render order. */
   private[dsl] def bodyPartsAround(
     headerParts: List[AppliedFragment],
-    whereOpt:    Option[Fragment[?]],
-    groupBys:    List[TypedExpr[?, ?]],
-    havingOpt:   Option[Fragment[?]],
-    orderBys:    List[OrderBy[?]],
-    limitOpt:    Option[Int],
-    offsetOpt:   Option[Int],
-    lockingOpt:  Option[Locking]
+    whereOpt: Option[Fragment[?]],
+    groupBys: List[TypedExpr[?, ?]],
+    havingOpt: Option[Fragment[?]],
+    orderBys: List[OrderBy[?]],
+    limitOpt: Option[Int],
+    offsetOpt: Option[Int],
+    lockingOpt: Option[Locking]
   ): List[BodyPart] = {
     val buf = scala.collection.mutable.ListBuffer[BodyPart]()
     headerParts.foreach(af => buf += SelectBuilder.bake(af))
@@ -665,33 +690,33 @@ object SelectBuilder {
   }
 
   /**
-   * Bind a `Fragment[?]` at `Void` to obtain an `AppliedFragment`. For groupBys / orderBys / DISTINCT ON
-   * exprs that may carry typed Args (Param-bearing) — currently constrained to Void-args inputs (typed-args
-   * threading through these positions is roadmap).
+   * Bind a `Fragment[?]` at `Void` to obtain an `AppliedFragment`. For groupBys / orderBys / DISTINCT ON exprs that may
+   * carry typed Args (Param-bearing) — currently constrained to Void-args inputs (typed-args threading through these
+   * positions is roadmap).
    */
   private[dsl] def bindVoid(f: Fragment[?]): AppliedFragment =
     f.asInstanceOf[Fragment[Void]].apply(Void)
 
   /**
-   * Empty `Fragment[Void]` placeholder. Used as a Right slot filler when a typed position (WHERE /
-   * GROUP BY / HAVING) is absent — keeps the assemble walker's slot index stable so subsequent
-   * positions land on the correct A_i. Renders no SQL and emits no encoded value.
+   * Empty `Fragment[Void]` placeholder. Used as a Right slot filler when a typed position (WHERE / GROUP BY / HAVING)
+   * is absent — keeps the assemble walker's slot index stable so subsequent positions land on the correct A_i. Renders
+   * no SQL and emits no encoded value.
    */
   private[dsl] val emptyVoidSlot: Fragment[Void] = TypedExpr.voidFragment("")
 
   /**
-   * Generic N-slot assembler. Each `Right(f)` in `bodyParts` is a typed slot; the i-th Right slot
-   * gets its runtime value from `slotValues(args)(i)`. Callers build `slotValues` by unfolding the
-   * nested `Where.Concat` chain via `Where.projectConcat` for their specific slot count.
+   * Generic N-slot assembler. Each `Right(f)` in `bodyParts` is a typed slot; the i-th Right slot gets its runtime
+   * value from `slotValues(args)(i)`. Callers build `slotValues` by unfolding the nested `Where.Concat` chain via
+   * `Where.projectConcat` for their specific slot count.
    */
   private[dsl] def assembleN[Args, R](
-    bodyParts:  List[BodyPart],
-    ctes:       List[CteRelation[?, ?, ?, ?]],
-    codec:      Codec[R],
+    bodyParts: List[BodyPart],
+    ctes: List[CteRelation[?, ?, ?, ?]],
+    codec: Codec[R],
     slotValues: Args => IArray[Any]
   ): QueryTemplate[Args, R] = {
-    val ctePreambleParts: List[BodyPart] = renderWithPreambleParts(ctes)
-    val allParts: List[BodyPart]         = ctePreambleParts ++ bodyParts
+    val ctePreambleParts: List[BodyPart]                             = renderWithPreambleParts(ctes)
+    val allParts: List[BodyPart]                                     = ctePreambleParts ++ bodyParts
     val sqlParts: List[Either[String, cats.data.State[Int, String]]] =
       allParts.flatMap {
         case Left(f)  => f.parts
@@ -728,7 +753,7 @@ object SelectBuilder {
           }
         }
       override def encode(args: Args): List[Option[skunk.data.Encoded]] = {
-        val slots = slotValues(args)
+        val slots    = slotValues(args)
         var typedIdx = 0
         allParts.flatMap {
           case Left(f) =>
@@ -750,7 +775,16 @@ object SelectBuilder {
 /**
  * A SELECT with an explicit projection list — rows have shape `Row` instead of the relation's default named tuple.
  */
-final class ProjectedSelect[Ss <: Tuple, Proj <: Tuple, Groups <: Tuple, DistinctOn <: Tuple, Orders <: Tuple, WArgs, HArgs, Row](
+final class ProjectedSelect[
+  Ss <: Tuple,
+  Proj <: Tuple,
+  Groups <: Tuple,
+  DistinctOn <: Tuple,
+  Orders <: Tuple,
+  WArgs,
+  HArgs,
+  Row
+](
   private[sharp] val sources: Ss,
   private[sharp] val distinct: Boolean,
   private[sharp] val projections: List[TypedExpr[?, ?]],
@@ -795,22 +829,30 @@ final class ProjectedSelect[Ss <: Tuple, Proj <: Tuple, Groups <: Tuple, Distinc
 
   private def view: SelectView[Ss] = buildSelectView[Ss](sources)
 
-  inline def where[A](f: SelectView[Ss] => Where[A]): ProjectedSelect[Ss, Proj, Groups, DistinctOn, Orders, Where.Concat[WArgs, A], HArgs, Row] = {
+  inline def where[A](f: SelectView[Ss] => Where[A])
+    : ProjectedSelect[Ss, Proj, Groups, DistinctOn, Orders, Where.Concat[WArgs, A], HArgs, Row] = {
     val pred     = f(view)
-    val combined = SelectBuilder.andInto[WArgs, A](whereOpt.asInstanceOf[Option[Fragment[WArgs]]], pred, c => Where.projectConcat[WArgs, A](c))
+    val combined = SelectBuilder.andInto[WArgs, A](
+      whereOpt.asInstanceOf[Option[Fragment[WArgs]]],
+      pred,
+      c => Where.projectConcat[WArgs, A](c)
+    )
     cp[Where.Concat[WArgs, A], HArgs](whereOpt = Some(combined))
   }
 
   inline def whereRaw(af: AppliedFragment): ProjectedSelect[Ss, Proj, Groups, DistinctOn, Orders, ?, HArgs, Row] = {
-    val combined = SelectBuilder.andRawInto[WArgs](whereOpt.asInstanceOf[Option[Fragment[WArgs]]], af, c => Where.projectConcat[WArgs, Void](c))
+    val combined = SelectBuilder.andRawInto[WArgs](
+      whereOpt.asInstanceOf[Option[Fragment[WArgs]]],
+      af,
+      c => Where.projectConcat[WArgs, Void](c)
+    )
     cp[Any, HArgs](whereOpt = Some(combined))
   }
 
   /**
-   * `ORDER BY …` — items are typed `OrderBy[A]` wrappers around `expr.asc / .desc / .nullsFirst /
-   * .nullsLast`. `Orders` accumulates the wrapper types via `Tuple.Concat[Orders, NormProj[O]]` so
-   * Param-bearing items thread their `A` into the QueryTemplate Args slot at `.compile` time
-   * (similar to GROUP BY).
+   * `ORDER BY …` — items are typed `OrderBy[A]` wrappers around `expr.asc / .desc / .nullsFirst / .nullsLast`. `Orders`
+   * accumulates the wrapper types via `Tuple.Concat[Orders, NormProj[O]]` so Param-bearing items thread their `A` into
+   * the QueryTemplate Args slot at `.compile` time (similar to GROUP BY).
    */
   transparent inline def orderBy[O](inline f: SelectView[Ss] => O)
     : ProjectedSelect[Ss, Proj, Groups, DistinctOn, Tuple.Concat[Orders, NormProj[O]], WArgs, HArgs, Row] = {
@@ -858,26 +900,38 @@ final class ProjectedSelect[Ss <: Tuple, Proj <: Tuple, Groups <: Tuple, Distinc
     )
   }
 
-  inline def having[H](f: SelectView[Ss] => Where[H]): ProjectedSelect[Ss, Proj, Groups, DistinctOn, Orders, WArgs, Where.Concat[HArgs, H], Row] = {
+  inline def having[H](f: SelectView[Ss] => Where[H])
+    : ProjectedSelect[Ss, Proj, Groups, DistinctOn, Orders, WArgs, Where.Concat[HArgs, H], Row] = {
     val pred     = f(view)
-    val combined = SelectBuilder.andInto[HArgs, H](havingOpt.asInstanceOf[Option[Fragment[HArgs]]], pred, c => Where.projectConcat[HArgs, H](c))
+    val combined = SelectBuilder.andInto[HArgs, H](
+      havingOpt.asInstanceOf[Option[Fragment[HArgs]]],
+      pred,
+      c => Where.projectConcat[HArgs, H](c)
+    )
     cp[WArgs, Where.Concat[HArgs, H]](havingOpt = Some(combined))
   }
 
   inline def havingRaw(af: AppliedFragment): ProjectedSelect[Ss, Proj, Groups, DistinctOn, Orders, WArgs, ?, Row] = {
-    val combined = SelectBuilder.andRawInto[HArgs](havingOpt.asInstanceOf[Option[Fragment[HArgs]]], af, c => Where.projectConcat[HArgs, Void](c))
+    val combined = SelectBuilder.andRawInto[HArgs](
+      havingOpt.asInstanceOf[Option[Fragment[HArgs]]],
+      af,
+      c => Where.projectConcat[HArgs, Void](c)
+    )
     cp[WArgs, Any](havingOpt = Some(combined))
   }
 
-  def limit(n: Int): ProjectedSelect[Ss, Proj, Groups, DistinctOn, Orders, WArgs, HArgs, Row]  = cp[WArgs, HArgs](limitOpt = Some(n))
-  def offset(n: Int): ProjectedSelect[Ss, Proj, Groups, DistinctOn, Orders, WArgs, HArgs, Row] = cp[WArgs, HArgs](offsetOpt = Some(n))
+  def limit(n: Int): ProjectedSelect[Ss, Proj, Groups, DistinctOn, Orders, WArgs, HArgs, Row] =
+    cp[WArgs, HArgs](limitOpt = Some(n))
 
-  def distinctRows: ProjectedSelect[Ss, Proj, Groups, DistinctOn, Orders, WArgs, HArgs, Row] = cp[WArgs, HArgs](distinct = true)
+  def offset(n: Int): ProjectedSelect[Ss, Proj, Groups, DistinctOn, Orders, WArgs, HArgs, Row] =
+    cp[WArgs, HArgs](offsetOpt = Some(n))
+
+  def distinctRows: ProjectedSelect[Ss, Proj, Groups, DistinctOn, Orders, WArgs, HArgs, Row] =
+    cp[WArgs, HArgs](distinct = true)
 
   /**
-   * `DISTINCT ON (e1, e2, …)` projection. Items can be Param-bearing — at `.compile` time the
-   * static `DistinctOn` type is folded by [[ProjArgsOf]] into a `DArgs` slot threaded ahead of the
-   * projection list in render order.
+   * `DISTINCT ON (e1, e2, …)` projection. Items can be Param-bearing — at `.compile` time the static `DistinctOn` type
+   * is folded by [[ProjArgsOf]] into a `DArgs` slot threaded ahead of the projection list in render order.
    */
   transparent inline def distinctOn[D](inline f: SelectView[Ss] => D)
     : ProjectedSelect[Ss, Proj, Groups, NormProj[D], Orders, WArgs, HArgs, Row] = {
@@ -905,16 +959,22 @@ final class ProjectedSelect[Ss <: Tuple, Proj <: Tuple, Groups <: Tuple, Distinc
   def forUpdate(using ev: IsSingleTable[Ss]): ProjectedSelect[Ss, Proj, Groups, DistinctOn, Orders, WArgs, HArgs, Row] =
     cp[WArgs, HArgs](lockingOpt = Some(Locking(LockMode.ForUpdate)))
 
-  def forNoKeyUpdate(using ev: IsSingleTable[Ss]): ProjectedSelect[Ss, Proj, Groups, DistinctOn, Orders, WArgs, HArgs, Row] =
+  def forNoKeyUpdate(using
+    ev: IsSingleTable[Ss]
+  ): ProjectedSelect[Ss, Proj, Groups, DistinctOn, Orders, WArgs, HArgs, Row] =
     cp[WArgs, HArgs](lockingOpt = Some(Locking(LockMode.ForNoKeyUpdate)))
 
   def forShare(using ev: IsSingleTable[Ss]): ProjectedSelect[Ss, Proj, Groups, DistinctOn, Orders, WArgs, HArgs, Row] =
     cp[WArgs, HArgs](lockingOpt = Some(Locking(LockMode.ForShare)))
 
-  def forKeyShare(using ev: IsSingleTable[Ss]): ProjectedSelect[Ss, Proj, Groups, DistinctOn, Orders, WArgs, HArgs, Row] =
+  def forKeyShare(using
+    ev: IsSingleTable[Ss]
+  ): ProjectedSelect[Ss, Proj, Groups, DistinctOn, Orders, WArgs, HArgs, Row] =
     cp[WArgs, HArgs](lockingOpt = Some(Locking(LockMode.ForKeyShare)))
 
-  def skipLocked(using ev: IsSingleTable[Ss]): ProjectedSelect[Ss, Proj, Groups, DistinctOn, Orders, WArgs, HArgs, Row] =
+  def skipLocked(using
+    ev: IsSingleTable[Ss]
+  ): ProjectedSelect[Ss, Proj, Groups, DistinctOn, Orders, WArgs, HArgs, Row] =
     cp[WArgs, HArgs](lockingOpt = lockingOpt.map(_.copy(waitPolicy = WaitPolicy.SkipLocked)))
 
   def noWait(using ev: IsSingleTable[Ss]): ProjectedSelect[Ss, Proj, Groups, DistinctOn, Orders, WArgs, HArgs, Row] =
@@ -943,20 +1003,20 @@ final class ProjectedSelect[Ss <: Tuple, Proj <: Tuple, Groups <: Tuple, Distinc
   }
 
   /**
-   * Compile into a [[QueryTemplate]]. Enforces [[GroupCoverage]] and threads typed `Args` from
-   * Param-bearing items in **seven** logical positions in render order:
+   * Compile into a [[QueryTemplate]]. Enforces [[GroupCoverage]] and threads typed `Args` from Param-bearing items in
+   * **seven** logical positions in render order:
    *
-   *   - `DArgs`    — `DISTINCT ON` items (via [[ProjArgsOf]] over `DistinctOn`).
+   *   - `DArgs` — `DISTINCT ON` items (via [[ProjArgsOf]] over `DistinctOn`).
    *   - `ProjArgs` — projection items (via [[ProjArgsOf]] over `Proj`).
-   *   - `SArgs`    — source body args (inner query Args when source is a typed subquery via `.alias`).
-   *   - `WArgs`    — WHERE clause.
-   *   - `GArgs`    — GROUP BY items (via [[ProjArgsOf]] over `Groups`).
-   *   - `HArgs`    — HAVING clause.
-   *   - `OArgs`    — ORDER BY items (via [[ProjArgsOf]] over `Orders`).
+   *   - `SArgs` — source body args (inner query Args when source is a typed subquery via `.alias`).
+   *   - `WArgs` — WHERE clause.
+   *   - `GArgs` — GROUP BY items (via [[ProjArgsOf]] over `Groups`).
+   *   - `HArgs` — HAVING clause.
+   *   - `OArgs` — ORDER BY items (via [[ProjArgsOf]] over `Orders`).
    *
-   * `Where.Concat` is smart-flat, so the user-facing `Args` is the non-Void slots flattened into a single
-   * tuple — e.g. a query carrying only a WHERE Param[UUID] returns `QueryTemplate[UUID, Row]`; one with
-   * Param[Int] in DISTINCT ON and Param[String] in WHERE returns `QueryTemplate[(Int, String), Row]`.
+   * `Where.Concat` is smart-flat, so the user-facing `Args` is the non-Void slots flattened into a single tuple — e.g.
+   * a query carrying only a WHERE Param[UUID] returns `QueryTemplate[UUID, Row]`; one with Param[Int] in DISTINCT ON
+   * and Param[String] in WHERE returns `QueryTemplate[(Int, String), Row]`.
    */
   // Concat-chain evidences. Each name spells the accumulator at that step (left-to-right over the slot order):
   // CArgs ⊕ DArgs ⊕ ProjArgs ⊕ SArgs ⊕ OnA ⊕ WArgs ⊕ GArgs ⊕ HArgs ⊕ OArgs.
@@ -969,54 +1029,90 @@ final class ProjectedSelect[Ss <: Tuple, Proj <: Tuple, Groups <: Tuple, Distinc
   //   cdpsowgh = CDPSOWG ⊕ HArgs                                    → CDPSOWGH
   //   cdpsowgho = CDPSOWGH ⊕ OArgs                                  → outer Args
   inline def compile[SArgs, OnA, CArgs, DArgs, ProjArgs, GArgs, OArgs](using
-    ev:      GroupCoverage[Proj, Groups],
-    sbOf:    SourceBodyArgsOf.Aux[Ss, SArgs],
-    bff:     SourceBodyArgsProj[Ss],
-    onSum:   SourceOnArgsOf.Aux[Ss, OnA],
-    onProj:  SourceOnArgsProj[Ss],
-    cteSum:  CteArgsOf.Aux[Ss, CArgs],
+    ev: GroupCoverage[Proj, Groups],
+    sbOf: SourceBodyArgsOf.Aux[Ss, SArgs],
+    bff: SourceBodyArgsProj[Ss],
+    onSum: SourceOnArgsOf.Aux[Ss, OnA],
+    onProj: SourceOnArgsProj[Ss],
+    cteSum: CteArgsOf.Aux[Ss, CArgs],
     cteProj: CteArgsProj[Ss],
-    d:       ProjArgsOf.Aux[DistinctOn, DArgs],
-    pa:      ProjArgsOf.Aux[Proj, ProjArgs],
-    g:       ProjArgsOf.Aux[Groups, GArgs],
-    o:       ProjArgsOf.Aux[Orders, OArgs]
-  ): QueryTemplate[Where.Concat[Where.Concat[Where.Concat[Where.Concat[Where.Concat[Where.Concat[Where.Concat[Where.Concat[CArgs, DArgs], ProjArgs], SArgs], OnA], WArgs], GArgs], HArgs], OArgs], Row] = {
-    val entries = sources.toList.asInstanceOf[List[SourceEntry[?, ?, ?, ?, ?]]]
-    val ctes    = collectCtesInOrder(entries)
-    val rawDistProjector  = d.project.asInstanceOf[Any => List[Any]]
-    val rawProjProjector  = pa.project.asInstanceOf[Any => List[Any]]
-    val rawGroupProjector = g.project.asInstanceOf[Any => List[Any]]
-    val rawOrderProjector = o.project.asInstanceOf[Any => List[Any]]
-    val distinctSize      = distinctOnOpt.fold(0)(_.size)
-    val distProjector: Any => List[Any] = a => { val xs = rawDistProjector(a);  if (xs.size == distinctSize)     xs else List.fill(distinctSize)(Void) }
-    val projProjector: Any => List[Any] = a => { val xs = rawProjProjector(a);  if (xs.size == projections.size) xs else List.fill(projections.size)(Void) }
-    val groupProjector: Any => List[Any] = a => { val xs = rawGroupProjector(a); if (xs.size == groupBys.size)    xs else List.fill(groupBys.size)(Void) }
-    val orderProjector: Any => List[Any] = a => { val xs = rawOrderProjector(a); if (xs.size == orderBys.size)    xs else List.fill(orderBys.size)(Void) }
-    type Out = Where.Concat[Where.Concat[Where.Concat[Where.Concat[Where.Concat[Where.Concat[Where.Concat[Where.Concat[CArgs, DArgs], ProjArgs], SArgs], OnA], WArgs], GArgs], HArgs], OArgs]
-    val srcSlotCount = sourceSlotCount(entries)
+    d: ProjArgsOf.Aux[DistinctOn, DArgs],
+    pa: ProjArgsOf.Aux[Proj, ProjArgs],
+    g: ProjArgsOf.Aux[Groups, GArgs],
+    o: ProjArgsOf.Aux[Orders, OArgs]
+  ): QueryTemplate[
+    Where.Concat[
+      Where.Concat[Where.Concat[
+        Where.Concat[Where.Concat[Where.Concat[Where.Concat[Where.Concat[CArgs, DArgs], ProjArgs], SArgs], OnA], WArgs],
+        GArgs
+      ], HArgs],
+      OArgs
+    ],
+    Row
+  ] = {
+    val entries                         = sources.toList.asInstanceOf[List[SourceEntry[?, ?, ?, ?, ?]]]
+    val ctes                            = collectCtesInOrder(entries)
+    val rawDistProjector                = d.project.asInstanceOf[Any => List[Any]]
+    val rawProjProjector                = pa.project.asInstanceOf[Any => List[Any]]
+    val rawGroupProjector               = g.project.asInstanceOf[Any => List[Any]]
+    val rawOrderProjector               = o.project.asInstanceOf[Any => List[Any]]
+    val distinctSize                    = distinctOnOpt.fold(0)(_.size)
+    val distProjector: Any => List[Any] =
+      a => { val xs = rawDistProjector(a); if (xs.size == distinctSize) xs else List.fill(distinctSize)(Void) }
+    val projProjector: Any => List[Any] =
+      a => { val xs = rawProjProjector(a); if (xs.size == projections.size) xs else List.fill(projections.size)(Void) }
+    val groupProjector: Any => List[Any] =
+      a => { val xs = rawGroupProjector(a); if (xs.size == groupBys.size) xs else List.fill(groupBys.size)(Void) }
+    val orderProjector: Any => List[Any] =
+      a => { val xs = rawOrderProjector(a); if (xs.size == orderBys.size) xs else List.fill(orderBys.size)(Void) }
+    type Out = Where.Concat[
+      Where.Concat[Where.Concat[
+        Where.Concat[Where.Concat[Where.Concat[Where.Concat[Where.Concat[CArgs, DArgs], ProjArgs], SArgs], OnA], WArgs],
+        GArgs
+      ], HArgs],
+      OArgs
+    ]
+    val srcSlotCount                   = sourceSlotCount(entries)
     val slotValues: Out => IArray[Any] = args => {
-      val (cdpsowghAcc, oArgs) = Where.projectConcat[Where.Concat[Where.Concat[Where.Concat[Where.Concat[Where.Concat[Where.Concat[Where.Concat[CArgs, DArgs], ProjArgs], SArgs], OnA], WArgs], GArgs], HArgs], OArgs](args)
-      val (cdpsowgAcc, hArgs)  = Where.projectConcat[Where.Concat[Where.Concat[Where.Concat[Where.Concat[Where.Concat[Where.Concat[CArgs, DArgs], ProjArgs], SArgs], OnA], WArgs], GArgs], HArgs](cdpsowghAcc)
-      val (cdpsowAcc, gArgs)   = Where.projectConcat[Where.Concat[Where.Concat[Where.Concat[Where.Concat[Where.Concat[CArgs, DArgs], ProjArgs], SArgs], OnA], WArgs], GArgs](cdpsowgAcc)
-      val (cdpsoAcc, wArgs)    = Where.projectConcat[Where.Concat[Where.Concat[Where.Concat[Where.Concat[CArgs, DArgs], ProjArgs], SArgs], OnA], WArgs](cdpsowAcc)
-      val (cdpsAcc, onArgs)    = Where.projectConcat[Where.Concat[Where.Concat[Where.Concat[CArgs, DArgs], ProjArgs], SArgs], OnA](cdpsoAcc)
-      val (cdpAcc, sArgs)      = Where.projectConcat[Where.Concat[Where.Concat[CArgs, DArgs], ProjArgs], SArgs](cdpsAcc)
-      val (cdAcc, pArgs)       = Where.projectConcat[Where.Concat[CArgs, DArgs], ProjArgs](cdpAcc)
-      val (cArgs, dArgs)       = Where.projectConcat[CArgs, DArgs](cdAcc)
-      val baseSlots = buildSlotIArray(dArgs, pArgs, sArgs, onArgs, srcSlotCount, bff, onProj, wArgs, gArgs, hArgs, oArgs)
+      val (cdpsowghAcc, oArgs) = Where.projectConcat[
+        Where.Concat[Where.Concat[Where.Concat[
+          Where.Concat[Where.Concat[Where.Concat[Where.Concat[CArgs, DArgs], ProjArgs], SArgs], OnA],
+          WArgs
+        ], GArgs], HArgs],
+        OArgs
+      ](args)
+      val (cdpsowgAcc, hArgs) = Where.projectConcat[Where.Concat[
+        Where.Concat[Where.Concat[Where.Concat[Where.Concat[Where.Concat[CArgs, DArgs], ProjArgs], SArgs], OnA], WArgs],
+        GArgs
+      ], HArgs](cdpsowghAcc)
+      val (cdpsowAcc, gArgs) = Where.projectConcat[Where.Concat[
+        Where.Concat[Where.Concat[Where.Concat[Where.Concat[CArgs, DArgs], ProjArgs], SArgs], OnA],
+        WArgs
+      ], GArgs](cdpsowgAcc)
+      val (cdpsoAcc, wArgs) = Where.projectConcat[Where.Concat[
+        Where.Concat[Where.Concat[Where.Concat[CArgs, DArgs], ProjArgs], SArgs],
+        OnA
+      ], WArgs](cdpsowAcc)
+      val (cdpsAcc, onArgs) =
+        Where.projectConcat[Where.Concat[Where.Concat[Where.Concat[CArgs, DArgs], ProjArgs], SArgs], OnA](cdpsoAcc)
+      val (cdpAcc, sArgs) = Where.projectConcat[Where.Concat[Where.Concat[CArgs, DArgs], ProjArgs], SArgs](cdpsAcc)
+      val (cdAcc, pArgs)  = Where.projectConcat[Where.Concat[CArgs, DArgs], ProjArgs](cdpAcc)
+      val (cArgs, dArgs)  = Where.projectConcat[CArgs, DArgs](cdAcc)
+      val baseSlots       =
+        buildSlotIArray(dArgs, pArgs, sArgs, onArgs, srcSlotCount, bff, onProj, wArgs, gArgs, hArgs, oArgs)
       buildCteAndSlotIArrayWithEntries(entries, cteProj, cArgs, ctes, baseSlots)
     }
     SelectBuilder.assembleN[Out, Row](
-      bodyParts  = compileBodyParts(distProjector, projProjector, groupProjector, orderProjector),
-      ctes       = ctes,
-      codec      = codec,
+      bodyParts = compileBodyParts(distProjector, projProjector, groupProjector, orderProjector),
+      ctes = ctes,
+      codec = codec,
       slotValues = slotValues
     )
   }
 
   /**
-   * Produces a typed `Fragment[CombinedArgs]` for the SELECT body **without** any CTE preamble.
-   * Used by [[ProjectedSelect.alias]] to capture the inner query fragment.
+   * Produces a typed `Fragment[CombinedArgs]` for the SELECT body **without** any CTE preamble. Used by
+   * [[ProjectedSelect.alias]] to capture the inner query fragment.
    *
    * Slot order: `[DIST=0, PROJ=1, SRC=2, WHERE=3, GROUP=4, HAVING=5, ORDER=6]`.
    */
@@ -1024,56 +1120,75 @@ final class ProjectedSelect[Ss <: Tuple, Proj <: Tuple, Groups <: Tuple, Distinc
   // DArgs ⊕ ProjArgs ⊕ SArgs ⊕ OnA ⊕ WArgs ⊕ GArgs ⊕ HArgs ⊕ OArgs. (No CArgs here — `compileBodyFragment`
   // captures the body alone; CTE refs in this body bind at the OUTER query's WITH preamble.)
   private[dsl] inline def compileBodyFragment[SA, OnA, DA2, PA, GA, OA2](using
-    ev:      GroupCoverage[Proj, Groups],
-    sbOf:    SourceBodyArgsOf.Aux[Ss, SA],
-    bff:     SourceBodyArgsProj[Ss],
-    onSum:   SourceOnArgsOf.Aux[Ss, OnA],
-    onProj:  SourceOnArgsProj[Ss],
-    d:       ProjArgsOf.Aux[DistinctOn, DA2],
-    pa:      ProjArgsOf.Aux[Proj, PA],
-    g:       ProjArgsOf.Aux[Groups, GA],
-    o:       ProjArgsOf.Aux[Orders, OA2]
-  ): Fragment[Where.Concat[Where.Concat[Where.Concat[Where.Concat[Where.Concat[Where.Concat[Where.Concat[DA2, PA], SA], OnA], WArgs], GA], HArgs], OA2]] = {
-    val entries = sources.toList.asInstanceOf[List[SourceEntry[?, ?, ?, ?, ?]]]
-    val rawDistProjector:  Any => List[Any] = d.project.asInstanceOf[Any => List[Any]]
-    val rawProjProjector:  Any => List[Any] = pa.project.asInstanceOf[Any => List[Any]]
+    ev: GroupCoverage[Proj, Groups],
+    sbOf: SourceBodyArgsOf.Aux[Ss, SA],
+    bff: SourceBodyArgsProj[Ss],
+    onSum: SourceOnArgsOf.Aux[Ss, OnA],
+    onProj: SourceOnArgsProj[Ss],
+    d: ProjArgsOf.Aux[DistinctOn, DA2],
+    pa: ProjArgsOf.Aux[Proj, PA],
+    g: ProjArgsOf.Aux[Groups, GA],
+    o: ProjArgsOf.Aux[Orders, OA2]
+  ): Fragment[Where.Concat[Where.Concat[
+    Where.Concat[Where.Concat[Where.Concat[Where.Concat[Where.Concat[DA2, PA], SA], OnA], WArgs], GA],
+    HArgs
+  ], OA2]] = {
+    val entries                             = sources.toList.asInstanceOf[List[SourceEntry[?, ?, ?, ?, ?]]]
+    val rawDistProjector: Any => List[Any]  = d.project.asInstanceOf[Any => List[Any]]
+    val rawProjProjector: Any => List[Any]  = pa.project.asInstanceOf[Any => List[Any]]
     val rawGroupProjector: Any => List[Any] = g.project.asInstanceOf[Any => List[Any]]
     val rawOrderProjector: Any => List[Any] = o.project.asInstanceOf[Any => List[Any]]
-    val distinctSize = distinctOnOpt.fold(0)(_.size)
-    val distProjector:  Any => List[Any] = a => { val xs = rawDistProjector(a);  if (xs.size == distinctSize)     xs else List.fill(distinctSize)(Void) }
-    val projProjector:  Any => List[Any] = a => { val xs = rawProjProjector(a);  if (xs.size == projections.size) xs else List.fill(projections.size)(Void) }
-    val groupProjector: Any => List[Any] = a => { val xs = rawGroupProjector(a); if (xs.size == groupBys.size)    xs else List.fill(groupBys.size)(Void) }
-    val orderProjector: Any => List[Any] = a => { val xs = rawOrderProjector(a); if (xs.size == orderBys.size)    xs else List.fill(orderBys.size)(Void) }
-    type Out = Where.Concat[Where.Concat[Where.Concat[Where.Concat[Where.Concat[Where.Concat[Where.Concat[DA2, PA], SA], OnA], WArgs], GA], HArgs], OA2]
-    val srcSlotCount = sourceSlotCount(entries)
+    val distinctSize                        = distinctOnOpt.fold(0)(_.size)
+    val distProjector: Any => List[Any]     =
+      a => { val xs = rawDistProjector(a); if (xs.size == distinctSize) xs else List.fill(distinctSize)(Void) }
+    val projProjector: Any => List[Any] =
+      a => { val xs = rawProjProjector(a); if (xs.size == projections.size) xs else List.fill(projections.size)(Void) }
+    val groupProjector: Any => List[Any] =
+      a => { val xs = rawGroupProjector(a); if (xs.size == groupBys.size) xs else List.fill(groupBys.size)(Void) }
+    val orderProjector: Any => List[Any] =
+      a => { val xs = rawOrderProjector(a); if (xs.size == orderBys.size) xs else List.fill(orderBys.size)(Void) }
+    type Out = Where.Concat[Where.Concat[
+      Where.Concat[Where.Concat[Where.Concat[Where.Concat[Where.Concat[DA2, PA], SA], OnA], WArgs], GA],
+      HArgs
+    ], OA2]
+    val srcSlotCount                   = sourceSlotCount(entries)
     val slotValues: Out => IArray[Any] = args => {
-      val (dpsowghAcc, oArgs) = Where.projectConcat[Where.Concat[Where.Concat[Where.Concat[Where.Concat[Where.Concat[Where.Concat[DA2, PA], SA], OnA], WArgs], GA], HArgs], OA2](args)
-      val (dpsowgAcc, hArgs)  = Where.projectConcat[Where.Concat[Where.Concat[Where.Concat[Where.Concat[Where.Concat[DA2, PA], SA], OnA], WArgs], GA], HArgs](dpsowghAcc)
-      val (dpsowAcc, gArgs)   = Where.projectConcat[Where.Concat[Where.Concat[Where.Concat[Where.Concat[DA2, PA], SA], OnA], WArgs], GA](dpsowgAcc)
-      val (dpsoAcc, wArgs)    = Where.projectConcat[Where.Concat[Where.Concat[Where.Concat[DA2, PA], SA], OnA], WArgs](dpsowAcc)
-      val (dpsAcc, onArgs)    = Where.projectConcat[Where.Concat[Where.Concat[DA2, PA], SA], OnA](dpsoAcc)
-      val (dpAcc, sArgs)      = Where.projectConcat[Where.Concat[DA2, PA], SA](dpsAcc)
-      val (dArgs, pArgs)      = Where.projectConcat[DA2, PA](dpAcc)
+      val (dpsowghAcc, oArgs) = Where.projectConcat[Where.Concat[
+        Where.Concat[Where.Concat[Where.Concat[Where.Concat[Where.Concat[DA2, PA], SA], OnA], WArgs], GA],
+        HArgs
+      ], OA2](args)
+      val (dpsowgAcc, hArgs) = Where.projectConcat[Where.Concat[
+        Where.Concat[Where.Concat[Where.Concat[Where.Concat[DA2, PA], SA], OnA], WArgs],
+        GA
+      ], HArgs](dpsowghAcc)
+      val (dpsowAcc, gArgs) = Where.projectConcat[Where.Concat[
+        Where.Concat[Where.Concat[Where.Concat[DA2, PA], SA], OnA],
+        WArgs
+      ], GA](dpsowgAcc)
+      val (dpsoAcc, wArgs) =
+        Where.projectConcat[Where.Concat[Where.Concat[Where.Concat[DA2, PA], SA], OnA], WArgs](dpsowAcc)
+      val (dpsAcc, onArgs) = Where.projectConcat[Where.Concat[Where.Concat[DA2, PA], SA], OnA](dpsoAcc)
+      val (dpAcc, sArgs)   = Where.projectConcat[Where.Concat[DA2, PA], SA](dpsAcc)
+      val (dArgs, pArgs)   = Where.projectConcat[DA2, PA](dpAcc)
       buildSlotIArray(dArgs, pArgs, sArgs, onArgs, srcSlotCount, bff, onProj, wArgs, gArgs, hArgs, oArgs)
     }
     SelectBuilder.assembleN[Out, Row](
-      bodyParts  = compileBodyParts(distProjector, projProjector, groupProjector, orderProjector),
-      ctes       = Nil,
-      codec      = codec,
+      bodyParts = compileBodyParts(distProjector, projProjector, groupProjector, orderProjector),
+      ctes = Nil,
+      codec = codec,
       slotValues = slotValues
     ).fragment
   }
 
   /**
-   * Build body parts with stable slot indices:
-   * `[DIST=0, PROJ=1, SRC=2, WHERE=3, GROUP=4, HAVING=5, ORDER=6]`.
+   * Build body parts with stable slot indices: `[DIST=0, PROJ=1, SRC=2, WHERE=3, GROUP=4, HAVING=5, ORDER=6]`.
    *
-   * Slot 2 (SRC) is the source-body slot: typed subquery → `Right(innerFrag)`; plain source →
-   * `Right(emptyVoidSlot)`.  All slots are always emitted (absent clauses use `emptyVoidSlot`).
+   * Slot 2 (SRC) is the source-body slot: typed subquery → `Right(innerFrag)`; plain source → `Right(emptyVoidSlot)`.
+   * All slots are always emitted (absent clauses use `emptyVoidSlot`).
    */
   private def compileBodyParts(
-    distProjector:  Any => List[Any],
-    projProjector:  Any => List[Any],
+    distProjector: Any => List[Any],
+    projProjector: Any => List[Any],
     groupProjector: Any => List[Any],
     orderProjector: Any => List[Any]
   ): List[SelectBuilder.BodyPart] = {
@@ -1108,7 +1223,7 @@ final class ProjectedSelect[Ss <: Tuple, Proj <: Tuple, Groups <: Tuple, Distinc
         s.onPredOpt match {
           case Some(p) =>
             buf += Right(SelectBuilder.prefixedFrag(RawConstants.ON, p.fragment.asInstanceOf[Fragment[Any]]))
-          case None    =>
+          case None =>
             buf += Right(SelectBuilder.emptyVoidSlot)
         }
       }
@@ -1157,25 +1272,25 @@ final class ProjectedSelect[Ss <: Tuple, Proj <: Tuple, Groups <: Tuple, Distinc
 }
 
 /**
- * Number of (body, on) source-slot PAIRS emitted by [[ProjectedSelect.compileBodyParts]] for a given source
- * list. Each source contributes two slots — a body slot and an ON slot. Head and CROSS sources contribute
- * `emptyVoidSlot` for their ON. The FROM-less branch emits one body + one ON placeholder pair regardless.
+ * Number of (body, on) source-slot PAIRS emitted by [[ProjectedSelect.compileBodyParts]] for a given source list. Each
+ * source contributes two slots — a body slot and an ON slot. Head and CROSS sources contribute `emptyVoidSlot` for
+ * their ON. The FROM-less branch emits one body + one ON placeholder pair regardless.
  */
 private[dsl] def sourceSlotCount(entries: List[SourceEntry[?, ?, ?, ?, ?]]): Int =
   if (entries.nonEmpty && entries.head.relation.hasFromClause) entries.size else 1
 
 /**
- * Map of CTE name → body-args value, built from a `CteArgsProj` projection over the source-tuple combined
- * `cArgs` value. Plain (non-CteRelation) source positions yield Void and are filtered out.
+ * Map of CTE name → body-args value, built from a `CteArgsProj` projection over the source-tuple combined `cArgs`
+ * value. Plain (non-CteRelation) source positions yield Void and are filtered out.
  *
- * Walks `entries` in source order to extract CTE names from `IsCte` relations, zipping with the projected
- * per-source args list. The result is consumed by [[buildCtePreambleSlots]] which emits one Void or typed
- * value per collected CTE in dep order.
+ * Walks `entries` in source order to extract CTE names from `IsCte` relations, zipping with the projected per-source
+ * args list. The result is consumed by [[buildCtePreambleSlots]] which emits one Void or typed value per collected CTE
+ * in dep order.
  */
 private[dsl] def cteDirectArgsByName(
-  entries:  List[SourceEntry[?, ?, ?, ?, ?]],
-  cteProj:  CteArgsProj[? <: Tuple],
-  cArgs:    Any
+  entries: List[SourceEntry[?, ?, ?, ?, ?]],
+  cteProj: CteArgsProj[? <: Tuple],
+  cArgs: Any
 ): Map[String, Any] = {
   val perSource = cteProj.project(cArgs)
   if (perSource.isEmpty) Map.empty
@@ -1186,28 +1301,27 @@ private[dsl] def cteDirectArgsByName(
 }
 
 /**
- * Per-CTE body-args slot values in collected (dep) order. CTEs that appear as direct refs in `entries` look
- * up their args in the projected `cArgs`; transitive deps (constrained `Void` by [[CteDepsAllVoid]]) get
- * `Void`.
+ * Per-CTE body-args slot values in collected (dep) order. CTEs that appear as direct refs in `entries` look up their
+ * args in the projected `cArgs`; transitive deps (constrained `Void` by [[CteDepsAllVoid]]) get `Void`.
  */
 private[dsl] def buildCtePreambleSlots(
-  ctes:           List[CteRelation[?, ?, ?, ?]],
+  ctes: List[CteRelation[?, ?, ?, ?]],
   directArgsByName: Map[String, Any]
 ): IArray[Any] =
   IArray.from(ctes.map(c => directArgsByName.getOrElse(c.cteName, Void)))
 
 /**
- * Prepend per-CTE preamble slot values to a base IArray of body slot values. Walks `entries` in source
- * order to map projected `cArgs` values to CTE names, then assembles preamble slot values in dep order
- * (matching `renderWithPreambleParts`'s emission order). Transitive-dep CTEs (constrained Void by
- * [[CteDepsAllVoid]]) get Void slots.
+ * Prepend per-CTE preamble slot values to a base IArray of body slot values. Walks `entries` in source order to map
+ * projected `cArgs` values to CTE names, then assembles preamble slot values in dep order (matching
+ * `renderWithPreambleParts`'s emission order). Transitive-dep CTEs (constrained Void by [[CteDepsAllVoid]]) get Void
+ * slots.
  */
 private[dsl] def buildCteAndSlotIArrayWithEntries(
-  entries:    List[SourceEntry[?, ?, ?, ?, ?]],
-  cteProj:    CteArgsProj[? <: Tuple],
-  cArgs:      Any,
-  collected:  List[CteRelation[?, ?, ?, ?]],
-  baseSlots:  IArray[Any]
+  entries: List[SourceEntry[?, ?, ?, ?, ?]],
+  cteProj: CteArgsProj[? <: Tuple],
+  cArgs: Any,
+  collected: List[CteRelation[?, ?, ?, ?]],
+  baseSlots: IArray[Any]
 ): IArray[Any] =
   if (collected.isEmpty) baseSlots
   else {
@@ -1220,27 +1334,27 @@ private[dsl] def buildCteAndSlotIArrayWithEntries(
   }
 
 /**
- * Assemble the `IArray[Any]` slot values for a [[ProjectedSelect.compile]] / `compileBodyFragment` body.
- * Layout matches the body parts emitted by `compileBodyParts`:
- * `[DIST, PROJ, body_1, on_1, body_2, on_2, …, body_N, on_N, WHERE, GROUP, HAVING, ORDER]` — body and ON
- * slots are interleaved, in source order, two per source.
+ * Assemble the `IArray[Any]` slot values for a [[ProjectedSelect.compile]] / `compileBodyFragment` body. Layout matches
+ * the body parts emitted by `compileBodyParts`:
+ * `[DIST, PROJ, body_1, on_1, body_2, on_2, …, body_N, on_N, WHERE, GROUP, HAVING, ORDER]` — body and ON slots are
+ * interleaved, in source order, two per source.
  *
- * Per-source body args come from `SourceBodyArgsProj`; per-source ON args come from `SourceOnArgsProj`.
- * Both produce N-element lists in source order; we zip them positionally. When the head is FROM-less
- * (single placeholder pair) we replace the projected lists with `Void` placeholders.
+ * Per-source body args come from `SourceBodyArgsProj`; per-source ON args come from `SourceOnArgsProj`. Both produce
+ * N-element lists in source order; we zip them positionally. When the head is FROM-less (single placeholder pair) we
+ * replace the projected lists with `Void` placeholders.
  */
 private[dsl] def buildSlotIArray(
-  dArgs:        Any,
-  pArgs:        Any,
-  sArgs:        Any,
-  onArgs:       Any,
+  dArgs: Any,
+  pArgs: Any,
+  sArgs: Any,
+  onArgs: Any,
   srcSlotCount: Int,
-  bff:          SourceBodyArgsProj[? <: Tuple],
-  onProj:       SourceOnArgsProj[? <: Tuple],
-  wArgs:        Any,
-  gArgs:        Any,
-  hArgs:        Any,
-  oArgs:        Any
+  bff: SourceBodyArgsProj[? <: Tuple],
+  onProj: SourceOnArgsProj[? <: Tuple],
+  wArgs: Any,
+  gArgs: Any,
+  hArgs: Any,
+  oArgs: Any
 ): IArray[Any] = {
   val perBody: List[Any] = {
     val projected = bff.project(sArgs)
@@ -1295,7 +1409,8 @@ extension [L, RL <: Relation[CL], CL <: Tuple, AL <: String & Singleton, ML <: A
 /** `empty.select(…)` — FROM-less SELECT. */
 extension (rel: skunk.sharp.empty.type) {
 
-  def select[T, A](e: TypedExpr[T, A]): ProjectedSelect[EmptyTuple, TypedExpr[T, A] *: EmptyTuple, EmptyTuple, EmptyTuple, EmptyTuple, Void, Void, T] =
+  def select[T, A](e: TypedExpr[T, A])
+    : ProjectedSelect[EmptyTuple, TypedExpr[T, A] *: EmptyTuple, EmptyTuple, EmptyTuple, EmptyTuple, Void, Void, T] =
     new ProjectedSelect[EmptyTuple, TypedExpr[T, A] *: EmptyTuple, EmptyTuple, EmptyTuple, EmptyTuple, Void, Void, T](
       EmptyTuple,
       false,
@@ -1310,7 +1425,8 @@ extension (rel: skunk.sharp.empty.type) {
       None
     )
 
-  def select[X <: NonEmptyTuple](t: X): ProjectedSelect[EmptyTuple, X, EmptyTuple, EmptyTuple, EmptyTuple, Void, Void, ExprOutputs[X]] = {
+  def select[X <: NonEmptyTuple](t: X)
+    : ProjectedSelect[EmptyTuple, X, EmptyTuple, EmptyTuple, EmptyTuple, Void, Void, ExprOutputs[X]] = {
     val exprs = t.toList.asInstanceOf[List[TypedExpr[?, ?]]]
     val codec = tupleCodec(exprs.map(_.codec)).asInstanceOf[Codec[ExprOutputs[X]]]
     new ProjectedSelect[EmptyTuple, X, EmptyTuple, EmptyTuple, EmptyTuple, Void, Void, ExprOutputs[X]](
@@ -1384,7 +1500,8 @@ extension (rel: skunk.sharp.empty.type) {
         val tup   = f(v).asInstanceOf[NonEmptyTuple]
         val exprs = tup.toList.asInstanceOf[List[TypedExpr[?, ?]]]
         val codec = tupleCodec(exprs.map(_.codec)).asInstanceOf[Codec[ExprOutputs[X & Tuple]]]
-        new ProjectedSelect[EmptyTuple, X & Tuple, EmptyTuple, EmptyTuple, EmptyTuple, Void, Void, ExprOutputs[X & Tuple]](
+        new ProjectedSelect[EmptyTuple, X & Tuple, EmptyTuple, EmptyTuple, EmptyTuple, Void, Void, ExprOutputs[X &
+          Tuple]](
           EmptyTuple,
           false,
           exprs,
@@ -1406,7 +1523,7 @@ extension (rel: skunk.sharp.empty.type) {
 
 type SelectView[Ss <: Tuple] = Ss match {
   case SourceEntry[?, ?, c, ?, ?] *: EmptyTuple => ColumnsView[c]
-  case _                                     => JoinedView[Ss]
+  case _                                        => JoinedView[Ss]
 }
 
 private[sharp] def buildSelectView[Ss <: Tuple](sources: Ss): SelectView[Ss] =
@@ -1472,9 +1589,9 @@ type ExprOutputs[T <: Tuple] <: Tuple = T match {
 }
 
 /**
- * Dual of [[ExprOutputs]] — extracts the per-item `Args` slot from a tuple of `TypedExpr`s. A column
- * reference contributes `Void`; a `Param[T]` contributes `T`. Combined with [[Where.FoldConcat]] this
- * gives the result Args for variadic / multi-item DSL positions.
+ * Dual of [[ExprOutputs]] — extracts the per-item `Args` slot from a tuple of `TypedExpr`s. A column reference
+ * contributes `Void`; a `Param[T]` contributes `T`. Combined with [[Where.FoldConcat]] this gives the result Args for
+ * variadic / multi-item DSL positions.
  */
 type CollectArgs[T <: Tuple] <: Tuple = T match {
   case EmptyTuple              => EmptyTuple
@@ -1497,23 +1614,27 @@ type LookupTypes[Cols <: Tuple, Names <: Tuple] <: Tuple = Names match {
 }
 
 /**
- * ORDER BY entry — typed `Fragment[A]` parametrised over the underlying TypedExpr's `Args` so
- * Param-bearing exprs (`Param[Int].desc`) thread `A` into the assembled query.
+ * ORDER BY entry — typed `Fragment[A]` parametrised over the underlying TypedExpr's `Args` so Param-bearing exprs
+ * (`Param[Int].desc`) thread `A` into the assembled query.
  */
 final case class OrderBy[A](fragment: Fragment[A]) {
   def nullsFirst: OrderBy[A] = OrderBy(appendKw(fragment, " NULLS FIRST"))
   def nullsLast: OrderBy[A]  = OrderBy(appendKw(fragment, " NULLS LAST"))
+
   private def appendKw(f: Fragment[A], s: String): Fragment[A] = {
     val parts = f.parts ++ List[Either[String, cats.data.State[Int, String]]](Left(s))
     Fragment(parts, f.encoder, Origin.unknown)
   }
+
 }
 
 extension [T, A](expr: TypedExpr[T, A]) {
   def asc: OrderBy[A]  = OrderBy(appendKw(expr.fragment, " ASC"))
   def desc: OrderBy[A] = OrderBy(appendKw(expr.fragment, " DESC"))
+
   private def appendKw(f: Fragment[A], s: String): Fragment[A] = {
     val parts = f.parts ++ List[Either[String, cats.data.State[Int, String]]](Left(s))
     Fragment(parts, f.encoder, Origin.unknown)
   }
+
 }

--- a/modules/core/src/main/scala/skunk/sharp/dsl/SetOpQuery.scala
+++ b/modules/core/src/main/scala/skunk/sharp/dsl/SetOpQuery.scala
@@ -7,9 +7,9 @@ import skunk.sharp.where.Where
 /**
  * Row-compatible combination of two or more queries via `UNION` / `INTERSECT` / `EXCEPT` (and their `ALL` variants).
  *
- * Each combinator step concatenates a typed `Fragment[A]` for the right arm via `combineSep`, so any `Param` in
- * either arm threads through to the outer query's `Args` via `Concat`. Held **lazily**: each chained step appends
- * to a render thunk that is only invoked at the single terminal `.compile` call.
+ * Each combinator step concatenates a typed `Fragment[A]` for the right arm via `combineSep`, so any `Param` in either
+ * arm threads through to the outer query's `Args` via `Concat`. Held **lazily**: each chained step appends to a render
+ * thunk that is only invoked at the single terminal `.compile` call.
  *
  * Constructed through the [[union]] / [[intersect]] / [[except]] extensions on a [[SelectBuilder]],
  * [[ProjectedSelect]], [[CompiledQuery]], or another [[SetOpQuery]]. All sides flow through [[AsSubquery]], so users
@@ -33,25 +33,33 @@ final class SetOpQuery[A, R] @scala.annotation.publicInBinary private[sharp] (
   def compile: QueryTemplate[A, R] = QueryTemplate.mk[A, R](renderFn(), codec)
 
   /** `(<this>) UNION (<right>)` — deduplicated union. */
-  inline def union[Q, B](right: Q)(using ev: AsSubquery[Q, R, B]): SetOpQuery[Where.Concat[A, B], R] = append("UNION", right)
+  inline def union[Q, B](right: Q)(using ev: AsSubquery[Q, R, B]): SetOpQuery[Where.Concat[A, B], R] =
+    append("UNION", right)
 
   /** `(<this>) UNION ALL (<right>)` — keeps duplicates. */
-  inline def unionAll[Q, B](right: Q)(using ev: AsSubquery[Q, R, B]): SetOpQuery[Where.Concat[A, B], R] = append("UNION ALL", right)
+  inline def unionAll[Q, B](right: Q)(using ev: AsSubquery[Q, R, B]): SetOpQuery[Where.Concat[A, B], R] =
+    append("UNION ALL", right)
 
   /** `(<this>) INTERSECT (<right>)` — deduplicated intersection. */
-  inline def intersect[Q, B](right: Q)(using ev: AsSubquery[Q, R, B]): SetOpQuery[Where.Concat[A, B], R] = append("INTERSECT", right)
+  inline def intersect[Q, B](right: Q)(using ev: AsSubquery[Q, R, B]): SetOpQuery[Where.Concat[A, B], R] =
+    append("INTERSECT", right)
 
   /** `(<this>) INTERSECT ALL (<right>)` — multiset intersection. */
-  inline def intersectAll[Q, B](right: Q)(using ev: AsSubquery[Q, R, B]): SetOpQuery[Where.Concat[A, B], R] = append("INTERSECT ALL", right)
+  inline def intersectAll[Q, B](right: Q)(using ev: AsSubquery[Q, R, B]): SetOpQuery[Where.Concat[A, B], R] =
+    append("INTERSECT ALL", right)
 
   /** `(<this>) EXCEPT (<right>)` — deduplicated difference. */
-  inline def except[Q, B](right: Q)(using ev: AsSubquery[Q, R, B]): SetOpQuery[Where.Concat[A, B], R] = append("EXCEPT", right)
+  inline def except[Q, B](right: Q)(using ev: AsSubquery[Q, R, B]): SetOpQuery[Where.Concat[A, B], R] =
+    append("EXCEPT", right)
 
   /** `(<this>) EXCEPT ALL (<right>)` — multiset difference. */
-  inline def exceptAll[Q, B](right: Q)(using ev: AsSubquery[Q, R, B]): SetOpQuery[Where.Concat[A, B], R] = append("EXCEPT ALL", right)
+  inline def exceptAll[Q, B](right: Q)(using ev: AsSubquery[Q, R, B]): SetOpQuery[Where.Concat[A, B], R] =
+    append("EXCEPT ALL", right)
 
-  private inline def append[Q, B](op: String, right: Q)(using ev: AsSubquery[Q, R, B]): SetOpQuery[Where.Concat[A, B], R] = {
-    val leftFn     = renderFn
+  private inline def append[Q, B](op: String, right: Q)(using
+    ev: AsSubquery[Q, R, B]
+  ): SetOpQuery[Where.Concat[A, B], R] = {
+    val leftFn                 = renderFn
     val rightFrag: Fragment[B] = ev.fragment(right)
     new SetOpQuery[Where.Concat[A, B], R](
       codec,
@@ -68,8 +76,8 @@ object SetOpQuery {
 
   /**
    * Seed a chain: `(<arm>)`. Only called by the start-of-chain extensions on [[SelectBuilder]], [[ProjectedSelect]],
-   * and [[QueryTemplate]]. The left thunk is wrapped in parens up front so later appends can just glue
-   * ` OP (<right>)` on the tail.
+   * and [[QueryTemplate]]. The left thunk is wrapped in parens up front so later appends can just glue ` OP (<right>)`
+   * on the tail.
    */
   private[sharp] def start[T, Q, A](q: Q)(using ev: AsSubquery[Q, T, A]): SetOpQuery[A, T] = {
     val innerFrag: Fragment[A] = ev.fragment(q)
@@ -93,27 +101,45 @@ object SetOpQuery {
 extension [Q](left: Q) {
 
   /** `(<left>) UNION (<right>)` — deduplicated. */
-  inline def union[T, Q2, A1, A2](right: Q2)(using evL: AsSubquery[Q, T, A1], evR: AsSubquery[Q2, T, A2]): SetOpQuery[Where.Concat[A1, A2], T] =
+  inline def union[T, Q2, A1, A2](right: Q2)(using
+    evL: AsSubquery[Q, T, A1],
+    evR: AsSubquery[Q2, T, A2]
+  ): SetOpQuery[Where.Concat[A1, A2], T] =
     SetOpQuery.start[T, Q, A1](left).union(right)
 
   /** `(<left>) UNION ALL (<right>)` — keeps duplicates. */
-  inline def unionAll[T, Q2, A1, A2](right: Q2)(using evL: AsSubquery[Q, T, A1], evR: AsSubquery[Q2, T, A2]): SetOpQuery[Where.Concat[A1, A2], T] =
+  inline def unionAll[T, Q2, A1, A2](right: Q2)(using
+    evL: AsSubquery[Q, T, A1],
+    evR: AsSubquery[Q2, T, A2]
+  ): SetOpQuery[Where.Concat[A1, A2], T] =
     SetOpQuery.start[T, Q, A1](left).unionAll(right)
 
   /** `(<left>) INTERSECT (<right>)` — deduplicated intersection. */
-  inline def intersect[T, Q2, A1, A2](right: Q2)(using evL: AsSubquery[Q, T, A1], evR: AsSubquery[Q2, T, A2]): SetOpQuery[Where.Concat[A1, A2], T] =
+  inline def intersect[T, Q2, A1, A2](right: Q2)(using
+    evL: AsSubquery[Q, T, A1],
+    evR: AsSubquery[Q2, T, A2]
+  ): SetOpQuery[Where.Concat[A1, A2], T] =
     SetOpQuery.start[T, Q, A1](left).intersect(right)
 
   /** `(<left>) INTERSECT ALL (<right>)` — multiset intersection. */
-  inline def intersectAll[T, Q2, A1, A2](right: Q2)(using evL: AsSubquery[Q, T, A1], evR: AsSubquery[Q2, T, A2]): SetOpQuery[Where.Concat[A1, A2], T] =
+  inline def intersectAll[T, Q2, A1, A2](right: Q2)(using
+    evL: AsSubquery[Q, T, A1],
+    evR: AsSubquery[Q2, T, A2]
+  ): SetOpQuery[Where.Concat[A1, A2], T] =
     SetOpQuery.start[T, Q, A1](left).intersectAll(right)
 
   /** `(<left>) EXCEPT (<right>)` — deduplicated difference. */
-  inline def except[T, Q2, A1, A2](right: Q2)(using evL: AsSubquery[Q, T, A1], evR: AsSubquery[Q2, T, A2]): SetOpQuery[Where.Concat[A1, A2], T] =
+  inline def except[T, Q2, A1, A2](right: Q2)(using
+    evL: AsSubquery[Q, T, A1],
+    evR: AsSubquery[Q2, T, A2]
+  ): SetOpQuery[Where.Concat[A1, A2], T] =
     SetOpQuery.start[T, Q, A1](left).except(right)
 
   /** `(<left>) EXCEPT ALL (<right>)` — multiset difference. */
-  inline def exceptAll[T, Q2, A1, A2](right: Q2)(using evL: AsSubquery[Q, T, A1], evR: AsSubquery[Q2, T, A2]): SetOpQuery[Where.Concat[A1, A2], T] =
+  inline def exceptAll[T, Q2, A1, A2](right: Q2)(using
+    evL: AsSubquery[Q, T, A1],
+    evR: AsSubquery[Q2, T, A2]
+  ): SetOpQuery[Where.Concat[A1, A2], T] =
     SetOpQuery.start[T, Q, A1](left).exceptAll(right)
 
 }

--- a/modules/core/src/main/scala/skunk/sharp/dsl/Update.scala
+++ b/modules/core/src/main/scala/skunk/sharp/dsl/Update.scala
@@ -17,7 +17,7 @@ import scala.compiletime.constValueTuple
  * Threads two captured-args type parameters end-to-end:
  *
  *   - `SetArgs` — args from the SET RHS expressions.
- *   - `WArgs`   — args from the WHERE clause.
+ *   - `WArgs` — args from the WHERE clause.
  *
  * `.compile` produces `CommandTemplate[Where.Concat[SetArgs, WArgs]]`.
  */
@@ -26,9 +26,9 @@ final class UpdateBuilder[Cols <: Tuple, Name <: String & Singleton] private[sha
 ) {
 
   /**
-   * `SET <col := value>` — single-assignment form. `SetArgs` propagates from the assignment's `Args`,
-   * so `c.email := Param[String]` produces `UpdateWithSet[..., String]` and the value is supplied at
-   * execute time. `c.email := "literal"` produces `UpdateWithSet[..., Void]` (value-baked).
+   * `SET <col := value>` — single-assignment form. `SetArgs` propagates from the assignment's `Args`, so
+   * `c.email := Param[String]` produces `UpdateWithSet[..., String]` and the value is supplied at execute time.
+   * `c.email := "literal"` produces `UpdateWithSet[..., Void]` (value-baked).
    */
   def set[A](f: ColumnsView[Cols] => SetAssignment[?, A]): UpdateWithSet[Cols, Name, A] = {
     val sa = f(table.columnsView)
@@ -36,10 +36,10 @@ final class UpdateBuilder[Cols <: Tuple, Name <: String & Singleton] private[sha
   }
 
   /**
-   * `SET (<col := v>, ...)` — tuple form for multiple assignments. `SetArgs` is fixed to `Void`: the
-   * underlying typed Fragment encoder still composes whatever args the assignments contribute, but the
-   * static `SetArgs` slot stays `Void`. For typed-Args across multiple SET items, use the `&` infix
-   * combinator (`c.email := Param[String] & c.age := Param[Int]`) which threads `Concat[A1, A2]`.
+   * `SET (<col := v>, ...)` — tuple form for multiple assignments. `SetArgs` is fixed to `Void`: the underlying typed
+   * Fragment encoder still composes whatever args the assignments contribute, but the static `SetArgs` slot stays
+   * `Void`. For typed-Args across multiple SET items, use the `&` infix combinator (`c.email := Param[String] & c.age
+   * := Param[Int]`) which threads `Concat[A1, A2]`.
    */
   @scala.annotation.targetName("setTuple")
   def set(f: ColumnsView[Cols] => Tuple): UpdateWithSet[Cols, Name, Void] = {
@@ -99,8 +99,8 @@ private[sharp] def buildPatch[Cols <: Tuple, Name <: String & Singleton](
   names: List[String],
   values: List[Any]
 ): UpdateWithSet[Cols, Name, Void] = {
-  val allCols = table.columns.toList.asInstanceOf[List[Column[?, ?, ?, ?]]]
-  val byName  = allCols.iterator.map(c => c.name.toString -> c).toMap
+  val allCols                                = table.columns.toList.asInstanceOf[List[Column[?, ?, ?, ?]]]
+  val byName                                 = allCols.iterator.map(c => c.name.toString -> c).toMap
   val assignments: List[SetAssignment[?, ?]] =
     names.zip(values).collect { case (n, Some(v)) =>
       val col = byName(n)
@@ -137,7 +137,12 @@ final class UpdateWithSet[Cols <: Tuple, Name <: String & Singleton, SetArgs] pr
 
 }
 
-final class UpdateReady[Cols <: Tuple, Name <: String & Singleton, SetArgs, WArgs] @scala.annotation.publicInBinary private[sharp] (
+final class UpdateReady[
+  Cols <: Tuple,
+  Name <: String & Singleton,
+  SetArgs,
+  WArgs
+] @scala.annotation.publicInBinary private[sharp] (
   private[sharp] val table: Table[Cols, Name],
   private[sharp] val setFragment: Fragment[?],
   private[sharp] val whereOpt: Option[Fragment[?]]
@@ -145,12 +150,20 @@ final class UpdateReady[Cols <: Tuple, Name <: String & Singleton, SetArgs, WArg
 
   inline def where[A](f: ColumnsView[Cols] => Where[A]): UpdateReady[Cols, Name, SetArgs, Where.Concat[WArgs, A]] = {
     val pred     = f(table.columnsView)
-    val combined = SelectBuilder.andInto[WArgs, A](whereOpt.asInstanceOf[Option[Fragment[WArgs]]], pred, c => Where.projectConcat[WArgs, A](c))
+    val combined = SelectBuilder.andInto[WArgs, A](
+      whereOpt.asInstanceOf[Option[Fragment[WArgs]]],
+      pred,
+      c => Where.projectConcat[WArgs, A](c)
+    )
     new UpdateReady[Cols, Name, SetArgs, Where.Concat[WArgs, A]](table, setFragment, Some(combined))
   }
 
   inline def whereRaw(af: AppliedFragment): UpdateReady[Cols, Name, SetArgs, ?] = {
-    val combined = SelectBuilder.andRawInto[WArgs](whereOpt.asInstanceOf[Option[Fragment[WArgs]]], af, c => Where.projectConcat[WArgs, Void](c))
+    val combined = SelectBuilder.andRawInto[WArgs](
+      whereOpt.asInstanceOf[Option[Fragment[WArgs]]],
+      af,
+      c => Where.projectConcat[WArgs, Void](c)
+    )
     new UpdateReady[Cols, Name, SetArgs, Any](table, setFragment, Some(combined))
   }
 
@@ -172,7 +185,8 @@ final class UpdateReady[Cols <: Tuple, Name <: String & Singleton, SetArgs, WArg
   inline def compile: CommandTemplate[Where.Concat[SetArgs, WArgs]] =
     MutationAssembly.command[SetArgs, WArgs](updateParts)
 
-  inline def returning[T, A](f: ColumnsView[Cols] => TypedExpr[T, A]): QueryTemplate[Where.Concat[Where.Concat[SetArgs, WArgs], A], T] = {
+  inline def returning[T, A](f: ColumnsView[Cols] => TypedExpr[T, A])
+    : QueryTemplate[Where.Concat[Where.Concat[SetArgs, WArgs], A], T] = {
     val expr = f(table.columnsView)
     MutationAssembly.withReturningTyped[SetArgs, WArgs, A, T](updateParts, expr.fragment, expr.codec)
   }
@@ -274,7 +288,11 @@ final class UpdateFromWithSet[Cols <: Tuple, Name <: String & Singleton, Ss <: T
 }
 
 final class UpdateFromReady[
-  Cols <: Tuple, Name <: String & Singleton, Ss <: Tuple, SetArgs, WArgs
+  Cols <: Tuple,
+  Name <: String & Singleton,
+  Ss <: Tuple,
+  SetArgs,
+  WArgs
 ] @scala.annotation.publicInBinary private[sharp] (
   private[sharp] val table: Table[Cols, Name],
   private[sharp] val sources: Ss,
@@ -282,22 +300,30 @@ final class UpdateFromReady[
   private[sharp] val whereOpt: Option[Fragment[?]]
 ) {
 
-  inline def where[A](f: JoinedView[Ss] => Where[A]): UpdateFromReady[Cols, Name, Ss, SetArgs, Where.Concat[WArgs, A]] = {
+  inline def where[A](f: JoinedView[Ss] => Where[A])
+    : UpdateFromReady[Cols, Name, Ss, SetArgs, Where.Concat[WArgs, A]] = {
     val view     = buildJoinedView(sources)
     val pred     = f(view)
-    val combined = SelectBuilder.andInto[WArgs, A](whereOpt.asInstanceOf[Option[Fragment[WArgs]]], pred, c => Where.projectConcat[WArgs, A](c))
+    val combined = SelectBuilder.andInto[WArgs, A](
+      whereOpt.asInstanceOf[Option[Fragment[WArgs]]],
+      pred,
+      c => Where.projectConcat[WArgs, A](c)
+    )
     new UpdateFromReady[Cols, Name, Ss, SetArgs, Where.Concat[WArgs, A]](table, sources, setFragment, Some(combined))
   }
 
   inline def whereRaw(af: AppliedFragment): UpdateFromReady[Cols, Name, Ss, SetArgs, ?] = {
-    val combined = SelectBuilder.andRawInto[WArgs](whereOpt.asInstanceOf[Option[Fragment[WArgs]]], af, c => Where.projectConcat[WArgs, Void](c))
+    val combined = SelectBuilder.andRawInto[WArgs](
+      whereOpt.asInstanceOf[Option[Fragment[WArgs]]],
+      af,
+      c => Where.projectConcat[WArgs, Void](c)
+    )
     new UpdateFromReady[Cols, Name, Ss, SetArgs, Any](table, sources, setFragment, Some(combined))
   }
 
   /**
-   * UPDATE … SET … FROM <tail sources> WHERE — emits per-source body Right slots so typed-subquery FROM
-   * sources thread their inner Args into the outer command's args. Plain tables contribute `emptyVoidSlot`
-   * for their body slot.
+   * UPDATE … SET … FROM <tail sources> WHERE — emits per-source body Right slots so typed-subquery FROM sources thread
+   * their inner Args into the outer command's args. Plain tables contribute `emptyVoidSlot` for their body slot.
    */
   private def updateFromParts: List[BodyPart] = {
     val buf = scala.collection.mutable.ListBuffer[BodyPart](
@@ -321,8 +347,8 @@ final class UpdateFromReady[
   }
 
   /**
-   * Number of FROM-tail body Right slots emitted by [[updateFromParts]] — one per tail source. Matches the
-   * count of values produced by `bff.project(sArgs).tail` (skipping the target table at index 0).
+   * Number of FROM-tail body Right slots emitted by [[updateFromParts]] — one per tail source. Matches the count of
+   * values produced by `bff.project(sArgs).tail` (skipping the target table at index 0).
    */
   private def fromTailBodyArgs(bff: SourceBodyArgsProj[? <: Tuple], sArgs: Any): List[Any] =
     bff.project(sArgs) match {
@@ -333,14 +359,14 @@ final class UpdateFromReady[
   // Concat-chain: SetArgs ⊕ SArgs ⊕ WArgs.
   inline def compile[SArgs](using
     sbOf: SourceBodyArgsOf.Aux[Ss, SArgs],
-    bff:  SourceBodyArgsProj[Ss]
+    bff: SourceBodyArgsProj[Ss]
   ): CommandTemplate[Where.Concat[Where.Concat[SetArgs, SArgs], WArgs]] = {
     type Out = Where.Concat[Where.Concat[SetArgs, SArgs], WArgs]
     val slotValues: Out => IArray[Any] = args => {
       val (setSAcc, wArgs) = Where.projectConcat[Where.Concat[SetArgs, SArgs], WArgs](args)
       val (setArgs, sArgs) = Where.projectConcat[SetArgs, SArgs](setSAcc)
       val perTailBody      = fromTailBodyArgs(bff, sArgs)
-      val out = scala.collection.mutable.ArrayBuffer.empty[Any]
+      val out              = scala.collection.mutable.ArrayBuffer.empty[Any]
       out += setArgs
       perTailBody.foreach(out += _)
       out += wArgs
@@ -353,17 +379,18 @@ final class UpdateFromReady[
   // Concat-chain: SetArgs ⊕ SArgs ⊕ WArgs ⊕ A (RETURNING).
   inline def returning[T, A, SArgs](f: JoinedView[Ss] => TypedExpr[T, A])(using
     sbOf: SourceBodyArgsOf.Aux[Ss, SArgs],
-    bff:  SourceBodyArgsProj[Ss]
+    bff: SourceBodyArgsProj[Ss]
   ): QueryTemplate[Where.Concat[Where.Concat[Where.Concat[SetArgs, SArgs], WArgs], A], T] = {
-    val expr  = f(buildJoinedView(sources))
-    val parts: List[BodyPart] = updateFromParts ++ List[BodyPart](SelectBuilder.bake(RawConstants.RETURNING), Right(expr.fragment))
+    val expr                  = f(buildJoinedView(sources))
+    val parts: List[BodyPart] = updateFromParts ++
+      List[BodyPart](SelectBuilder.bake(RawConstants.RETURNING), Right(expr.fragment))
     type Out = Where.Concat[Where.Concat[Where.Concat[SetArgs, SArgs], WArgs], A]
     val slotValues: Out => IArray[Any] = args => {
       val (setSwAcc, retArgs) = Where.projectConcat[Where.Concat[Where.Concat[SetArgs, SArgs], WArgs], A](args)
       val (setSAcc, wArgs)    = Where.projectConcat[Where.Concat[SetArgs, SArgs], WArgs](setSwAcc)
       val (setArgs, sArgs)    = Where.projectConcat[SetArgs, SArgs](setSAcc)
       val perTailBody         = fromTailBodyArgs(bff, sArgs)
-      val out = scala.collection.mutable.ArrayBuffer.empty[Any]
+      val out                 = scala.collection.mutable.ArrayBuffer.empty[Any]
       out += setArgs
       perTailBody.foreach(out += _)
       out += wArgs
@@ -374,9 +401,9 @@ final class UpdateFromReady[
   }
 
   inline def returningTuple[T <: NonEmptyTuple, SArgs, TOut](f: JoinedView[Ss] => T)(using
-    pa:   ProjArgsOf.Aux[T, TOut],
+    pa: ProjArgsOf.Aux[T, TOut],
     sbOf: SourceBodyArgsOf.Aux[Ss, SArgs],
-    bff:  SourceBodyArgsProj[Ss]
+    bff: SourceBodyArgsProj[Ss]
   ): QueryTemplate[Where.Concat[Where.Concat[Where.Concat[SetArgs, SArgs], WArgs], TOut], ExprOutputs[T]] = {
     val exprs    = f(buildJoinedView(sources)).toList.asInstanceOf[List[TypedExpr[?, ?]]]
     val codec    = tupleCodec(exprs.map(_.codec)).asInstanceOf[Codec[ExprOutputs[T]]]
@@ -387,9 +414,9 @@ final class UpdateFromReady[
   }
 
   inline def returningNamed[NT <: scala.NamedTuple.AnyNamedTuple, SArgs, TOut](f: JoinedView[Ss] => NT)(using
-    pa:   ProjArgsOf.Aux[scala.NamedTuple.DropNames[NT], TOut],
+    pa: ProjArgsOf.Aux[scala.NamedTuple.DropNames[NT], TOut],
     sbOf: SourceBodyArgsOf.Aux[Ss, SArgs],
-    bff:  SourceBodyArgsProj[Ss]
+    bff: SourceBodyArgsProj[Ss]
   ): QueryTemplate[
     Where.Concat[Where.Concat[Where.Concat[SetArgs, SArgs], WArgs], TOut],
     scala.NamedTuple.NamedTuple[scala.NamedTuple.Names[NT], ExprOutputs[scala.NamedTuple.DropNames[NT]]]
@@ -408,7 +435,7 @@ final class UpdateFromReady[
 
   inline def returningAll[SArgs](using
     sbOf: SourceBodyArgsOf.Aux[Ss, SArgs],
-    bff:  SourceBodyArgsProj[Ss]
+    bff: SourceBodyArgsProj[Ss]
   ): QueryTemplate[Where.Concat[Where.Concat[SetArgs, SArgs], WArgs], NamedRowOf[Cols]] = {
     val exprs =
       table.columns.toList.asInstanceOf[List[Column[?, ?, ?, ?]]].map(c =>
@@ -426,9 +453,9 @@ final class UpdateFromReady[
 // ---- SetAssignment ---------------------------------------------------------------------------------
 
 /**
- * One typed `column = expression` assignment in an UPDATE SET list. `Args` is the captured-args type from the
- * RHS expression — `Void` when the RHS is a runtime value (baked via [[Param.bind]]), `T` when the RHS is a
- * deferred [[Param]], or whatever the wider expression's Args is.
+ * One typed `column = expression` assignment in an UPDATE SET list. `Args` is the captured-args type from the RHS
+ * expression — `Void` when the RHS is a runtime value (baked via [[Param.bind]]), `T` when the RHS is a deferred
+ * [[Param]], or whatever the wider expression's Args is.
  */
 final class SetAssignment[T, Args] @scala.annotation.publicInBinary private[sharp] (
   private[sharp] val col: TypedColumn[T, ?, ?],
@@ -441,7 +468,9 @@ object SetAssignment {
    * Internal-only: bake a runtime value into a Void-args assignment. Used by `.patch(...)` where the runtime
    * named-tuple of `Option[T]`s genuinely cannot be expressed as a typed expression at the call site.
    */
-  private[sharp] def fromValue[T](col: TypedColumn[T, ?, ?], value: T)(using pf: PgTypeFor[T]): SetAssignment[T, Void] = {
+  private[sharp] def fromValue[T](col: TypedColumn[T, ?, ?], value: T)(using
+    pf: PgTypeFor[T]
+  ): SetAssignment[T, Void] = {
     val rhs = Param.bind(value)(using pf)
     fromExprAux[T, Void](col, rhs.fragment)
   }
@@ -459,10 +488,10 @@ object SetAssignment {
 
   /**
    * Combine a non-empty list of assignments into a single comma-joined `Fragment[?]`. Existential-typed
-   * (`SetAssignment[?, ?]`) — Args is erased here, so we use [[SelectBuilder.combineEncoders]]'s runtime
-   * Void-shortcut without a contramap. Safe for tuple-form `.set` where the OUTER `SetArgs` collapses to
-   * Void; would need a contramap+`projectConcat` if any side carries a non-singleton-Void typed-Args
-   * encoder (e.g. `Param.bind`). Use the `&` combinator instead for typed Args across multiple items.
+   * (`SetAssignment[?, ?]`) — Args is erased here, so we use [[SelectBuilder.combineEncoders]]'s runtime Void-shortcut
+   * without a contramap. Safe for tuple-form `.set` where the OUTER `SetArgs` collapses to Void; would need a
+   * contramap+`projectConcat` if any side carries a non-singleton-Void typed-Args encoder (e.g. `Param.bind`). Use the
+   * `&` combinator instead for typed Args across multiple items.
    */
   private[dsl] def combineAll(items: List[SetAssignment[?, ?]]): Fragment[?] = {
     require(items.nonEmpty, "skunk-sharp: cannot combine empty SET list")
@@ -474,19 +503,23 @@ object SetAssignment {
   }
 
   /**
-   * Infix `&` combinator — comma-style joining for tuple shapes. `proj` re-pairs `Concat[A1, A2]` →
-   * `(A1, A2)` for the combined product encoder's contramap; materialised at the call site as
-   * `c => Where.projectConcat[A1, A2](c)` so the inline dispatch reduces with concrete `A1`/`A2`.
+   * Infix `&` combinator — comma-style joining for tuple shapes. `proj` re-pairs `Concat[A1, A2]` → `(A1, A2)` for the
+   * combined product encoder's contramap; materialised at the call site as `c => Where.projectConcat[A1, A2](c)` so the
+   * inline dispatch reduces with concrete `A1`/`A2`.
    */
   extension [T1, A1](lhs: SetAssignment[T1, A1])
+
     inline def &[T2, A2](rhs: SetAssignment[T2, A2]): SetAssignment[Unit, Where.Concat[A1, A2]] = {
       val parts = lhs.fragment.parts ++ RawConstants.COMMA_SEP.fragment.parts ++ rhs.fragment.parts
       val enc   = TypedExpr.combineEnc[A1, A2](
-        lhs.fragment.encoder, rhs.fragment.encoder, c => Where.projectConcat[A1, A2](c)
+        lhs.fragment.encoder,
+        rhs.fragment.encoder,
+        c => Where.projectConcat[A1, A2](c)
       )
       val frag: Fragment[Where.Concat[A1, A2]] = Fragment(parts, enc, Origin.unknown)
       new SetAssignment[Unit, Where.Concat[A1, A2]](
-        null.asInstanceOf[TypedColumn[Unit, ?, ?]], frag
+        null.asInstanceOf[TypedColumn[Unit, ?, ?]],
+        frag
       )
     }
 
@@ -495,9 +528,9 @@ object SetAssignment {
 extension [T, Null <: Boolean, N <: String & Singleton](col: TypedColumn[T, Null, N]) {
 
   /**
-   * `col = <expression>` — RHS is any TypedExpr; its Args thread into the SetArgs slot. For value RHS pick
-   * `Param[T]` (deferred to execute time, static SQL), `lit(v)` (compile-time literal, primitives only), or
-   * `Param.bind(v)` (bake the runtime value into a Void-args fragment).
+   * `col = <expression>` — RHS is any TypedExpr; its Args thread into the SetArgs slot. For value RHS pick `Param[T]`
+   * (deferred to execute time, static SQL), `lit(v)` (compile-time literal, primitives only), or `Param.bind(v)` (bake
+   * the runtime value into a Void-args fragment).
    */
   def :=[A](expr: TypedExpr[T, A]): SetAssignment[T, A] =
     SetAssignment.fromExpr(col, expr)

--- a/modules/core/src/main/scala/skunk/sharp/dsl/WindowSpec.scala
+++ b/modules/core/src/main/scala/skunk/sharp/dsl/WindowSpec.scala
@@ -23,9 +23,9 @@ private enum FrameMode(val keyword: String):
 /**
  * Builder for the content of an `OVER (…)` clause.
  *
- * Args of partition-by and order-by items thread into the wrapping `over` extension's result Args via the
- * combined `Concat[PA, OA]` slot. Param-bearing items (`Param[Int].asc`, `partitionBy(Param[String])`) surface
- * as typed `Args` on the outer query. Frame bounds are static integer constants — Args-neutral.
+ * Args of partition-by and order-by items thread into the wrapping `over` extension's result Args via the combined
+ * `Concat[PA, OA]` slot. Param-bearing items (`Param[Int].asc`, `partitionBy(Param[String])`) surface as typed `Args`
+ * on the outer query. Frame bounds are static integer constants — Args-neutral.
  */
 final class WindowSpec[PA, OA] @scala.annotation.publicInBinary private[sharp] (
   // Comma-joined PARTITION BY items (without the leading `PARTITION BY ` keyword), or None when empty.
@@ -61,9 +61,9 @@ final class WindowSpec[PA, OA] @scala.annotation.publicInBinary private[sharp] (
     new WindowSpec(pbItems, obItems, Some((FrameMode.Groups, start, end)))
 
   /**
-   * Render the interior of `OVER (…)` as a typed `Fragment[Concat[PA, OA]]`. PARTITION-BY items appear first
-   * (typed via `PA`), then ORDER-BY items (typed via `OA`), then the frame clause (Args-neutral). Param-bearing
-   * items have their typed Args threaded into the outer query's `Args` via `Concat`.
+   * Render the interior of `OVER (…)` as a typed `Fragment[Concat[PA, OA]]`. PARTITION-BY items appear first (typed via
+   * `PA`), then ORDER-BY items (typed via `OA`), then the frame clause (Args-neutral). Param-bearing items have their
+   * typed Args threaded into the outer query's `Args` via `Concat`.
    */
   private[sharp] inline def renderTyped: Fragment[Where.Concat[PA, OA]] = {
     val frameSql: String = frameOpt.fold("") { case (mode, start, end) =>

--- a/modules/core/src/main/scala/skunk/sharp/dsl/package.scala
+++ b/modules/core/src/main/scala/skunk/sharp/dsl/package.scala
@@ -108,15 +108,15 @@ package object dsl {
   // Boolean combinators (`&&`, `||`, `!`, `and`, `or`, `not`) — top-level extension on
   // `TypedExpr[Boolean, A]` defined in `skunk.sharp.where`. Re-exported here so a single
   // `import skunk.sharp.dsl.*` brings them into scope.
-  export skunk.sharp.where.{&&, ||, and, or, not, unary_!}
+  export skunk.sharp.where.{&&, ||, and, not, or, unary_!}
 
   /**
-   * Variadic AND-fold over `Where[Void]`. Composes naturally — nest `anyOf` inside `allOf` (or vice versa) to
-   * spell out arbitrary boolean trees: `where(_ => allOf(w1, anyOf(w2, w3), w4))`. Empty argument list folds
-   * to `WHERE TRUE` (the AND identity, optimised away by Postgres).
+   * Variadic AND-fold over `Where[Void]`. Composes naturally — nest `anyOf` inside `allOf` (or vice versa) to spell out
+   * arbitrary boolean trees: `where(_ => allOf(w1, anyOf(w2, w3), w4))`. Empty argument list folds to `WHERE TRUE` (the
+   * AND identity, optimised away by Postgres).
    *
-   * For a runtime collection of predicates, splat into the varargs (`allOf(list*)`) — there's no separate
-   * `Foldable` overload to keep the call surface narrow.
+   * For a runtime collection of predicates, splat into the varargs (`allOf(list*)`) — there's no separate `Foldable`
+   * overload to keep the call surface narrow.
    */
   def allOf(ws: skunk.sharp.where.Where[skunk.Void]*): skunk.sharp.where.Where[skunk.Void] =
     skunk.sharp.where.Where.allOf(ws)
@@ -192,10 +192,10 @@ package object dsl {
   // `CASE WHEN target = v THEN …` and adds no expressiveness.
 
   /**
-   * Start a `CASE`. Each branch has its own boolean predicate. The first branch's `branch:
-   * TypedExpr[T]` pins the output type; later `.when`s must agree. Captured `Items` accumulate the
-   * sequence of `(cond, branch)` typed expressions so `.otherwise` / `.end` can fold their `Args`
-   * into the final QueryTemplate Args slot via [[ProjArgsOf]].
+   * Start a `CASE`. Each branch has its own boolean predicate. The first branch's `branch: TypedExpr[T]` pins the
+   * output type; later `.when`s must agree. Captured `Items` accumulate the sequence of `(cond, branch)` typed
+   * expressions so `.otherwise` / `.end` can fold their `Args` into the final QueryTemplate Args slot via
+   * [[ProjArgsOf]].
    */
   def caseWhen[T, A1, A2](
     cond: skunk.sharp.TypedExpr[Boolean, A1],

--- a/modules/core/src/main/scala/skunk/sharp/internal/ExprMacro.scala
+++ b/modules/core/src/main/scala/skunk/sharp/internal/ExprMacro.scala
@@ -11,10 +11,10 @@ import scala.quoted.*
  * Macro behind the `expr"..."` interpolator (see [[skunk.sharp.expr]]).
  *
  * The job is exactly: concatenate the literal SQL pieces from the `StringContext` with each interpolated
- * [[TypedExpr]]'s `fragment.parts`, threading their `Args` slots through `Where.FoldConcat`. No value-baking,
- * no parameter wrapping — every interpolation must already be a `TypedExpr` (column ref, `Param[T]`,
- * `lit(v)`, …). Literal SQL pieces show up as `Left(s)` entries in the assembled `Fragment.parts`; arg
- * fragments contribute their own parts (which may carry `Right(state)` placeholders for `Param[T]`).
+ * [[TypedExpr]]'s `fragment.parts`, threading their `Args` slots through `Where.FoldConcat`. No value-baking, no
+ * parameter wrapping — every interpolation must already be a `TypedExpr` (column ref, `Param[T]`, `lit(v)`, …). Literal
+ * SQL pieces show up as `Left(s)` entries in the assembled `Fragment.parts`; arg fragments contribute their own parts
+ * (which may carry `Right(state)` placeholders for `Param[T]`).
  */
 private[sharp] object ExprMacro {
 
@@ -47,7 +47,7 @@ private[sharp] object ExprMacro {
     // class hierarchy via `baseClasses`. We also `simplified` the term type to reduce match-type aliases
     // (e.g. `NamedTuple.Elem[…, 1]` for a column field access on a `ColumnsView` lambda parameter), then
     // coerce via a `Typed` wrapper so the splice's `.fragment` projection sees the concrete `TypedExpr` type.
-    val typedExprSym = TypeRepr.of[TypedExpr[Any, Any]].typeSymbol
+    val typedExprSym                                  = TypeRepr.of[TypedExpr[Any, Any]].typeSymbol
     val argSlots: List[(TypeRepr, Expr[Fragment[?]])] = argExprs.map { argExpr =>
       val widened = argExpr.asTerm.tpe.widen.dealias.simplified
 
@@ -125,23 +125,23 @@ private[sharp] object ExprMacro {
 }
 
 /**
- * Runtime helpers used by `expr"..."`-emitted code. Lives in a regular object so the assembly + encoder
- * construction don't get duplicated at every inline call site.
+ * Runtime helpers used by `expr"..."`-emitted code. Lives in a regular object so the assembly + encoder construction
+ * don't get duplicated at every inline call site.
  */
 object ExprMacroRuntime {
 
   /**
-   * Direct concatenation: `literals(0)`, then for each `i`, `argFrags(i).parts ++ literals(i+1)`. The
-   * resulting `Fragment.parts` is exactly the user's SQL with each interpolated `TypedExpr`'s parts spliced
-   * in — including any `$N` placeholders the args carry. The encoder folds the args' encoders into one
-   * that consumes a `Where.FoldConcat[Tup]` value and emits each arg's encoded bytes in render order.
+   * Direct concatenation: `literals(0)`, then for each `i`, `argFrags(i).parts ++ literals(i+1)`. The resulting
+   * `Fragment.parts` is exactly the user's SQL with each interpolated `TypedExpr`'s parts spliced in — including any
+   * `$N` placeholders the args carry. The encoder folds the args' encoders into one that consumes a
+   * `Where.FoldConcat[Tup]` value and emits each arg's encoded bytes in render order.
    */
   inline def assemble[Tup <: Tuple, Args](
     literals: List[String],
     argFrags: List[Fragment[?]]
   ): Fragment[Args] = {
     val parts: List[Either[String, cats.data.State[Int, String]]] = {
-      val buf = scala.collection.mutable.ListBuffer.empty[Either[String, cats.data.State[Int, String]]]
+      val buf  = scala.collection.mutable.ListBuffer.empty[Either[String, cats.data.State[Int, String]]]
       val head = literals.head
       if (head.nonEmpty) buf += Left(head)
       argFrags.zip(literals.tail).foreach { case (f, lit) =>
@@ -157,11 +157,10 @@ object ExprMacroRuntime {
   }
 
   /**
-   * Build an encoder that consumes the user-facing `Args` value (a flat tuple, scalar, or `Void`), walks
-   * `argFrags` in render order, and for each non-`Void` slot delegates to its arg's encoder. The projector
-   * is materialised at the inline call site so `Where.projectFoldConcat[Tup]` reduces with the concrete
-   * tuple shape; this method itself is a non-inline def so the anonymous `Encoder` class isn't duplicated
-   * at every interpolation site.
+   * Build an encoder that consumes the user-facing `Args` value (a flat tuple, scalar, or `Void`), walks `argFrags` in
+   * render order, and for each non-`Void` slot delegates to its arg's encoder. The projector is materialised at the
+   * inline call site so `Where.projectFoldConcat[Tup]` reduces with the concrete tuple shape; this method itself is a
+   * non-inline def so the anonymous `Encoder` class isn't duplicated at every interpolation site.
    */
   private[sharp] def buildEncoder[Args](
     argFrags: List[Fragment[?]],

--- a/modules/core/src/main/scala/skunk/sharp/ops/ExprOps.scala
+++ b/modules/core/src/main/scala/skunk/sharp/ops/ExprOps.scala
@@ -8,31 +8,30 @@ import skunk.util.Origin
 import scala.annotation.unused
 
 /**
- * The expression-level operator set: `=, <>, <, <=, >, >=, BETWEEN, IN, LIKE, IS NULL`. Each operator produces
- * a `Where[A]` (= `TypedExpr[Boolean, A]`) — a typed predicate carrying its parameter tuple as a visible Args
- * type. Operators slot wherever a boolean expression is valid in Postgres: WHERE, HAVING, SELECT projections,
- * ORDER BY, function arguments, CASE WHEN predicates.
+ * The expression-level operator set: `=, <>, <, <=, >, >=, BETWEEN, IN, LIKE, IS NULL`. Each operator produces a
+ * `Where[A]` (= `TypedExpr[Boolean, A]`) — a typed predicate carrying its parameter tuple as a visible Args type.
+ * Operators slot wherever a boolean expression is valid in Postgres: WHERE, HAVING, SELECT projections, ORDER BY,
+ * function arguments, CASE WHEN predicates.
  *
- * Operators are *extension methods* on `TypedExpr[T, A]` so third-party modules add new ones without touching
- * core.
+ * Operators are *extension methods* on `TypedExpr[T, A]` so third-party modules add new ones without touching core.
  *
  * **RHS forms** for binary operators — RHS is always a `TypedExpr`. To compare against a value pick one of:
  *
- *   - `lhs === Param[T]` — deferred parameter, supplied at execute time. Args contributes `T`. The static-SQL
- *     path: one `Fragment[T]` is built and reused across every argument value.
+ *   - `lhs === Param[T]` — deferred parameter, supplied at execute time. Args contributes `T`. The static-SQL path: one
+ *     `Fragment[T]` is built and reused across every argument value.
  *   - `lhs === lit(v)` — compile-time literal (primitives only). Inline SQL, Args contributes `Void`.
  *   - `lhs === otherExpr` — column-vs-expression / function-call result. Args from `otherExpr`.
- *   - `lhs === Param.bind(v)` — bake a runtime value into a `Void`-args fragment now. Rebuilds an encoder
- *     closure per `.compile`; pick this when the value really can't be deferred.
+ *   - `lhs === Param.bind(v)` — bake a runtime value into a `Void`-args fragment now. Rebuilds an encoder closure per
+ *     `.compile`; pick this when the value really can't be deferred.
  *
- * **Nullable columns.** If a column is declared nullable, comparisons like `col === Param[T]` take the
- * underlying value type, not `Option[value]`. Trying to compare against `None` is a compile error — use
- * `.isNull` / `.isNotNull` instead. See [[Stripped]].
+ * **Nullable columns.** If a column is declared nullable, comparisons like `col === Param[T]` take the underlying value
+ * type, not `Option[value]`. Trying to compare against `None` is a compile error — use `.isNull` / `.isNotNull`
+ * instead. See [[Stripped]].
  */
 
 /**
- * Type-level alias: strip outermost `Option[_]` if there is one, otherwise unchanged. Used as an evidence
- * bound in `like` / `ilike` / `similarTo` / `notSimilarTo` so a nullable-string column (`TypedColumn[Option[String], true, _]`)
+ * Type-level alias: strip outermost `Option[_]` if there is one, otherwise unchanged. Used as an evidence bound in
+ * `like` / `ilike` / `similarTo` / `notSimilarTo` so a nullable-string column (`TypedColumn[Option[String], true, _]`)
  * accepts those operators — `Stripped[Option[String]] <:< String` resolves cleanly. Also used by
  * [[skunk.sharp.pg.functions.Shared.StrLike]] and [[skunk.sharp.pg.functions.PgSrf]]'s `nullif`.
  */
@@ -56,6 +55,7 @@ private inline def opCombine[T, U, A, B](
 // `T` appears in a parameter position — overload search fails before the `using` is summoned.
 
 extension [T, A](lhs: TypedExpr[T, A]) {
+
   /** `lhs = rhs` — RHS is any TypedExpr. Use `Param[T]`, `lit(v)`, or `Param.bind(v)` for value RHS. */
   inline def ===[B](rhs: TypedExpr[T, B]): Where[Where.Concat[A, B]] = opCombine(lhs, " = ", rhs)
 
@@ -72,6 +72,7 @@ extension [T, A](lhs: TypedExpr[T, A]) {
 
   inline def >=[B](rhs: TypedExpr[T, B])(using @unused ord: cats.Order[T]): Where[Where.Concat[A, B]] =
     opCombine(lhs, " >= ", rhs)
+
 }
 
 /** Column-to-expression equality alias for source compat. Equivalent to `===` with TypedExpr RHS. */
@@ -126,19 +127,30 @@ extension [T, A](lhs: TypedExpr[T, A]) {
 
 }
 
-/** `lhs LIKE pattern` / `ILIKE` / `SIMILAR TO`. Pattern must be a `TypedExpr[String, _]` — use `lit("…%")` or `Param[String]`. */
+/**
+ * `lhs LIKE pattern` / `ILIKE` / `SIMILAR TO`. Pattern must be a `TypedExpr[String, _]` — use `lit("…%")` or
+ * `Param[String]`.
+ */
 extension [T, A](lhs: TypedExpr[T, A]) {
 
-  inline def like[B](pattern: TypedExpr[String, B])(using @unused ev: Stripped[T] <:< String): Where[Where.Concat[A, B]] =
+  inline def like[B](pattern: TypedExpr[String, B])(using
+    @unused ev: Stripped[T] <:< String
+  ): Where[Where.Concat[A, B]] =
     opCombine(lhs, " LIKE ", pattern)
 
-  inline def ilike[B](pattern: TypedExpr[String, B])(using @unused ev: Stripped[T] <:< String): Where[Where.Concat[A, B]] =
+  inline def ilike[B](pattern: TypedExpr[String, B])(using
+    @unused ev: Stripped[T] <:< String
+  ): Where[Where.Concat[A, B]] =
     opCombine(lhs, " ILIKE ", pattern)
 
-  inline def similarTo[B](pattern: TypedExpr[String, B])(using @unused ev: Stripped[T] <:< String): Where[Where.Concat[A, B]] =
+  inline def similarTo[B](pattern: TypedExpr[String, B])(using
+    @unused ev: Stripped[T] <:< String
+  ): Where[Where.Concat[A, B]] =
     opCombine(lhs, " SIMILAR TO ", pattern)
 
-  inline def notSimilarTo[B](pattern: TypedExpr[String, B])(using @unused ev: Stripped[T] <:< String): Where[Where.Concat[A, B]] =
+  inline def notSimilarTo[B](pattern: TypedExpr[String, B])(using
+    @unused ev: Stripped[T] <:< String
+  ): Where[Where.Concat[A, B]] =
     opCombine(lhs, " NOT SIMILAR TO ", pattern)
 
 }
@@ -178,17 +190,16 @@ object InRhs {
   type Aux[T, Rhs, A0] = InRhs[T, Rhs] { type RA = A0 }
 
   /**
-   * `lhs IN (e1, e2, …)` over a non-empty `Reducible` of typed expressions. Each item must be a
-   * `TypedExpr[T, Void]` — pass `lit(v)` (compile-time literal), `Param.bind(v)` (bake runtime value), or any
-   * other Void-args expression. For execute-time-deferred lists, prefer `lhs === ANY(Param[Arr[T]])` (see
-   * [[skunk.sharp.pg.ArrayOps.elemOf]]) — `IN` with multiple `Param[T]` would require N execute-time slots
-   * which the API doesn't model.
+   * `lhs IN (e1, e2, …)` over a non-empty `Reducible` of typed expressions. Each item must be a `TypedExpr[T, Void]` —
+   * pass `lit(v)` (compile-time literal), `Param.bind(v)` (bake runtime value), or any other Void-args expression. For
+   * execute-time-deferred lists, prefer `lhs === ANY(Param[Arr[T]])` (see [[skunk.sharp.pg.ArrayOps.elemOf]]) — `IN`
+   * with multiple `Param[T]` would require N execute-time slots which the API doesn't model.
    */
   given reducibleIn[T, F[_]](using R: cats.Reducible[F]): InRhs.Aux[T, F[TypedExpr[T, Void]], Void] =
     new InRhs[T, F[TypedExpr[T, Void]]] {
       type RA = Void
       def renderParens(values: F[TypedExpr[T, Void]]): Fragment[Void] = {
-        val frags = R.toNonEmptyList(values).toList.map(_.fragment)
+        val frags  = R.toNonEmptyList(values).toList.map(_.fragment)
         val joined = frags.reduceLeft((a, b) =>
           TypedExpr.combineSepInl[Void, Void](a, ", ", b).asInstanceOf[Fragment[Void]]
         )
@@ -206,9 +217,9 @@ object InRhs {
     }
 
   /**
-   * `lhs IN (listExpr)` where `listExpr` is a `Param[List[T]]` (built via [[skunk.sharp.Param.list]]) —
-   * expands to N comma-separated `$N` placeholders and binds a single `List[T]` at execute time. Single
-   * prepared statement per size; sidesteps the `Param.bind`-per-element pattern.
+   * `lhs IN (listExpr)` where `listExpr` is a `Param[List[T]]` (built via [[skunk.sharp.Param.list]]) — expands to N
+   * comma-separated `$N` placeholders and binds a single `List[T]` at execute time. Single prepared statement per size;
+   * sidesteps the `Param.bind`-per-element pattern.
    */
   given paramListIn[T]: InRhs.Aux[T, skunk.sharp.Param[List[T]], List[T]] =
     new InRhs[T, skunk.sharp.Param[List[T]]] {
@@ -233,8 +244,8 @@ extension [T, A](lhs: TypedExpr[T, A]) {
 }
 
 /**
- * ANY / ALL quantifier over a subquery RHS. Renders as `<lhs> <op> ANY (<subquery>)` / `<lhs> <op> ALL
- * (<subquery>)`. Param-bearing inner subqueries thread their `QA` slot into the result via `Concat[A, QA]`.
+ * ANY / ALL quantifier over a subquery RHS. Renders as `<lhs> <op> ANY (<subquery>)` / `<lhs> <op> ALL (<subquery>)`.
+ * Param-bearing inner subqueries thread their `QA` slot into the result via `Concat[A, QA]`.
  */
 private inline def quantifiedRender[T, A, Q, ET, QA](
   lhs: TypedExpr[T, A],

--- a/modules/core/src/main/scala/skunk/sharp/pg/functions/PgArray.scala
+++ b/modules/core/src/main/scala/skunk/sharp/pg/functions/PgArray.scala
@@ -13,7 +13,7 @@ import skunk.sharp.where.Where
 trait PgArray {
 
   inline def arrayLength[A, X, Y](
-    a:   TypedExpr[A, X],
+    a: TypedExpr[A, X],
     dim: TypedExpr[Int, Y]
   )(using @annotation.unused ev: IsArray[A]): TypedExpr[Option[Int], Where.Concat[X, Y]] = {
     val inner = TypedExpr.combineSepInl[X, Y](a.fragment, ", ", dim.fragment)
@@ -83,7 +83,7 @@ trait PgArray {
   }
 
   inline def arrayToString[A, X, Y](
-    a:   TypedExpr[A, X],
+    a: TypedExpr[A, X],
     sep: TypedExpr[String, Y]
   )(using @annotation.unused ev: IsArray[A]): TypedExpr[String, Where.Concat[X, Y]] = {
     val inner = TypedExpr.combineSepInl[X, Y](a.fragment, ", ", sep.fragment)
@@ -94,16 +94,18 @@ trait PgArray {
   import skunk.sharp.PgFunction
 
   inline def arrayToString[A, X, Y, Z](
-    a:       TypedExpr[A, X],
-    sep:     TypedExpr[String, Y],
+    a: TypedExpr[A, X],
+    sep: TypedExpr[String, Y],
     nullStr: TypedExpr[String, Z]
   )(using @annotation.unused ev: IsArray[A]): TypedExpr[String, Where.FoldConcat[X *: Y *: Z *: EmptyTuple]] =
     PgFunction.naryTypedFold[String, X *: Y *: Z *: EmptyTuple](
-      "array_to_string", List(a.fragment, sep.fragment, nullStr.fragment), pg.text
+      "array_to_string",
+      List(a.fragment, sep.fragment, nullStr.fragment),
+      pg.text
     )
 
   inline def stringToArray[X, Y](
-    s:   TypedExpr[String, X],
+    s: TypedExpr[String, X],
     sep: TypedExpr[String, Y]
   ): TypedExpr[Arr[String], Where.Concat[X, Y]] = {
     val inner = TypedExpr.combineSepInl[X, Y](s.fragment, ", ", sep.fragment)
@@ -117,7 +119,8 @@ trait PgArray {
   }
 
   def unnest[A, E, X](a: TypedExpr[A, X])(using
-    @annotation.unused ev: IsArray.Aux[A, E], pf: PgTypeFor[E]
+    @annotation.unused ev: IsArray.Aux[A, E],
+    pf: PgTypeFor[E]
   ): TypedExpr[E, X] = {
     val frag = TypedExpr.wrap("unnest(", a.fragment, ")")
     TypedExpr[E, X](frag, pf.codec)

--- a/modules/core/src/main/scala/skunk/sharp/pg/functions/PgNull.scala
+++ b/modules/core/src/main/scala/skunk/sharp/pg/functions/PgNull.scala
@@ -46,41 +46,63 @@ trait PgNull {
     TypedExpr[T, Where.Concat[Where.Concat[A1, A2], A3]](frag, pf.codec)
   }
 
-  /** `coalesce(a, b, c, d)` — `Args` flattens to the non-Void slots of `(A1, A2, A3, A4)` via `Where.Concat`.  */
+  /** `coalesce(a, b, c, d)` — `Args` flattens to the non-Void slots of `(A1, A2, A3, A4)` via `Where.Concat`. */
   inline def coalesce[T, A1, A2, A3, A4](
-    a: TypedExpr[T, A1], b: TypedExpr[T, A2], c: TypedExpr[T, A3], d: TypedExpr[T, A4]
+    a: TypedExpr[T, A1],
+    b: TypedExpr[T, A2],
+    c: TypedExpr[T, A3],
+    d: TypedExpr[T, A4]
   )(using
     pf: PgTypeFor[T]
   ): TypedExpr[T, Where.FoldConcat[A1 *: A2 *: A3 *: A4 *: EmptyTuple]] =
     PgFunction.naryTypedFold[T, A1 *: A2 *: A3 *: A4 *: EmptyTuple](
-      "coalesce", List(a.fragment, b.fragment, c.fragment, d.fragment), pf.codec
+      "coalesce",
+      List(a.fragment, b.fragment, c.fragment, d.fragment),
+      pf.codec
     )
 
-  /** `coalesce(a, b, c, d, e)` — `Args` flattens to the non-Void slots of `(A1…A5)` via `Where.Concat`.  */
+  /** `coalesce(a, b, c, d, e)` — `Args` flattens to the non-Void slots of `(A1…A5)` via `Where.Concat`. */
   inline def coalesce[T, A1, A2, A3, A4, A5](
-    a: TypedExpr[T, A1], b: TypedExpr[T, A2], c: TypedExpr[T, A3], d: TypedExpr[T, A4], e: TypedExpr[T, A5]
+    a: TypedExpr[T, A1],
+    b: TypedExpr[T, A2],
+    c: TypedExpr[T, A3],
+    d: TypedExpr[T, A4],
+    e: TypedExpr[T, A5]
   )(using
     pf: PgTypeFor[T]
   ): TypedExpr[T, Where.FoldConcat[A1 *: A2 *: A3 *: A4 *: A5 *: EmptyTuple]] =
     PgFunction.naryTypedFold[T, A1 *: A2 *: A3 *: A4 *: A5 *: EmptyTuple](
-      "coalesce", List(a.fragment, b.fragment, c.fragment, d.fragment, e.fragment), pf.codec
+      "coalesce",
+      List(a.fragment, b.fragment, c.fragment, d.fragment, e.fragment),
+      pf.codec
     )
 
-  /** `coalesce(a, b, c, d, e, f)` — `Args` flattens to the non-Void slots of `(A1…A6)` via `Where.Concat`.  */
+  /** `coalesce(a, b, c, d, e, f)` — `Args` flattens to the non-Void slots of `(A1…A6)` via `Where.Concat`. */
   inline def coalesce[T, A1, A2, A3, A4, A5, A6](
-    a: TypedExpr[T, A1], b: TypedExpr[T, A2], c: TypedExpr[T, A3], d: TypedExpr[T, A4],
-    e: TypedExpr[T, A5], f: TypedExpr[T, A6]
+    a: TypedExpr[T, A1],
+    b: TypedExpr[T, A2],
+    c: TypedExpr[T, A3],
+    d: TypedExpr[T, A4],
+    e: TypedExpr[T, A5],
+    f: TypedExpr[T, A6]
   )(using
     pf: PgTypeFor[T]
   ): TypedExpr[T, Where.FoldConcat[A1 *: A2 *: A3 *: A4 *: A5 *: A6 *: EmptyTuple]] =
     PgFunction.naryTypedFold[T, A1 *: A2 *: A3 *: A4 *: A5 *: A6 *: EmptyTuple](
-      "coalesce", List(a.fragment, b.fragment, c.fragment, d.fragment, e.fragment, f.fragment), pf.codec
+      "coalesce",
+      List(a.fragment, b.fragment, c.fragment, d.fragment, e.fragment, f.fragment),
+      pf.codec
     )
 
-  /** `coalesce(a, b, c, d, e, f, g)` — `Args` flattens to the non-Void slots of `(A1…A7)` via `Where.Concat`.  */
+  /** `coalesce(a, b, c, d, e, f, g)` — `Args` flattens to the non-Void slots of `(A1…A7)` via `Where.Concat`. */
   inline def coalesce[T, A1, A2, A3, A4, A5, A6, A7](
-    a: TypedExpr[T, A1], b: TypedExpr[T, A2], c: TypedExpr[T, A3], d: TypedExpr[T, A4],
-    e: TypedExpr[T, A5], f: TypedExpr[T, A6], g: TypedExpr[T, A7]
+    a: TypedExpr[T, A1],
+    b: TypedExpr[T, A2],
+    c: TypedExpr[T, A3],
+    d: TypedExpr[T, A4],
+    e: TypedExpr[T, A5],
+    f: TypedExpr[T, A6],
+    g: TypedExpr[T, A7]
   )(using
     pf: PgTypeFor[T]
   ): TypedExpr[T, Where.FoldConcat[A1 *: A2 *: A3 *: A4 *: A5 *: A6 *: A7 *: EmptyTuple]] =
@@ -90,10 +112,16 @@ trait PgNull {
       pf.codec
     )
 
-  /** `coalesce(a, b, c, d, e, f, g, h)` — `Args` flattens to the non-Void slots of `(A1…A8)` via `Where.Concat`.  */
+  /** `coalesce(a, b, c, d, e, f, g, h)` — `Args` flattens to the non-Void slots of `(A1…A8)` via `Where.Concat`. */
   inline def coalesce[T, A1, A2, A3, A4, A5, A6, A7, A8](
-    a: TypedExpr[T, A1], b: TypedExpr[T, A2], c: TypedExpr[T, A3], d: TypedExpr[T, A4],
-    e: TypedExpr[T, A5], f: TypedExpr[T, A6], g: TypedExpr[T, A7], h: TypedExpr[T, A8]
+    a: TypedExpr[T, A1],
+    b: TypedExpr[T, A2],
+    c: TypedExpr[T, A3],
+    d: TypedExpr[T, A4],
+    e: TypedExpr[T, A5],
+    f: TypedExpr[T, A6],
+    g: TypedExpr[T, A7],
+    h: TypedExpr[T, A8]
   )(using
     pf: PgTypeFor[T]
   ): TypedExpr[T, Where.FoldConcat[A1 *: A2 *: A3 *: A4 *: A5 *: A6 *: A7 *: A8 *: EmptyTuple]] =
@@ -103,10 +131,17 @@ trait PgNull {
       pf.codec
     )
 
-  /** `coalesce(a, b, c, d, e, f, g, h, i)` — `Args` flattens to the non-Void slots of `(A1…A9)` via `Where.Concat`.  */
+  /** `coalesce(a, b, c, d, e, f, g, h, i)` — `Args` flattens to the non-Void slots of `(A1…A9)` via `Where.Concat`. */
   inline def coalesce[T, A1, A2, A3, A4, A5, A6, A7, A8, A9](
-    a: TypedExpr[T, A1], b: TypedExpr[T, A2], c: TypedExpr[T, A3], d: TypedExpr[T, A4],
-    e: TypedExpr[T, A5], f: TypedExpr[T, A6], g: TypedExpr[T, A7], h: TypedExpr[T, A8], i: TypedExpr[T, A9]
+    a: TypedExpr[T, A1],
+    b: TypedExpr[T, A2],
+    c: TypedExpr[T, A3],
+    d: TypedExpr[T, A4],
+    e: TypedExpr[T, A5],
+    f: TypedExpr[T, A6],
+    g: TypedExpr[T, A7],
+    h: TypedExpr[T, A8],
+    i: TypedExpr[T, A9]
   )(using
     pf: PgTypeFor[T]
   ): TypedExpr[T, Where.FoldConcat[A1 *: A2 *: A3 *: A4 *: A5 *: A6 *: A7 *: A8 *: A9 *: EmptyTuple]] =

--- a/modules/core/src/main/scala/skunk/sharp/pg/functions/PgNumeric.scala
+++ b/modules/core/src/main/scala/skunk/sharp/pg/functions/PgNumeric.scala
@@ -21,7 +21,7 @@ trait PgNumeric {
 
   /** `round(x, digits)` — Postgres defines this only for `numeric`. */
   inline def round[T, A1, A2](
-    e:      TypedExpr[T, A1],
+    e: TypedExpr[T, A1],
     digits: TypedExpr[Int, A2]
   ): TypedExpr[T, Where.Concat[A1, A2]] = {
     val inner = TypedExpr.combineSepInl[A1, A2](e.fragment, ", ", digits.fragment)
@@ -51,7 +51,9 @@ trait PgNumeric {
 
   /** `greatest(a, b, c)` — `Args` flattens to `(A1, A2, A3)` via `Where.Concat` (Void slots dropped). */
   inline def greatest[T, A1, A2, A3](
-    a: TypedExpr[T, A1], b: TypedExpr[T, A2], c: TypedExpr[T, A3]
+    a: TypedExpr[T, A1],
+    b: TypedExpr[T, A2],
+    c: TypedExpr[T, A3]
   ): TypedExpr[T, Where.Concat[Where.Concat[A1, A2], A3]] = {
     val projector: Where.Concat[Where.Concat[A1, A2], A3] => List[Any] = combined => {
       val (a12, a3v) = Where.projectConcat[Where.Concat[A1, A2], A3](combined)
@@ -59,41 +61,65 @@ trait PgNumeric {
       List(a1v, a2v, a3v)
     }
     val combined = TypedExpr.combineList[Where.Concat[Where.Concat[A1, A2], A3]](
-      List(a.fragment, b.fragment, c.fragment), ", ", projector
+      List(a.fragment, b.fragment, c.fragment),
+      ", ",
+      projector
     )
     val frag = TypedExpr.wrap("greatest(", combined, ")")
     TypedExpr[T, Where.Concat[Where.Concat[A1, A2], A3]](frag, a.codec)
   }
 
-  /** `greatest(a, b, c, d)` — `Args` flattens to the non-Void slots of `(A1, A2, A3, A4)` via `Where.Concat`.  */
+  /** `greatest(a, b, c, d)` — `Args` flattens to the non-Void slots of `(A1, A2, A3, A4)` via `Where.Concat`. */
   inline def greatest[T, A1, A2, A3, A4](
-    a: TypedExpr[T, A1], b: TypedExpr[T, A2], c: TypedExpr[T, A3], d: TypedExpr[T, A4]
+    a: TypedExpr[T, A1],
+    b: TypedExpr[T, A2],
+    c: TypedExpr[T, A3],
+    d: TypedExpr[T, A4]
   ): TypedExpr[T, Where.FoldConcat[A1 *: A2 *: A3 *: A4 *: EmptyTuple]] =
     PgFunction.naryTypedFold[T, A1 *: A2 *: A3 *: A4 *: EmptyTuple](
-      "greatest", List(a.fragment, b.fragment, c.fragment, d.fragment), a.codec
+      "greatest",
+      List(a.fragment, b.fragment, c.fragment, d.fragment),
+      a.codec
     )
 
-  /** `greatest(a, b, c, d, e)` — `Args` flattens to the non-Void slots of `(A1…A5)` via `Where.Concat`.  */
+  /** `greatest(a, b, c, d, e)` — `Args` flattens to the non-Void slots of `(A1…A5)` via `Where.Concat`. */
   inline def greatest[T, A1, A2, A3, A4, A5](
-    a: TypedExpr[T, A1], b: TypedExpr[T, A2], c: TypedExpr[T, A3], d: TypedExpr[T, A4], e: TypedExpr[T, A5]
+    a: TypedExpr[T, A1],
+    b: TypedExpr[T, A2],
+    c: TypedExpr[T, A3],
+    d: TypedExpr[T, A4],
+    e: TypedExpr[T, A5]
   ): TypedExpr[T, Where.FoldConcat[A1 *: A2 *: A3 *: A4 *: A5 *: EmptyTuple]] =
     PgFunction.naryTypedFold[T, A1 *: A2 *: A3 *: A4 *: A5 *: EmptyTuple](
-      "greatest", List(a.fragment, b.fragment, c.fragment, d.fragment, e.fragment), a.codec
+      "greatest",
+      List(a.fragment, b.fragment, c.fragment, d.fragment, e.fragment),
+      a.codec
     )
 
-  /** `greatest(a, b, c, d, e, f)` — `Args` flattens to the non-Void slots of `(A1…A6)` via `Where.Concat`.  */
+  /** `greatest(a, b, c, d, e, f)` — `Args` flattens to the non-Void slots of `(A1…A6)` via `Where.Concat`. */
   inline def greatest[T, A1, A2, A3, A4, A5, A6](
-    a: TypedExpr[T, A1], b: TypedExpr[T, A2], c: TypedExpr[T, A3], d: TypedExpr[T, A4],
-    e: TypedExpr[T, A5], f: TypedExpr[T, A6]
+    a: TypedExpr[T, A1],
+    b: TypedExpr[T, A2],
+    c: TypedExpr[T, A3],
+    d: TypedExpr[T, A4],
+    e: TypedExpr[T, A5],
+    f: TypedExpr[T, A6]
   ): TypedExpr[T, Where.FoldConcat[A1 *: A2 *: A3 *: A4 *: A5 *: A6 *: EmptyTuple]] =
     PgFunction.naryTypedFold[T, A1 *: A2 *: A3 *: A4 *: A5 *: A6 *: EmptyTuple](
-      "greatest", List(a.fragment, b.fragment, c.fragment, d.fragment, e.fragment, f.fragment), a.codec
+      "greatest",
+      List(a.fragment, b.fragment, c.fragment, d.fragment, e.fragment, f.fragment),
+      a.codec
     )
 
-  /** `greatest(a, b, c, d, e, f, g)` — `Args` flattens to the non-Void slots of `(A1…A7)` via `Where.Concat`.  */
+  /** `greatest(a, b, c, d, e, f, g)` — `Args` flattens to the non-Void slots of `(A1…A7)` via `Where.Concat`. */
   inline def greatest[T, A1, A2, A3, A4, A5, A6, A7](
-    a: TypedExpr[T, A1], b: TypedExpr[T, A2], c: TypedExpr[T, A3], d: TypedExpr[T, A4],
-    e: TypedExpr[T, A5], f: TypedExpr[T, A6], g: TypedExpr[T, A7]
+    a: TypedExpr[T, A1],
+    b: TypedExpr[T, A2],
+    c: TypedExpr[T, A3],
+    d: TypedExpr[T, A4],
+    e: TypedExpr[T, A5],
+    f: TypedExpr[T, A6],
+    g: TypedExpr[T, A7]
   ): TypedExpr[T, Where.FoldConcat[A1 *: A2 *: A3 *: A4 *: A5 *: A6 *: A7 *: EmptyTuple]] =
     PgFunction.naryTypedFold[T, A1 *: A2 *: A3 *: A4 *: A5 *: A6 *: A7 *: EmptyTuple](
       "greatest",
@@ -101,10 +127,16 @@ trait PgNumeric {
       a.codec
     )
 
-  /** `greatest(a, b, c, d, e, f, g, h)` — `Args` flattens to the non-Void slots of `(A1…A8)` via `Where.Concat`.  */
+  /** `greatest(a, b, c, d, e, f, g, h)` — `Args` flattens to the non-Void slots of `(A1…A8)` via `Where.Concat`. */
   inline def greatest[T, A1, A2, A3, A4, A5, A6, A7, A8](
-    a: TypedExpr[T, A1], b: TypedExpr[T, A2], c: TypedExpr[T, A3], d: TypedExpr[T, A4],
-    e: TypedExpr[T, A5], f: TypedExpr[T, A6], g: TypedExpr[T, A7], h: TypedExpr[T, A8]
+    a: TypedExpr[T, A1],
+    b: TypedExpr[T, A2],
+    c: TypedExpr[T, A3],
+    d: TypedExpr[T, A4],
+    e: TypedExpr[T, A5],
+    f: TypedExpr[T, A6],
+    g: TypedExpr[T, A7],
+    h: TypedExpr[T, A8]
   ): TypedExpr[T, Where.FoldConcat[A1 *: A2 *: A3 *: A4 *: A5 *: A6 *: A7 *: A8 *: EmptyTuple]] =
     PgFunction.naryTypedFold[T, A1 *: A2 *: A3 *: A4 *: A5 *: A6 *: A7 *: A8 *: EmptyTuple](
       "greatest",
@@ -112,10 +144,17 @@ trait PgNumeric {
       a.codec
     )
 
-  /** `greatest(a, b, c, d, e, f, g, h, i)` — `Args` flattens to the non-Void slots of `(A1…A9)` via `Where.Concat`.  */
+  /** `greatest(a, b, c, d, e, f, g, h, i)` — `Args` flattens to the non-Void slots of `(A1…A9)` via `Where.Concat`. */
   inline def greatest[T, A1, A2, A3, A4, A5, A6, A7, A8, A9](
-    a: TypedExpr[T, A1], b: TypedExpr[T, A2], c: TypedExpr[T, A3], d: TypedExpr[T, A4],
-    e: TypedExpr[T, A5], f: TypedExpr[T, A6], g: TypedExpr[T, A7], h: TypedExpr[T, A8], i: TypedExpr[T, A9]
+    a: TypedExpr[T, A1],
+    b: TypedExpr[T, A2],
+    c: TypedExpr[T, A3],
+    d: TypedExpr[T, A4],
+    e: TypedExpr[T, A5],
+    f: TypedExpr[T, A6],
+    g: TypedExpr[T, A7],
+    h: TypedExpr[T, A8],
+    i: TypedExpr[T, A9]
   ): TypedExpr[T, Where.FoldConcat[A1 *: A2 *: A3 *: A4 *: A5 *: A6 *: A7 *: A8 *: A9 *: EmptyTuple]] =
     PgFunction.naryTypedFold[T, A1 *: A2 *: A3 *: A4 *: A5 *: A6 *: A7 *: A8 *: A9 *: EmptyTuple](
       "greatest",
@@ -138,7 +177,9 @@ trait PgNumeric {
 
   /** `least(a, b, c)` — `Args` flattens to `(A1, A2, A3)` via `Where.Concat` (Void slots dropped). */
   inline def least[T, A1, A2, A3](
-    a: TypedExpr[T, A1], b: TypedExpr[T, A2], c: TypedExpr[T, A3]
+    a: TypedExpr[T, A1],
+    b: TypedExpr[T, A2],
+    c: TypedExpr[T, A3]
   ): TypedExpr[T, Where.Concat[Where.Concat[A1, A2], A3]] = {
     val projector: Where.Concat[Where.Concat[A1, A2], A3] => List[Any] = combined => {
       val (a12, a3v) = Where.projectConcat[Where.Concat[A1, A2], A3](combined)
@@ -146,41 +187,65 @@ trait PgNumeric {
       List(a1v, a2v, a3v)
     }
     val combined = TypedExpr.combineList[Where.Concat[Where.Concat[A1, A2], A3]](
-      List(a.fragment, b.fragment, c.fragment), ", ", projector
+      List(a.fragment, b.fragment, c.fragment),
+      ", ",
+      projector
     )
     val frag = TypedExpr.wrap("least(", combined, ")")
     TypedExpr[T, Where.Concat[Where.Concat[A1, A2], A3]](frag, a.codec)
   }
 
-  /** `least(a, b, c, d)` — `Args` flattens to the non-Void slots of `(A1, A2, A3, A4)` via `Where.Concat`.  */
+  /** `least(a, b, c, d)` — `Args` flattens to the non-Void slots of `(A1, A2, A3, A4)` via `Where.Concat`. */
   inline def least[T, A1, A2, A3, A4](
-    a: TypedExpr[T, A1], b: TypedExpr[T, A2], c: TypedExpr[T, A3], d: TypedExpr[T, A4]
+    a: TypedExpr[T, A1],
+    b: TypedExpr[T, A2],
+    c: TypedExpr[T, A3],
+    d: TypedExpr[T, A4]
   ): TypedExpr[T, Where.FoldConcat[A1 *: A2 *: A3 *: A4 *: EmptyTuple]] =
     PgFunction.naryTypedFold[T, A1 *: A2 *: A3 *: A4 *: EmptyTuple](
-      "least", List(a.fragment, b.fragment, c.fragment, d.fragment), a.codec
+      "least",
+      List(a.fragment, b.fragment, c.fragment, d.fragment),
+      a.codec
     )
 
-  /** `least(a, b, c, d, e)` — `Args` flattens to the non-Void slots of `(A1…A5)` via `Where.Concat`.  */
+  /** `least(a, b, c, d, e)` — `Args` flattens to the non-Void slots of `(A1…A5)` via `Where.Concat`. */
   inline def least[T, A1, A2, A3, A4, A5](
-    a: TypedExpr[T, A1], b: TypedExpr[T, A2], c: TypedExpr[T, A3], d: TypedExpr[T, A4], e: TypedExpr[T, A5]
+    a: TypedExpr[T, A1],
+    b: TypedExpr[T, A2],
+    c: TypedExpr[T, A3],
+    d: TypedExpr[T, A4],
+    e: TypedExpr[T, A5]
   ): TypedExpr[T, Where.FoldConcat[A1 *: A2 *: A3 *: A4 *: A5 *: EmptyTuple]] =
     PgFunction.naryTypedFold[T, A1 *: A2 *: A3 *: A4 *: A5 *: EmptyTuple](
-      "least", List(a.fragment, b.fragment, c.fragment, d.fragment, e.fragment), a.codec
+      "least",
+      List(a.fragment, b.fragment, c.fragment, d.fragment, e.fragment),
+      a.codec
     )
 
-  /** `least(a, b, c, d, e, f)` — `Args` flattens to the non-Void slots of `(A1…A6)` via `Where.Concat`.  */
+  /** `least(a, b, c, d, e, f)` — `Args` flattens to the non-Void slots of `(A1…A6)` via `Where.Concat`. */
   inline def least[T, A1, A2, A3, A4, A5, A6](
-    a: TypedExpr[T, A1], b: TypedExpr[T, A2], c: TypedExpr[T, A3], d: TypedExpr[T, A4],
-    e: TypedExpr[T, A5], f: TypedExpr[T, A6]
+    a: TypedExpr[T, A1],
+    b: TypedExpr[T, A2],
+    c: TypedExpr[T, A3],
+    d: TypedExpr[T, A4],
+    e: TypedExpr[T, A5],
+    f: TypedExpr[T, A6]
   ): TypedExpr[T, Where.FoldConcat[A1 *: A2 *: A3 *: A4 *: A5 *: A6 *: EmptyTuple]] =
     PgFunction.naryTypedFold[T, A1 *: A2 *: A3 *: A4 *: A5 *: A6 *: EmptyTuple](
-      "least", List(a.fragment, b.fragment, c.fragment, d.fragment, e.fragment, f.fragment), a.codec
+      "least",
+      List(a.fragment, b.fragment, c.fragment, d.fragment, e.fragment, f.fragment),
+      a.codec
     )
 
-  /** `least(a, b, c, d, e, f, g)` — `Args` flattens to the non-Void slots of `(A1…A7)` via `Where.Concat`.  */
+  /** `least(a, b, c, d, e, f, g)` — `Args` flattens to the non-Void slots of `(A1…A7)` via `Where.Concat`. */
   inline def least[T, A1, A2, A3, A4, A5, A6, A7](
-    a: TypedExpr[T, A1], b: TypedExpr[T, A2], c: TypedExpr[T, A3], d: TypedExpr[T, A4],
-    e: TypedExpr[T, A5], f: TypedExpr[T, A6], g: TypedExpr[T, A7]
+    a: TypedExpr[T, A1],
+    b: TypedExpr[T, A2],
+    c: TypedExpr[T, A3],
+    d: TypedExpr[T, A4],
+    e: TypedExpr[T, A5],
+    f: TypedExpr[T, A6],
+    g: TypedExpr[T, A7]
   ): TypedExpr[T, Where.FoldConcat[A1 *: A2 *: A3 *: A4 *: A5 *: A6 *: A7 *: EmptyTuple]] =
     PgFunction.naryTypedFold[T, A1 *: A2 *: A3 *: A4 *: A5 *: A6 *: A7 *: EmptyTuple](
       "least",
@@ -188,10 +253,16 @@ trait PgNumeric {
       a.codec
     )
 
-  /** `least(a, b, c, d, e, f, g, h)` — `Args` flattens to the non-Void slots of `(A1…A8)` via `Where.Concat`.  */
+  /** `least(a, b, c, d, e, f, g, h)` — `Args` flattens to the non-Void slots of `(A1…A8)` via `Where.Concat`. */
   inline def least[T, A1, A2, A3, A4, A5, A6, A7, A8](
-    a: TypedExpr[T, A1], b: TypedExpr[T, A2], c: TypedExpr[T, A3], d: TypedExpr[T, A4],
-    e: TypedExpr[T, A5], f: TypedExpr[T, A6], g: TypedExpr[T, A7], h: TypedExpr[T, A8]
+    a: TypedExpr[T, A1],
+    b: TypedExpr[T, A2],
+    c: TypedExpr[T, A3],
+    d: TypedExpr[T, A4],
+    e: TypedExpr[T, A5],
+    f: TypedExpr[T, A6],
+    g: TypedExpr[T, A7],
+    h: TypedExpr[T, A8]
   ): TypedExpr[T, Where.FoldConcat[A1 *: A2 *: A3 *: A4 *: A5 *: A6 *: A7 *: A8 *: EmptyTuple]] =
     PgFunction.naryTypedFold[T, A1 *: A2 *: A3 *: A4 *: A5 *: A6 *: A7 *: A8 *: EmptyTuple](
       "least",
@@ -199,10 +270,17 @@ trait PgNumeric {
       a.codec
     )
 
-  /** `least(a, b, c, d, e, f, g, h, i)` — `Args` flattens to the non-Void slots of `(A1…A9)` via `Where.Concat`.  */
+  /** `least(a, b, c, d, e, f, g, h, i)` — `Args` flattens to the non-Void slots of `(A1…A9)` via `Where.Concat`. */
   inline def least[T, A1, A2, A3, A4, A5, A6, A7, A8, A9](
-    a: TypedExpr[T, A1], b: TypedExpr[T, A2], c: TypedExpr[T, A3], d: TypedExpr[T, A4],
-    e: TypedExpr[T, A5], f: TypedExpr[T, A6], g: TypedExpr[T, A7], h: TypedExpr[T, A8], i: TypedExpr[T, A9]
+    a: TypedExpr[T, A1],
+    b: TypedExpr[T, A2],
+    c: TypedExpr[T, A3],
+    d: TypedExpr[T, A4],
+    e: TypedExpr[T, A5],
+    f: TypedExpr[T, A6],
+    g: TypedExpr[T, A7],
+    h: TypedExpr[T, A8],
+    i: TypedExpr[T, A9]
   ): TypedExpr[T, Where.FoldConcat[A1 *: A2 *: A3 *: A4 *: A5 *: A6 *: A7 *: A8 *: A9 *: EmptyTuple]] =
     PgFunction.naryTypedFold[T, A1 *: A2 *: A3 *: A4 *: A5 *: A6 *: A7 *: A8 *: A9 *: EmptyTuple](
       "least",
@@ -212,7 +290,8 @@ trait PgNumeric {
 
   // -------- Fixed `Double` return (NULL-propagating) ---------------------------------------------
 
-  def sqrt[T, A](e: TypedExpr[T, A])(using PgTypeFor[Lift[T, Double]]): TypedExpr[Lift[T, Double], A] = doubleFn("sqrt", e)
+  def sqrt[T, A](e: TypedExpr[T, A])(using PgTypeFor[Lift[T, Double]]): TypedExpr[Lift[T, Double], A] =
+    doubleFn("sqrt", e)
 
   inline def power[A, B, AA, BA](a: TypedExpr[A, AA], b: TypedExpr[B, BA])(using
     pf: PgTypeFor[Lift[A, Double]]
@@ -222,13 +301,17 @@ trait PgNumeric {
     TypedExpr[Lift[A, Double], Where.Concat[AA, BA]](frag, pf.codec)
   }
 
-  def exp[T, A](e: TypedExpr[T, A])(using PgTypeFor[Lift[T, Double]]): TypedExpr[Lift[T, Double], A] = doubleFn("exp", e)
-  def ln[T, A](e: TypedExpr[T, A])(using PgTypeFor[Lift[T, Double]]):  TypedExpr[Lift[T, Double], A] = doubleFn("ln", e)
-  def log[T, A](e: TypedExpr[T, A])(using PgTypeFor[Lift[T, Double]]): TypedExpr[Lift[T, Double], A] = doubleFn("log", e)
+  def exp[T, A](e: TypedExpr[T, A])(using PgTypeFor[Lift[T, Double]]): TypedExpr[Lift[T, Double], A] =
+    doubleFn("exp", e)
+
+  def ln[T, A](e: TypedExpr[T, A])(using PgTypeFor[Lift[T, Double]]): TypedExpr[Lift[T, Double], A] = doubleFn("ln", e)
+
+  def log[T, A](e: TypedExpr[T, A])(using PgTypeFor[Lift[T, Double]]): TypedExpr[Lift[T, Double], A] =
+    doubleFn("log", e)
 
   // -------- Constants ----------------------------------------------------------------------------
 
-  val pi: TypedExpr[Double, Void]     = TypedExpr(TypedExpr.voidFragment("pi()"),     skunk.codec.all.float8)
+  val pi: TypedExpr[Double, Void]     = TypedExpr(TypedExpr.voidFragment("pi()"), skunk.codec.all.float8)
   val random: TypedExpr[Double, Void] = TypedExpr(TypedExpr.voidFragment("random()"), skunk.codec.all.float8)
 
   // -------- Sign ---------------------------------------------------------------------------------
@@ -237,17 +320,31 @@ trait PgNumeric {
 
   // -------- Degree / radian conversion ----------------------------------------------------------
 
-  def degrees[T, A](e: TypedExpr[T, A])(using PgTypeFor[Lift[T, Double]]): TypedExpr[Lift[T, Double], A] = doubleFn("degrees", e)
-  def radians[T, A](e: TypedExpr[T, A])(using PgTypeFor[Lift[T, Double]]): TypedExpr[Lift[T, Double], A] = doubleFn("radians", e)
+  def degrees[T, A](e: TypedExpr[T, A])(using PgTypeFor[Lift[T, Double]]): TypedExpr[Lift[T, Double], A] =
+    doubleFn("degrees", e)
+
+  def radians[T, A](e: TypedExpr[T, A])(using PgTypeFor[Lift[T, Double]]): TypedExpr[Lift[T, Double], A] =
+    doubleFn("radians", e)
 
   // -------- Trigonometric (return Double, NULL-propagating) -------------------------------------
 
-  def sin[T, A](e: TypedExpr[T, A])(using PgTypeFor[Lift[T, Double]]):  TypedExpr[Lift[T, Double], A] = doubleFn("sin", e)
-  def cos[T, A](e: TypedExpr[T, A])(using PgTypeFor[Lift[T, Double]]):  TypedExpr[Lift[T, Double], A] = doubleFn("cos", e)
-  def tan[T, A](e: TypedExpr[T, A])(using PgTypeFor[Lift[T, Double]]):  TypedExpr[Lift[T, Double], A] = doubleFn("tan", e)
-  def asin[T, A](e: TypedExpr[T, A])(using PgTypeFor[Lift[T, Double]]): TypedExpr[Lift[T, Double], A] = doubleFn("asin", e)
-  def acos[T, A](e: TypedExpr[T, A])(using PgTypeFor[Lift[T, Double]]): TypedExpr[Lift[T, Double], A] = doubleFn("acos", e)
-  def atan[T, A](e: TypedExpr[T, A])(using PgTypeFor[Lift[T, Double]]): TypedExpr[Lift[T, Double], A] = doubleFn("atan", e)
+  def sin[T, A](e: TypedExpr[T, A])(using PgTypeFor[Lift[T, Double]]): TypedExpr[Lift[T, Double], A] =
+    doubleFn("sin", e)
+
+  def cos[T, A](e: TypedExpr[T, A])(using PgTypeFor[Lift[T, Double]]): TypedExpr[Lift[T, Double], A] =
+    doubleFn("cos", e)
+
+  def tan[T, A](e: TypedExpr[T, A])(using PgTypeFor[Lift[T, Double]]): TypedExpr[Lift[T, Double], A] =
+    doubleFn("tan", e)
+
+  def asin[T, A](e: TypedExpr[T, A])(using PgTypeFor[Lift[T, Double]]): TypedExpr[Lift[T, Double], A] =
+    doubleFn("asin", e)
+
+  def acos[T, A](e: TypedExpr[T, A])(using PgTypeFor[Lift[T, Double]]): TypedExpr[Lift[T, Double], A] =
+    doubleFn("acos", e)
+
+  def atan[T, A](e: TypedExpr[T, A])(using PgTypeFor[Lift[T, Double]]): TypedExpr[Lift[T, Double], A] =
+    doubleFn("atan", e)
 
   /** `atan2(y, x)` — both arms typed; combined Args. */
   inline def atan2[A, B, AA, BA](y: TypedExpr[A, AA], x: TypedExpr[B, BA])(using
@@ -260,8 +357,13 @@ trait PgNumeric {
 
   // -------- Hyperbolic --------------------------------------------------------------------------
 
-  def sinh[T, A](e: TypedExpr[T, A])(using PgTypeFor[Lift[T, Double]]): TypedExpr[Lift[T, Double], A] = doubleFn("sinh", e)
-  def cosh[T, A](e: TypedExpr[T, A])(using PgTypeFor[Lift[T, Double]]): TypedExpr[Lift[T, Double], A] = doubleFn("cosh", e)
-  def tanh[T, A](e: TypedExpr[T, A])(using PgTypeFor[Lift[T, Double]]): TypedExpr[Lift[T, Double], A] = doubleFn("tanh", e)
+  def sinh[T, A](e: TypedExpr[T, A])(using PgTypeFor[Lift[T, Double]]): TypedExpr[Lift[T, Double], A] =
+    doubleFn("sinh", e)
+
+  def cosh[T, A](e: TypedExpr[T, A])(using PgTypeFor[Lift[T, Double]]): TypedExpr[Lift[T, Double], A] =
+    doubleFn("cosh", e)
+
+  def tanh[T, A](e: TypedExpr[T, A])(using PgTypeFor[Lift[T, Double]]): TypedExpr[Lift[T, Double], A] =
+    doubleFn("tanh", e)
 
 }

--- a/modules/core/src/main/scala/skunk/sharp/pg/functions/PgRange.scala
+++ b/modules/core/src/main/scala/skunk/sharp/pg/functions/PgRange.scala
@@ -1,6 +1,5 @@
 package skunk.sharp.pg.functions
 
-
 import skunk.codec.all as pg
 import skunk.sharp.{PgFunction, TypedExpr}
 import skunk.sharp.pg.{IsRange, PgTypeFor}
@@ -15,12 +14,14 @@ trait PgRangeFns {
   // -------- Accessors -----------------------------------------------------------------------
 
   def rangeLower[R, E, X](r: TypedExpr[R, X])(using
-    @annotation.unused ev: IsRange.Aux[R, E], pf: PgTypeFor[Option[E]]
+    @annotation.unused ev: IsRange.Aux[R, E],
+    pf: PgTypeFor[Option[E]]
   ): TypedExpr[Option[E], X] =
     unaryRange("lower", r, pf.codec)
 
   def rangeUpper[R, E, X](r: TypedExpr[R, X])(using
-    @annotation.unused ev: IsRange.Aux[R, E], pf: PgTypeFor[Option[E]]
+    @annotation.unused ev: IsRange.Aux[R, E],
+    pf: PgTypeFor[Option[E]]
   ): TypedExpr[Option[E], X] =
     unaryRange("upper", r, pf.codec)
 
@@ -63,7 +64,11 @@ trait PgRangeFns {
     pf: PgTypeFor[PgRangeTag[BigDecimal]]
   ): TypedExpr[PgRangeTag[BigDecimal], Where.Concat[X, Y]] = rangeCtor2("numrange", lo, hi, pf.codec)
 
-  inline def numrange[X, Y, Z](lo: TypedExpr[BigDecimal, X], hi: TypedExpr[BigDecimal, Y], bounds: TypedExpr[String, Z])(using
+  inline def numrange[X, Y, Z](
+    lo: TypedExpr[BigDecimal, X],
+    hi: TypedExpr[BigDecimal, Y],
+    bounds: TypedExpr[String, Z]
+  )(using
     pf: PgTypeFor[PgRangeTag[BigDecimal]]
   ): TypedExpr[PgRangeTag[BigDecimal], Where.FoldConcat[X *: Y *: Z *: EmptyTuple]] =
     rangeCtor3("numrange", lo, hi, bounds, pf.codec)
@@ -72,7 +77,11 @@ trait PgRangeFns {
     pf: PgTypeFor[PgRangeTag[LocalDate]]
   ): TypedExpr[PgRangeTag[LocalDate], Where.Concat[X, Y]] = rangeCtor2("daterange", lo, hi, pf.codec)
 
-  inline def daterange[X, Y, Z](lo: TypedExpr[LocalDate, X], hi: TypedExpr[LocalDate, Y], bounds: TypedExpr[String, Z])(using
+  inline def daterange[X, Y, Z](
+    lo: TypedExpr[LocalDate, X],
+    hi: TypedExpr[LocalDate, Y],
+    bounds: TypedExpr[String, Z]
+  )(using
     pf: PgTypeFor[PgRangeTag[LocalDate]]
   ): TypedExpr[PgRangeTag[LocalDate], Where.FoldConcat[X *: Y *: Z *: EmptyTuple]] =
     rangeCtor3("daterange", lo, hi, bounds, pf.codec)
@@ -81,7 +90,11 @@ trait PgRangeFns {
     pf: PgTypeFor[PgRangeTag[LocalDateTime]]
   ): TypedExpr[PgRangeTag[LocalDateTime], Where.Concat[X, Y]] = rangeCtor2("tsrange", lo, hi, pf.codec)
 
-  inline def tsrange[X, Y, Z](lo: TypedExpr[LocalDateTime, X], hi: TypedExpr[LocalDateTime, Y], bounds: TypedExpr[String, Z])(using
+  inline def tsrange[X, Y, Z](
+    lo: TypedExpr[LocalDateTime, X],
+    hi: TypedExpr[LocalDateTime, Y],
+    bounds: TypedExpr[String, Z]
+  )(using
     pf: PgTypeFor[PgRangeTag[LocalDateTime]]
   ): TypedExpr[PgRangeTag[LocalDateTime], Where.FoldConcat[X *: Y *: Z *: EmptyTuple]] =
     rangeCtor3("tsrange", lo, hi, bounds, pf.codec)
@@ -90,7 +103,11 @@ trait PgRangeFns {
     pf: PgTypeFor[PgRangeTag[OffsetDateTime]]
   ): TypedExpr[PgRangeTag[OffsetDateTime], Where.Concat[X, Y]] = rangeCtor2("tstzrange", lo, hi, pf.codec)
 
-  inline def tstzrange[X, Y, Z](lo: TypedExpr[OffsetDateTime, X], hi: TypedExpr[OffsetDateTime, Y], bounds: TypedExpr[String, Z])(using
+  inline def tstzrange[X, Y, Z](
+    lo: TypedExpr[OffsetDateTime, X],
+    hi: TypedExpr[OffsetDateTime, Y],
+    bounds: TypedExpr[String, Z]
+  )(using
     pf: PgTypeFor[PgRangeTag[OffsetDateTime]]
   ): TypedExpr[PgRangeTag[OffsetDateTime], Where.FoldConcat[X *: Y *: Z *: EmptyTuple]] =
     rangeCtor3("tstzrange", lo, hi, bounds, pf.codec)
@@ -98,14 +115,19 @@ trait PgRangeFns {
   // -------- Helpers -------------------------------------------------------------------------
 
   private def unaryRange[R, X, T](
-    name: String, r: TypedExpr[R, X], outCodec: skunk.Codec[T]
+    name: String,
+    r: TypedExpr[R, X],
+    outCodec: skunk.Codec[T]
   ): TypedExpr[T, X] = {
     val frag = TypedExpr.wrap(s"$name(", r.fragment, ")")
     TypedExpr[T, X](frag, outCodec)
   }
 
   private inline def rangeCtor2[T, A, B, X, Y](
-    name: String, lo: TypedExpr[A, X], hi: TypedExpr[B, Y], outCodec: skunk.Codec[T]
+    name: String,
+    lo: TypedExpr[A, X],
+    hi: TypedExpr[B, Y],
+    outCodec: skunk.Codec[T]
   ): TypedExpr[T, Where.Concat[X, Y]] = {
     val inner = TypedExpr.combineSepInl[X, Y](lo.fragment, ", ", hi.fragment)
     val frag  = TypedExpr.wrap(s"$name(", inner, ")")
@@ -114,10 +136,16 @@ trait PgRangeFns {
 
   /** Three-arg range constructor `name(lo, hi, bounds)`. */
   private inline def rangeCtor3[T, A, B, X, Y, Z](
-    name: String, lo: TypedExpr[A, X], hi: TypedExpr[B, Y], bounds: TypedExpr[String, Z], outCodec: skunk.Codec[T]
+    name: String,
+    lo: TypedExpr[A, X],
+    hi: TypedExpr[B, Y],
+    bounds: TypedExpr[String, Z],
+    outCodec: skunk.Codec[T]
   ): TypedExpr[T, Where.FoldConcat[X *: Y *: Z *: EmptyTuple]] =
     PgFunction.naryTypedFold[T, X *: Y *: Z *: EmptyTuple](
-      name, List(lo.fragment, hi.fragment, bounds.fragment), outCodec
+      name,
+      List(lo.fragment, hi.fragment, bounds.fragment),
+      outCodec
     )
 
 }

--- a/modules/core/src/main/scala/skunk/sharp/pg/functions/PgSession.scala
+++ b/modules/core/src/main/scala/skunk/sharp/pg/functions/PgSession.scala
@@ -6,11 +6,15 @@ import skunk.sharp.TypedExpr
 /** Session / connection introspection keywords. All Args = Void (no inputs). */
 trait PgSession {
 
-  val currentUser:     TypedExpr[String, Void] = TypedExpr(TypedExpr.voidFragment("current_user"),       skunk.codec.all.text)
-  val sessionUser:     TypedExpr[String, Void] = TypedExpr(TypedExpr.voidFragment("session_user"),       skunk.codec.all.text)
-  val user:            TypedExpr[String, Void] = TypedExpr(TypedExpr.voidFragment("user"),               skunk.codec.all.text)
-  val currentSchema:   TypedExpr[String, Void] = TypedExpr(TypedExpr.voidFragment("current_schema"),     skunk.codec.all.text)
-  val currentCatalog:  TypedExpr[String, Void] = TypedExpr(TypedExpr.voidFragment("current_catalog"),    skunk.codec.all.text)
-  val currentDatabase: TypedExpr[String, Void] = TypedExpr(TypedExpr.voidFragment("current_database()"), skunk.codec.all.text)
+  val currentUser: TypedExpr[String, Void]   = TypedExpr(TypedExpr.voidFragment("current_user"), skunk.codec.all.text)
+  val sessionUser: TypedExpr[String, Void]   = TypedExpr(TypedExpr.voidFragment("session_user"), skunk.codec.all.text)
+  val user: TypedExpr[String, Void]          = TypedExpr(TypedExpr.voidFragment("user"), skunk.codec.all.text)
+  val currentSchema: TypedExpr[String, Void] = TypedExpr(TypedExpr.voidFragment("current_schema"), skunk.codec.all.text)
+
+  val currentCatalog: TypedExpr[String, Void] =
+    TypedExpr(TypedExpr.voidFragment("current_catalog"), skunk.codec.all.text)
+
+  val currentDatabase: TypedExpr[String, Void] =
+    TypedExpr(TypedExpr.voidFragment("current_database()"), skunk.codec.all.text)
 
 }

--- a/modules/core/src/main/scala/skunk/sharp/pg/functions/PgSrf.scala
+++ b/modules/core/src/main/scala/skunk/sharp/pg/functions/PgSrf.scala
@@ -29,7 +29,9 @@ private[sharp] def srfRelation1[T, N <: String & Singleton, BA](
   argsFrag: Fragment[BA],
   colName: N,
   codec0: Codec[T]
-): TypedBodyRelation[Column[T, N, false, EmptyTuple] *: EmptyTuple, BA] { type Alias = N; type Mode = AliasMode.Explicit } = {
+): TypedBodyRelation[Column[T, N, false, EmptyTuple] *: EmptyTuple, BA] {
+  type Alias = N; type Mode = AliasMode.Explicit
+} = {
   val col: Column[T, N, false, EmptyTuple] =
     Column[T, N, false, EmptyTuple](
       name = colName,
@@ -53,10 +55,10 @@ private[sharp] def srfRelation1[T, N <: String & Singleton, BA](
     val srfColumnName: String                                  = colName
 
     /**
-     * Render the SRF as a single AppliedFragment for fallback paths (cache-warming, alias-wrapping). When the
-     * args fragment has no typed parameters (`encoder.types.isEmpty`), bind args at Void inline. Typed-args
-     * SRFs (encoder has types) can only be rendered via [[skunk.sharp.dsl.aliasedFromEntryParts]] in a
-     * SELECT/JOIN source position — calling `fromFragmentWith` on them throws.
+     * Render the SRF as a single AppliedFragment for fallback paths (cache-warming, alias-wrapping). When the args
+     * fragment has no typed parameters (`encoder.types.isEmpty`), bind args at Void inline. Typed-args SRFs (encoder
+     * has types) can only be rendered via [[skunk.sharp.dsl.aliasedFromEntryParts]] in a SELECT/JOIN source position —
+     * calling `fromFragmentWith` on them throws.
      */
     override def fromFragmentWith(x: String): AppliedFragment =
       if (argsFrag.encoder.types.isEmpty) {
@@ -65,12 +67,14 @@ private[sharp] def srfRelation1[T, N <: String & Singleton, BA](
       } else
         throw new UnsupportedOperationException(
           s"skunk-sharp: SRF '$funcName' has typed args (Param[T] or other typed expressions) and can only be " +
-          s"rendered via a SELECT/JOIN source position (aliasedFromEntryParts). The fallback rendering path " +
-          s"(`fromFragmentWith` / `starProjFromAfOpt`) does not support typed args."
+            s"rendered via a SELECT/JOIN source position (aliasedFromEntryParts). The fallback rendering path " +
+            s"(`fromFragmentWith` / `starProjFromAfOpt`) does not support typed args."
         )
 
-    /** Disable the cached `starProj FROM` AppliedFragment — SRFs always carry args; the body rendering is handled
-      * by `aliasedFromEntryParts` which threads typed args through Right slots. */
+    /**
+     * Disable the cached `starProj FROM` AppliedFragment — SRFs always carry args; the body rendering is handled by
+     * `aliasedFromEntryParts` which threads typed args through Right slots.
+     */
     override lazy val starProjFromAfOpt: Option[AppliedFragment] = None
   }
 }
@@ -99,7 +103,8 @@ trait PgSrf {
 
   /** `generate_series(start, stop)` — inclusive integer range, one column `n INT` per row. */
   inline def generateSeries[A, B](
-    start: TypedExpr[Int, A], stop: TypedExpr[Int, B]
+    start: TypedExpr[Int, A],
+    stop: TypedExpr[Int, B]
   ): TypedBodyRelation[Column[Int, "n", false, EmptyTuple] *: EmptyTuple, Where.Concat[A, B]] {
     type Alias = "n"
     type Mode  = AliasMode.Explicit
@@ -110,7 +115,9 @@ trait PgSrf {
 
   /** `generate_series(start, stop, step)` — with an explicit step (positive or negative). */
   inline def generateSeries[A, B, C](
-    start: TypedExpr[Int, A], stop: TypedExpr[Int, B], step: TypedExpr[Int, C]
+    start: TypedExpr[Int, A],
+    stop: TypedExpr[Int, B],
+    step: TypedExpr[Int, C]
   ): TypedBodyRelation[Column[Int, "n", false, EmptyTuple] *: EmptyTuple, Where.Concat[Where.Concat[A, B], C]] {
     type Alias = "n"
     type Mode  = AliasMode.Explicit
@@ -123,8 +130,7 @@ trait PgSrf {
 
   /**
    * `unnest(array)` as a [[Relation]]. The array expression's typed Args thread into the outer query: pass
-   * `Param[Arr[E]]` for a deferred array, `lit(arr)` for a compile-time literal, or any other
-   * `TypedExpr[Arr[E], A]`.
+   * `Param[Arr[E]]` for a deferred array, `lit(arr)` for a compile-time literal, or any other `TypedExpr[Arr[E], A]`.
    */
   def unnestAsRelation[A, E, BA](a: TypedExpr[A, BA])(using
     @scala.annotation.unused ev: IsArray.Aux[A, E],

--- a/modules/core/src/main/scala/skunk/sharp/pg/functions/PgString.scala
+++ b/modules/core/src/main/scala/skunk/sharp/pg/functions/PgString.scala
@@ -7,20 +7,19 @@ import skunk.sharp.where.Where
 /**
  * String functions. Mixed into [[skunk.sharp.Pg]]. Args of input expression(s) propagate to result.
  *
- * Every value-arg is a `TypedExpr[T, Args]`: callers pass column refs, `Param[T]` (deferred), `lit(v)`
- * (compile-time literal), or `Param.bind(v)` (explicit bake) — same static-by-default rule the operator
- * positions enforce. The result `Args` is the smart-flat concat over every input's `Args` (see
- * [[Where.FoldConcat]]).
+ * Every value-arg is a `TypedExpr[T, Args]`: callers pass column refs, `Param[T]` (deferred), `lit(v)` (compile-time
+ * literal), or `Param.bind(v)` (explicit bake) — same static-by-default rule the operator positions enforce. The result
+ * `Args` is the smart-flat concat over every input's `Args` (see [[Where.FoldConcat]]).
  */
 trait PgString {
 
   // ---- Preserve-tag, single-arg (T -> T) -------------------------------------------------------
 
-  def lower[T, A](e: TypedExpr[T, A])(using StrLike[T]): TypedExpr[T, A]   = stringPreserveFn("lower",   e)
-  def upper[T, A](e: TypedExpr[T, A])(using StrLike[T]): TypedExpr[T, A]   = stringPreserveFn("upper",   e)
-  def trim[T, A](e: TypedExpr[T, A])(using StrLike[T]):  TypedExpr[T, A]   = stringPreserveFn("trim",    e)
-  def ltrim[T, A](e: TypedExpr[T, A])(using StrLike[T]): TypedExpr[T, A]   = stringPreserveFn("ltrim",   e)
-  def rtrim[T, A](e: TypedExpr[T, A])(using StrLike[T]): TypedExpr[T, A]   = stringPreserveFn("rtrim",   e)
+  def lower[T, A](e: TypedExpr[T, A])(using StrLike[T]): TypedExpr[T, A]   = stringPreserveFn("lower", e)
+  def upper[T, A](e: TypedExpr[T, A])(using StrLike[T]): TypedExpr[T, A]   = stringPreserveFn("upper", e)
+  def trim[T, A](e: TypedExpr[T, A])(using StrLike[T]): TypedExpr[T, A]    = stringPreserveFn("trim", e)
+  def ltrim[T, A](e: TypedExpr[T, A])(using StrLike[T]): TypedExpr[T, A]   = stringPreserveFn("ltrim", e)
+  def rtrim[T, A](e: TypedExpr[T, A])(using StrLike[T]): TypedExpr[T, A]   = stringPreserveFn("rtrim", e)
   def reverse[T, A](e: TypedExpr[T, A])(using StrLike[T]): TypedExpr[T, A] = stringPreserveFn("reverse", e)
   def initcap[T, A](e: TypedExpr[T, A])(using StrLike[T]): TypedExpr[T, A] = stringPreserveFn("initcap", e)
 
@@ -29,7 +28,7 @@ trait PgString {
   /** `trim(chars FROM s)`. */
   inline def trim[T, A1, A2](
     chars: TypedExpr[String, A1],
-    e:     TypedExpr[T, A2]
+    e: TypedExpr[T, A2]
   )(using StrLike[T]): TypedExpr[T, Where.Concat[A1, A2]] = {
     val inner = TypedExpr.combineSepInl[A1, A2](chars.fragment, " FROM ", e.fragment)
     val frag  = TypedExpr.wrap("trim(", inner, ")")
@@ -38,17 +37,19 @@ trait PgString {
 
   /** `replace(s, from, to)`. */
   inline def replace[T, A1, A2, A3](
-    e:    TypedExpr[T, A1],
+    e: TypedExpr[T, A1],
     from: TypedExpr[String, A2],
-    to:   TypedExpr[String, A3]
+    to: TypedExpr[String, A3]
   )(using StrLike[T]): TypedExpr[T, Where.FoldConcat[A1 *: A2 *: A3 *: EmptyTuple]] =
     PgFunction.naryTypedFold[T, A1 *: A2 *: A3 *: EmptyTuple](
-      "replace", List(e.fragment, from.fragment, to.fragment), e.codec
+      "replace",
+      List(e.fragment, from.fragment, to.fragment),
+      e.codec
     )
 
   /** `substring(s FROM n)`. */
   inline def substring[T, A1, A2](
-    e:    TypedExpr[T, A1],
+    e: TypedExpr[T, A1],
     from: TypedExpr[Int, A2]
   )(using StrLike[T]): TypedExpr[T, Where.Concat[A1, A2]] = {
     val inner = TypedExpr.combineSepInl[A1, A2](e.fragment, " FROM ", from.fragment)
@@ -58,12 +59,12 @@ trait PgString {
 
   /** `substring(s FROM n FOR m)`. */
   inline def substring[T, A1, A2, A3](
-    e:      TypedExpr[T, A1],
-    from:   TypedExpr[Int, A2],
+    e: TypedExpr[T, A1],
+    from: TypedExpr[Int, A2],
     forLen: TypedExpr[Int, A3]
   )(using StrLike[T]): TypedExpr[T, Where.Concat[Where.Concat[A1, A2], A3]] = {
-    val ab  = TypedExpr.combineSepInl[A1, A2](e.fragment, " FROM ", from.fragment)
-    val abc = TypedExpr.combineSepInl[Where.Concat[A1, A2], A3](ab, " FOR ", forLen.fragment)
+    val ab   = TypedExpr.combineSepInl[A1, A2](e.fragment, " FROM ", from.fragment)
+    val abc  = TypedExpr.combineSepInl[Where.Concat[A1, A2], A3](ab, " FOR ", forLen.fragment)
     val frag = TypedExpr.wrap("substring(", abc, ")")
     TypedExpr(frag, e.codec)
   }
@@ -100,22 +101,26 @@ trait PgString {
 
   /** `regexp_replace(s, pattern, replacement)`. */
   inline def regexpReplace[T, A1, A2, A3](
-    e:           TypedExpr[T, A1],
-    pattern:     TypedExpr[String, A2],
+    e: TypedExpr[T, A1],
+    pattern: TypedExpr[String, A2],
     replacement: TypedExpr[String, A3]
   )(using StrLike[T]): TypedExpr[T, Where.FoldConcat[A1 *: A2 *: A3 *: EmptyTuple]] =
     PgFunction.naryTypedFold[T, A1 *: A2 *: A3 *: EmptyTuple](
-      "regexp_replace", List(e.fragment, pattern.fragment, replacement.fragment), e.codec
+      "regexp_replace",
+      List(e.fragment, pattern.fragment, replacement.fragment),
+      e.codec
     )
 
   /** `split_part(s, delim, field)`. */
   inline def splitPart[T, A1, A2, A3](
-    e:     TypedExpr[T, A1],
+    e: TypedExpr[T, A1],
     delim: TypedExpr[String, A2],
     field: TypedExpr[Int, A3]
   )(using StrLike[T]): TypedExpr[T, Where.FoldConcat[A1 *: A2 *: A3 *: EmptyTuple]] =
     PgFunction.naryTypedFold[T, A1 *: A2 *: A3 *: EmptyTuple](
-      "split_part", List(e.fragment, delim.fragment, field.fragment), e.codec
+      "split_part",
+      List(e.fragment, delim.fragment, field.fragment),
+      e.codec
     )
 
   /** `concat(a)` — single arg; Args propagates from `a`. */
@@ -126,7 +131,8 @@ trait PgString {
 
   /** `concat(a, b)` — Args = `Concat[A1, A2]`. */
   inline def concat[A1, A2](
-    a: TypedExpr[String, A1], b: TypedExpr[String, A2]
+    a: TypedExpr[String, A1],
+    b: TypedExpr[String, A2]
   ): TypedExpr[String, Where.Concat[A1, A2]] = {
     val inner = TypedExpr.combineSepInl[A1, A2](a.fragment, ", ", b.fragment)
     val frag  = TypedExpr.wrap("concat(", inner, ")")
@@ -135,33 +141,51 @@ trait PgString {
 
   /** `concat(a, b, c)` — `Args` flattens to the non-Void slots of `(A1…A3)` via `Where.FoldConcat`. */
   inline def concat[A1, A2, A3](
-    a: TypedExpr[String, A1], b: TypedExpr[String, A2], c: TypedExpr[String, A3]
+    a: TypedExpr[String, A1],
+    b: TypedExpr[String, A2],
+    c: TypedExpr[String, A3]
   ): TypedExpr[String, Where.FoldConcat[A1 *: A2 *: A3 *: EmptyTuple]] =
     PgFunction.naryTypedFold[String, A1 *: A2 *: A3 *: EmptyTuple](
-      "concat", List(a.fragment, b.fragment, c.fragment), skunk.codec.all.text
+      "concat",
+      List(a.fragment, b.fragment, c.fragment),
+      skunk.codec.all.text
     )
 
   /** `concat(a, b, c, d)` — `Args` flattens to the non-Void slots of `(A1…A4)` via `Where.FoldConcat`. */
   inline def concat[A1, A2, A3, A4](
-    a: TypedExpr[String, A1], b: TypedExpr[String, A2], c: TypedExpr[String, A3], d: TypedExpr[String, A4]
+    a: TypedExpr[String, A1],
+    b: TypedExpr[String, A2],
+    c: TypedExpr[String, A3],
+    d: TypedExpr[String, A4]
   ): TypedExpr[String, Where.FoldConcat[A1 *: A2 *: A3 *: A4 *: EmptyTuple]] =
     PgFunction.naryTypedFold[String, A1 *: A2 *: A3 *: A4 *: EmptyTuple](
-      "concat", List(a.fragment, b.fragment, c.fragment, d.fragment), skunk.codec.all.text
+      "concat",
+      List(a.fragment, b.fragment, c.fragment, d.fragment),
+      skunk.codec.all.text
     )
 
   /** `concat(a, b, c, d, e)` — `Args` flattens to the non-Void slots of `(A1…A5)` via `Where.FoldConcat`. */
   inline def concat[A1, A2, A3, A4, A5](
-    a: TypedExpr[String, A1], b: TypedExpr[String, A2], c: TypedExpr[String, A3],
-    d: TypedExpr[String, A4], e: TypedExpr[String, A5]
+    a: TypedExpr[String, A1],
+    b: TypedExpr[String, A2],
+    c: TypedExpr[String, A3],
+    d: TypedExpr[String, A4],
+    e: TypedExpr[String, A5]
   ): TypedExpr[String, Where.FoldConcat[A1 *: A2 *: A3 *: A4 *: A5 *: EmptyTuple]] =
     PgFunction.naryTypedFold[String, A1 *: A2 *: A3 *: A4 *: A5 *: EmptyTuple](
-      "concat", List(a.fragment, b.fragment, c.fragment, d.fragment, e.fragment), skunk.codec.all.text
+      "concat",
+      List(a.fragment, b.fragment, c.fragment, d.fragment, e.fragment),
+      skunk.codec.all.text
     )
 
   /** `concat(a, b, c, d, e, f)` — `Args` flattens to the non-Void slots of `(A1…A6)` via `Where.FoldConcat`. */
   inline def concat[A1, A2, A3, A4, A5, A6](
-    a: TypedExpr[String, A1], b: TypedExpr[String, A2], c: TypedExpr[String, A3],
-    d: TypedExpr[String, A4], e: TypedExpr[String, A5], f: TypedExpr[String, A6]
+    a: TypedExpr[String, A1],
+    b: TypedExpr[String, A2],
+    c: TypedExpr[String, A3],
+    d: TypedExpr[String, A4],
+    e: TypedExpr[String, A5],
+    f: TypedExpr[String, A6]
   ): TypedExpr[String, Where.FoldConcat[A1 *: A2 *: A3 *: A4 *: A5 *: A6 *: EmptyTuple]] =
     PgFunction.naryTypedFold[String, A1 *: A2 *: A3 *: A4 *: A5 *: A6 *: EmptyTuple](
       "concat",
@@ -171,8 +195,13 @@ trait PgString {
 
   /** `concat(a, b, c, d, e, f, g)` — `Args` flattens to the non-Void slots of `(A1…A7)` via `Where.FoldConcat`. */
   inline def concat[A1, A2, A3, A4, A5, A6, A7](
-    a: TypedExpr[String, A1], b: TypedExpr[String, A2], c: TypedExpr[String, A3],
-    d: TypedExpr[String, A4], e: TypedExpr[String, A5], f: TypedExpr[String, A6], g: TypedExpr[String, A7]
+    a: TypedExpr[String, A1],
+    b: TypedExpr[String, A2],
+    c: TypedExpr[String, A3],
+    d: TypedExpr[String, A4],
+    e: TypedExpr[String, A5],
+    f: TypedExpr[String, A6],
+    g: TypedExpr[String, A7]
   ): TypedExpr[String, Where.FoldConcat[A1 *: A2 *: A3 *: A4 *: A5 *: A6 *: A7 *: EmptyTuple]] =
     PgFunction.naryTypedFold[String, A1 *: A2 *: A3 *: A4 *: A5 *: A6 *: A7 *: EmptyTuple](
       "concat",
@@ -182,8 +211,14 @@ trait PgString {
 
   /** `concat(a, b, c, d, e, f, g, h)` — `Args` flattens to the non-Void slots of `(A1…A8)` via `Where.FoldConcat`. */
   inline def concat[A1, A2, A3, A4, A5, A6, A7, A8](
-    a: TypedExpr[String, A1], b: TypedExpr[String, A2], c: TypedExpr[String, A3], d: TypedExpr[String, A4],
-    e: TypedExpr[String, A5], f: TypedExpr[String, A6], g: TypedExpr[String, A7], h: TypedExpr[String, A8]
+    a: TypedExpr[String, A1],
+    b: TypedExpr[String, A2],
+    c: TypedExpr[String, A3],
+    d: TypedExpr[String, A4],
+    e: TypedExpr[String, A5],
+    f: TypedExpr[String, A6],
+    g: TypedExpr[String, A7],
+    h: TypedExpr[String, A8]
   ): TypedExpr[String, Where.FoldConcat[A1 *: A2 *: A3 *: A4 *: A5 *: A6 *: A7 *: A8 *: EmptyTuple]] =
     PgFunction.naryTypedFold[String, A1 *: A2 *: A3 *: A4 *: A5 *: A6 *: A7 *: A8 *: EmptyTuple](
       "concat",
@@ -191,11 +226,19 @@ trait PgString {
       skunk.codec.all.text
     )
 
-  /** `concat(a, b, c, d, e, f, g, h, i)` — `Args` flattens to the non-Void slots of `(A1…A9)` via `Where.FoldConcat`. */
+  /**
+   * `concat(a, b, c, d, e, f, g, h, i)` — `Args` flattens to the non-Void slots of `(A1…A9)` via `Where.FoldConcat`.
+   */
   inline def concat[A1, A2, A3, A4, A5, A6, A7, A8, A9](
-    a: TypedExpr[String, A1], b: TypedExpr[String, A2], c: TypedExpr[String, A3], d: TypedExpr[String, A4],
-    e: TypedExpr[String, A5], f: TypedExpr[String, A6], g: TypedExpr[String, A7],
-    h: TypedExpr[String, A8], i: TypedExpr[String, A9]
+    a: TypedExpr[String, A1],
+    b: TypedExpr[String, A2],
+    c: TypedExpr[String, A3],
+    d: TypedExpr[String, A4],
+    e: TypedExpr[String, A5],
+    f: TypedExpr[String, A6],
+    g: TypedExpr[String, A7],
+    h: TypedExpr[String, A8],
+    i: TypedExpr[String, A9]
   ): TypedExpr[String, Where.FoldConcat[A1 *: A2 *: A3 *: A4 *: A5 *: A6 *: A7 *: A8 *: A9 *: EmptyTuple]] =
     PgFunction.naryTypedFold[String, A1 *: A2 *: A3 *: A4 *: A5 *: A6 *: A7 *: A8 *: A9 *: EmptyTuple](
       "concat",
@@ -208,16 +251,22 @@ trait PgString {
   def length[T, A](e: TypedExpr[T, A])(using ev: StrLike[T], pf: PgTypeFor[Lift[T, Int]]): TypedExpr[Lift[T, Int], A] =
     stringToIntFn("length", e)
 
-  def charLength[T, A](e: TypedExpr[T, A])(using ev: StrLike[T], pf: PgTypeFor[Lift[T, Int]]): TypedExpr[Lift[T, Int], A] =
+  def charLength[T, A](e: TypedExpr[T, A])(using
+    ev: StrLike[T],
+    pf: PgTypeFor[Lift[T, Int]]
+  ): TypedExpr[Lift[T, Int], A] =
     stringToIntFn("char_length", e)
 
-  def octetLength[T, A](e: TypedExpr[T, A])(using ev: StrLike[T], pf: PgTypeFor[Lift[T, Int]]): TypedExpr[Lift[T, Int], A] =
+  def octetLength[T, A](e: TypedExpr[T, A])(using
+    ev: StrLike[T],
+    pf: PgTypeFor[Lift[T, Int]]
+  ): TypedExpr[Lift[T, Int], A] =
     stringToIntFn("octet_length", e)
 
   /** `position(substr IN str)` — nullability tracked via Lift on `in`. */
   inline def position[T, A1, A2](
     substr: TypedExpr[String, A1],
-    in:     TypedExpr[T, A2]
+    in: TypedExpr[T, A2]
   )(using ev: StrLike[T], pf: PgTypeFor[Lift[T, Int]]): TypedExpr[Lift[T, Int], Where.Concat[A1, A2]] = {
     val inner = TypedExpr.combineSepInl[A1, A2](substr.fragment, " IN ", in.fragment)
     val frag  = TypedExpr.wrap("position(", inner, ")")
@@ -228,12 +277,14 @@ trait PgString {
 
   /** `translate(s, from, to)`. */
   inline def translate[T, A1, A2, A3](
-    e:    TypedExpr[T, A1],
+    e: TypedExpr[T, A1],
     from: TypedExpr[String, A2],
-    to:   TypedExpr[String, A3]
+    to: TypedExpr[String, A3]
   )(using StrLike[T]): TypedExpr[T, Where.FoldConcat[A1 *: A2 *: A3 *: EmptyTuple]] =
     PgFunction.naryTypedFold[T, A1 *: A2 *: A3 *: EmptyTuple](
-      "translate", List(e.fragment, from.fragment, to.fragment), e.codec
+      "translate",
+      List(e.fragment, from.fragment, to.fragment),
+      e.codec
     )
 
   /** `lpad(s, n)`. */
@@ -248,12 +299,14 @@ trait PgString {
 
   /** `lpad(s, n, fill)`. */
   inline def lpad[T, A1, A2, A3](
-    e:    TypedExpr[T, A1],
-    n:    TypedExpr[Int, A2],
+    e: TypedExpr[T, A1],
+    n: TypedExpr[Int, A2],
     fill: TypedExpr[String, A3]
   )(using StrLike[T]): TypedExpr[T, Where.FoldConcat[A1 *: A2 *: A3 *: EmptyTuple]] =
     PgFunction.naryTypedFold[T, A1 *: A2 *: A3 *: EmptyTuple](
-      "lpad", List(e.fragment, n.fragment, fill.fragment), e.codec
+      "lpad",
+      List(e.fragment, n.fragment, fill.fragment),
+      e.codec
     )
 
   /** `rpad(s, n)`. */
@@ -268,17 +321,22 @@ trait PgString {
 
   /** `rpad(s, n, fill)`. */
   inline def rpad[T, A1, A2, A3](
-    e:    TypedExpr[T, A1],
-    n:    TypedExpr[Int, A2],
+    e: TypedExpr[T, A1],
+    n: TypedExpr[Int, A2],
     fill: TypedExpr[String, A3]
   )(using StrLike[T]): TypedExpr[T, Where.FoldConcat[A1 *: A2 *: A3 *: EmptyTuple]] =
     PgFunction.naryTypedFold[T, A1 *: A2 *: A3 *: EmptyTuple](
-      "rpad", List(e.fragment, n.fragment, fill.fragment), e.codec
+      "rpad",
+      List(e.fragment, n.fragment, fill.fragment),
+      e.codec
     )
 
   // ---- Fixed text return (NULL-propagating via Lift) ------------------------------------------
 
-  def md5[T, A](e: TypedExpr[T, A])(using ev: StrLike[T], pf: PgTypeFor[Lift[T, String]]): TypedExpr[Lift[T, String], A] = {
+  def md5[T, A](e: TypedExpr[T, A])(using
+    ev: StrLike[T],
+    pf: PgTypeFor[Lift[T, String]]
+  ): TypedExpr[Lift[T, String], A] = {
     val frag = TypedExpr.wrap("md5(", e.fragment, ")")
     TypedExpr[Lift[T, String], A](frag, pf.codec)
   }
@@ -290,7 +348,7 @@ trait PgString {
 
   /** `to_char(e, fmt)` — result is `Lift[T, String]`. */
   inline def toChar[T, A1, A2](
-    e:   TypedExpr[T, A1],
+    e: TypedExpr[T, A1],
     fmt: TypedExpr[String, A2]
   )(using pf: PgTypeFor[Lift[T, String]]): TypedExpr[Lift[T, String], Where.Concat[A1, A2]] = {
     val inner = TypedExpr.combineSepInl[A1, A2](e.fragment, ", ", fmt.fragment)
@@ -300,9 +358,8 @@ trait PgString {
 
   /**
    * `format(fmt, args*)` — variadic. Result `Args = Void`: every input is treated as Void-args by
-   * [[TypedExpr.joinedVoid]], so any `Param[T]` baked into a spliced fragment must already be a
-   * `Param.bind`-style Void-args fragment. Threading typed `Args` through the variadic shape is a
-   * roadmap item.
+   * [[TypedExpr.joinedVoid]], so any `Param[T]` baked into a spliced fragment must already be a `Param.bind`-style
+   * Void-args fragment. Threading typed `Args` through the variadic shape is a roadmap item.
    */
   def format(fmt: TypedExpr[String, ?], args: TypedExpr[?, ?]*): TypedExpr[String, skunk.Void] = {
     val joined = TypedExpr.joinedVoid(", ", fmt.fragment :: args.toList.map(_.fragment))
@@ -319,7 +376,7 @@ trait PgString {
 
   /** `to_number(e, fmt)`. */
   inline def toNumber[T, A1, A2](
-    e:   TypedExpr[T, A1],
+    e: TypedExpr[T, A1],
     fmt: TypedExpr[String, A2]
   )(using ev: StrLike[T], pf: PgTypeFor[Lift[T, BigDecimal]]): TypedExpr[Lift[T, BigDecimal], Where.Concat[A1, A2]] = {
     val inner = TypedExpr.combineSepInl[A1, A2](e.fragment, ", ", fmt.fragment)

--- a/modules/core/src/main/scala/skunk/sharp/pg/functions/PgTime.scala
+++ b/modules/core/src/main/scala/skunk/sharp/pg/functions/PgTime.scala
@@ -12,29 +12,39 @@ trait PgTime {
 
   val now: TypedExpr[OffsetDateTime, Void] = PgFunction.nullary[OffsetDateTime]("now")
 
-  val currentTimestamp: TypedExpr[OffsetDateTime, Void] = TypedExpr(TypedExpr.voidFragment("current_timestamp"), skunk.codec.all.timestamptz)
-  val currentDate:      TypedExpr[LocalDate, Void]      = TypedExpr(TypedExpr.voidFragment("current_date"),      skunk.codec.all.date)
-  val currentTime:      TypedExpr[OffsetTime, Void]     = TypedExpr(TypedExpr.voidFragment("current_time"),      skunk.codec.all.timetz)
-  val localTimestamp:   TypedExpr[LocalDateTime, Void]  = TypedExpr(TypedExpr.voidFragment("localtimestamp"),    skunk.codec.all.timestamp)
-  val localTime:        TypedExpr[LocalTime, Void]      = TypedExpr(TypedExpr.voidFragment("localtime"),         skunk.codec.all.time)
+  val currentTimestamp: TypedExpr[OffsetDateTime, Void] =
+    TypedExpr(TypedExpr.voidFragment("current_timestamp"), skunk.codec.all.timestamptz)
+
+  val currentDate: TypedExpr[LocalDate, Void] = TypedExpr(TypedExpr.voidFragment("current_date"), skunk.codec.all.date)
+
+  val currentTime: TypedExpr[OffsetTime, Void] =
+    TypedExpr(TypedExpr.voidFragment("current_time"), skunk.codec.all.timetz)
+
+  val localTimestamp: TypedExpr[LocalDateTime, Void] =
+    TypedExpr(TypedExpr.voidFragment("localtimestamp"), skunk.codec.all.timestamp)
+
+  val localTime: TypedExpr[LocalTime, Void] = TypedExpr(TypedExpr.voidFragment("localtime"), skunk.codec.all.time)
 
   /**
    * `(aStart, aEnd) OVERLAPS (bStart, bEnd)` — 4 typed positions; `Args` flattens to the non-Void slots of
-   * `(A1, A2, A3, A4)` via `Where.Concat`. Custom separator pattern (`, ` inside each pair,
-   * `) OVERLAPS (` between pairs) is handled by manually constructing the parts list while still
-   * delegating slot dispatch to a per-position projector.
+   * `(A1, A2, A3, A4)` via `Where.Concat`. Custom separator pattern (`, ` inside each pair, `) OVERLAPS (` between
+   * pairs) is handled by manually constructing the parts list while still delegating slot dispatch to a per-position
+   * projector.
    */
   inline def overlaps[T, A1, A2, A3, A4](
-    aStart: TypedExpr[T, A1], aEnd: TypedExpr[T, A2], bStart: TypedExpr[T, A3], bEnd: TypedExpr[T, A4]
+    aStart: TypedExpr[T, A1],
+    aEnd: TypedExpr[T, A2],
+    bStart: TypedExpr[T, A3],
+    bEnd: TypedExpr[T, A4]
   ): Where[Where.Concat[Where.Concat[Where.Concat[A1, A2], A3], A4]] = {
-    type Out  = Where.Concat[Where.Concat[Where.Concat[A1, A2], A3], A4]
+    type Out = Where.Concat[Where.Concat[Where.Concat[A1, A2], A3], A4]
     val items = List(aStart.fragment, aEnd.fragment, bStart.fragment, bEnd.fragment)
 
     val sep        = Left(", "): Either[String, cats.data.State[Int, String]]
     val openParen  = Left("("): Either[String, cats.data.State[Int, String]]
     val pairBreak  = Left(") OVERLAPS ("): Either[String, cats.data.State[Int, String]]
     val closeParen = Left(")"): Either[String, cats.data.State[Int, String]]
-    val parts =
+    val parts      =
       List(openParen) ++ aStart.fragment.parts ++
         List(sep) ++ aEnd.fragment.parts ++
         List(pairBreak) ++ bStart.fragment.parts ++
@@ -42,9 +52,9 @@ trait PgTime {
         List(closeParen)
 
     val encodeFn: Out => List[Option[skunk.data.Encoded]] = args => {
-      val (a123, a4v) = Where.projectConcat[Where.Concat[Where.Concat[A1, A2], A3], A4](args)
-      val (a12, a3v)  = Where.projectConcat[Where.Concat[A1, A2], A3](a123)
-      val (a1v, a2v)  = Where.projectConcat[A1, A2](a12)
+      val (a123, a4v)       = Where.projectConcat[Where.Concat[Where.Concat[A1, A2], A3], A4](args)
+      val (a12, a3v)        = Where.projectConcat[Where.Concat[A1, A2], A3](a123)
+      val (a1v, a2v)        = Where.projectConcat[A1, A2](a12)
       val values: List[Any] = List(a1v, a2v, a3v, a4v)
       items.zip(values).flatMap { case (f, v) =>
         val e = f.encoder.asInstanceOf[skunk.Encoder[Any]]
@@ -52,7 +62,7 @@ trait PgTime {
       }
     }
     val enc: skunk.Encoder[Out] = new OverlapsEncoder[Out](items, encodeFn)
-    val frag: Fragment[Out] = Fragment(parts, enc, skunk.util.Origin.unknown)
+    val frag: Fragment[Out]     = Fragment(parts, enc, skunk.util.Origin.unknown)
     Where(frag)
   }
 
@@ -72,7 +82,7 @@ trait PgTime {
   /** `date_trunc(precision, e)`. */
   inline def dateTrunc[T, A1, A2](
     precision: TypedExpr[String, A1],
-    e:         TypedExpr[T, A2]
+    e: TypedExpr[T, A2]
   ): TypedExpr[T, Where.Concat[A1, A2]] = {
     val inner = TypedExpr.combineSepInl[A1, A2](precision.fragment, ", ", e.fragment)
     val frag  = TypedExpr.wrap("date_trunc(", inner, ")")
@@ -89,15 +99,22 @@ trait PgTime {
 
   def age[T, A](e: TypedExpr[T, A]): TypedExpr[Duration, A] = unaryOut("age", e, skunk.codec.all.interval)
 
-  def justifyDays[A](e: TypedExpr[Duration, A]):     TypedExpr[Duration, A] = unaryOut("justify_days", e, skunk.codec.all.interval)
-  def justifyHours[A](e: TypedExpr[Duration, A]):    TypedExpr[Duration, A] = unaryOut("justify_hours", e, skunk.codec.all.interval)
-  def justifyInterval[A](e: TypedExpr[Duration, A]): TypedExpr[Duration, A] = unaryOut("justify_interval", e, skunk.codec.all.interval)
+  def justifyDays[A](e: TypedExpr[Duration, A]): TypedExpr[Duration, A] =
+    unaryOut("justify_days", e, skunk.codec.all.interval)
+
+  def justifyHours[A](e: TypedExpr[Duration, A]): TypedExpr[Duration, A] =
+    unaryOut("justify_hours", e, skunk.codec.all.interval)
+
+  def justifyInterval[A](e: TypedExpr[Duration, A]): TypedExpr[Duration, A] =
+    unaryOut("justify_interval", e, skunk.codec.all.interval)
 
   // -------- Construction -----------------------------------------------------------------------
 
   /** `make_date(year, month, day)` — 3 typed positions; `Args` flattens to the non-Void slots of `(Y, M, D)`. */
   inline def makeDate[Y, M, D](
-    year: TypedExpr[Int, Y], month: TypedExpr[Int, M], day: TypedExpr[Int, D]
+    year: TypedExpr[Int, Y],
+    month: TypedExpr[Int, M],
+    day: TypedExpr[Int, D]
   ): TypedExpr[LocalDate, Where.Concat[Where.Concat[Y, M], D]] = {
     val projector: Where.Concat[Where.Concat[Y, M], D] => List[Any] = combined => {
       val (a12, a3v) = Where.projectConcat[Where.Concat[Y, M], D](combined)
@@ -105,7 +122,9 @@ trait PgTime {
       List(a1v, a2v, a3v)
     }
     val combined = TypedExpr.combineList[Where.Concat[Where.Concat[Y, M], D]](
-      List(year.fragment, month.fragment, day.fragment), ", ", projector
+      List(year.fragment, month.fragment, day.fragment),
+      ", ",
+      projector
     )
     val frag = TypedExpr.wrap("make_date(", combined, ")")
     TypedExpr[LocalDate, Where.Concat[Where.Concat[Y, M], D]](frag, skunk.codec.all.date)
@@ -113,7 +132,9 @@ trait PgTime {
 
   /** `make_time(h, m, s)` — 3 typed positions; `Args` flattens to the non-Void slots of `(H, M, S)`. */
   inline def makeTime[H, MM, S](
-    h: TypedExpr[Int, H], m: TypedExpr[Int, MM], s: TypedExpr[Double, S]
+    h: TypedExpr[Int, H],
+    m: TypedExpr[Int, MM],
+    s: TypedExpr[Double, S]
   ): TypedExpr[LocalTime, Where.Concat[Where.Concat[H, MM], S]] = {
     val projector: Where.Concat[Where.Concat[H, MM], S] => List[Any] = combined => {
       val (a12, a3v) = Where.projectConcat[Where.Concat[H, MM], S](combined)
@@ -121,31 +142,44 @@ trait PgTime {
       List(a1v, a2v, a3v)
     }
     val combined = TypedExpr.combineList[Where.Concat[Where.Concat[H, MM], S]](
-      List(h.fragment, m.fragment, s.fragment), ", ", projector
+      List(h.fragment, m.fragment, s.fragment),
+      ", ",
+      projector
     )
     val frag = TypedExpr.wrap("make_time(", combined, ")")
     TypedExpr[LocalTime, Where.Concat[Where.Concat[H, MM], S]](frag, skunk.codec.all.time)
   }
 
   /**
-   * `make_timestamp(year, month, day, h, m, s)` — 6 typed positions; `Args` flattens to the non-Void slots
-   * of `(Y, MO, D, H, MI, S)` via `Where.Concat`.
+   * `make_timestamp(year, month, day, h, m, s)` — 6 typed positions; `Args` flattens to the non-Void slots of
+   * `(Y, MO, D, H, MI, S)` via `Where.Concat`.
    */
   inline def makeTimestamp[Y, MO, D, H, MI, S](
-    year:  TypedExpr[Int, Y],
+    year: TypedExpr[Int, Y],
     month: TypedExpr[Int, MO],
-    day:   TypedExpr[Int, D],
-    h:     TypedExpr[Int, H],
-    m:     TypedExpr[Int, MI],
-    s:     TypedExpr[Double, S]
-  ): TypedExpr[LocalDateTime, Where.Concat[Where.Concat[Where.Concat[Where.Concat[Where.Concat[Y, MO], D], H], MI], S]] = {
+    day: TypedExpr[Int, D],
+    h: TypedExpr[Int, H],
+    m: TypedExpr[Int, MI],
+    s: TypedExpr[Double, S]
+  ): TypedExpr[
+    LocalDateTime,
+    Where.Concat[Where.Concat[Where.Concat[Where.Concat[Where.Concat[Y, MO], D], H], MI], S]
+  ] = {
     type Out = Where.Concat[Where.Concat[Where.Concat[Where.Concat[Where.Concat[Y, MO], D], H], MI], S]
     val projector: Out => List[Any] = combined => {
-      val (a12345, a6v) = Where.projectConcat[Where.Concat[Where.Concat[Where.Concat[Where.Concat[Y, MO], D], H], MI], S](combined)
-      val (a1234, a5v)  = Where.projectConcat[Where.Concat[Where.Concat[Where.Concat[Y, MO], D], H], MI](a12345.asInstanceOf[Where.Concat[Where.Concat[Where.Concat[Where.Concat[Y, MO], D], H], MI]])
-      val (a123, a4v)   = Where.projectConcat[Where.Concat[Where.Concat[Y, MO], D], H](a1234.asInstanceOf[Where.Concat[Where.Concat[Where.Concat[Y, MO], D], H]])
-      val (a12, a3v)    = Where.projectConcat[Where.Concat[Y, MO], D](a123.asInstanceOf[Where.Concat[Where.Concat[Y, MO], D]])
-      val (a1v, a2v)    = Where.projectConcat[Y, MO](a12.asInstanceOf[Where.Concat[Y, MO]])
+      val (a12345, a6v) =
+        Where.projectConcat[Where.Concat[Where.Concat[Where.Concat[Where.Concat[Y, MO], D], H], MI], S](combined)
+      val (a1234, a5v) = Where.projectConcat[Where.Concat[
+        Where.Concat[Where.Concat[Y, MO], D],
+        H
+      ], MI](a12345.asInstanceOf[Where.Concat[Where.Concat[Where.Concat[Where.Concat[Y, MO], D], H], MI]])
+      val (a123, a4v) = Where.projectConcat[Where.Concat[
+        Where.Concat[Y, MO],
+        D
+      ], H](a1234.asInstanceOf[Where.Concat[Where.Concat[Where.Concat[Y, MO], D], H]])
+      val (a12, a3v) =
+        Where.projectConcat[Where.Concat[Y, MO], D](a123.asInstanceOf[Where.Concat[Where.Concat[Y, MO], D]])
+      val (a1v, a2v) = Where.projectConcat[Y, MO](a12.asInstanceOf[Where.Concat[Y, MO]])
       List(a1v, a2v, a3v, a4v, a5v, a6v)
     }
     val combined = TypedExpr.combineList[Out](
@@ -164,7 +198,7 @@ trait PgTime {
 
   /** `to_date(e, fmt)`. */
   inline def toDate[T, A1, A2](
-    e:   TypedExpr[T, A1],
+    e: TypedExpr[T, A1],
     fmt: TypedExpr[String, A2]
   )(using ev: StrLike[T]): TypedExpr[LocalDate, Where.Concat[A1, A2]] = {
     val inner = TypedExpr.combineSepInl[A1, A2](e.fragment, ", ", fmt.fragment)
@@ -182,15 +216,16 @@ trait PgTime {
 }
 
 private[functions] final class OverlapsEncoder[Out](
-  items:    List[skunk.Fragment[?]],
+  items: List[skunk.Fragment[?]],
   encodeFn: Out => List[Option[skunk.data.Encoded]]
 ) extends skunk.Encoder[Out] {
   override val types: List[skunk.data.Type] = items.flatMap(_.encoder.types)
+
   override val sql: cats.data.State[Int, String] =
     cats.data.State { (n0: Int) =>
       items.zipWithIndex.foldLeft((n0, "")) { case ((n, acc), (f, i)) =>
         val (n1, s) = f.encoder.sql.run(n).value
-        val sepStr = i match {
+        val sepStr  = i match {
           case 0 => "("
           case 1 => ", "
           case 2 => ") OVERLAPS ("
@@ -199,5 +234,6 @@ private[functions] final class OverlapsEncoder[Out](
         (n1, acc + sepStr + s)
       } match { case (n, acc) => (n, acc + ")") }
     }
+
   override def encode(args: Out): List[Option[skunk.data.Encoded]] = encodeFn(args)
 }

--- a/modules/core/src/main/scala/skunk/sharp/pg/functions/PgWindow.scala
+++ b/modules/core/src/main/scala/skunk/sharp/pg/functions/PgWindow.scala
@@ -9,11 +9,11 @@ trait PgWindow {
 
   // ---- Ranking functions (no input) -------------------------------------------------------------
 
-  val rowNumber:   TypedExpr[Long, Void]   = TypedExpr(TypedExpr.voidFragment("row_number()"),   skunk.codec.all.int8)
-  val rank:        TypedExpr[Long, Void]   = TypedExpr(TypedExpr.voidFragment("rank()"),         skunk.codec.all.int8)
-  val denseRank:   TypedExpr[Long, Void]   = TypedExpr(TypedExpr.voidFragment("dense_rank()"),   skunk.codec.all.int8)
+  val rowNumber: TypedExpr[Long, Void]     = TypedExpr(TypedExpr.voidFragment("row_number()"), skunk.codec.all.int8)
+  val rank: TypedExpr[Long, Void]          = TypedExpr(TypedExpr.voidFragment("rank()"), skunk.codec.all.int8)
+  val denseRank: TypedExpr[Long, Void]     = TypedExpr(TypedExpr.voidFragment("dense_rank()"), skunk.codec.all.int8)
   val percentRank: TypedExpr[Double, Void] = TypedExpr(TypedExpr.voidFragment("percent_rank()"), skunk.codec.all.float8)
-  val cumeDist:    TypedExpr[Double, Void] = TypedExpr(TypedExpr.voidFragment("cume_dist()"),    skunk.codec.all.float8)
+  val cumeDist: TypedExpr[Double, Void]    = TypedExpr(TypedExpr.voidFragment("cume_dist()"), skunk.codec.all.float8)
 
   /** `ntile(n)`. */
   inline def ntile[A](n: TypedExpr[Int, A]): TypedExpr[Int, A] = {
@@ -26,7 +26,10 @@ trait PgWindow {
   def lag[T, A](expr: TypedExpr[T, A]): TypedExpr[Option[T], A] =
     unaryOpt("lag", expr)
 
-  inline def lag[T, A1, A2](expr: TypedExpr[T, A1], offset: TypedExpr[Int, A2]): TypedExpr[Option[T], Where.Concat[A1, A2]] = {
+  inline def lag[T, A1, A2](
+    expr: TypedExpr[T, A1],
+    offset: TypedExpr[Int, A2]
+  ): TypedExpr[Option[T], Where.Concat[A1, A2]] = {
     val inner = TypedExpr.combineSepInl[A1, A2](expr.fragment, ", ", offset.fragment)
     val frag  = TypedExpr.wrap("lag(", inner, ")")
     TypedExpr(frag, expr.codec.opt)
@@ -34,18 +37,23 @@ trait PgWindow {
 
   /** `lag(expr, offset, default)`. */
   inline def lag[T, A1, A2, A3](
-    expr:    TypedExpr[T, A1],
-    offset:  TypedExpr[Int, A2],
+    expr: TypedExpr[T, A1],
+    offset: TypedExpr[Int, A2],
     default: TypedExpr[T, A3]
   ): TypedExpr[T, Where.FoldConcat[A1 *: A2 *: A3 *: EmptyTuple]] =
     PgFunction.naryTypedFold[T, A1 *: A2 *: A3 *: EmptyTuple](
-      "lag", List(expr.fragment, offset.fragment, default.fragment), expr.codec
+      "lag",
+      List(expr.fragment, offset.fragment, default.fragment),
+      expr.codec
     )
 
   def lead[T, A](expr: TypedExpr[T, A]): TypedExpr[Option[T], A] =
     unaryOpt("lead", expr)
 
-  inline def lead[T, A1, A2](expr: TypedExpr[T, A1], offset: TypedExpr[Int, A2]): TypedExpr[Option[T], Where.Concat[A1, A2]] = {
+  inline def lead[T, A1, A2](
+    expr: TypedExpr[T, A1],
+    offset: TypedExpr[Int, A2]
+  ): TypedExpr[Option[T], Where.Concat[A1, A2]] = {
     val inner = TypedExpr.combineSepInl[A1, A2](expr.fragment, ", ", offset.fragment)
     val frag  = TypedExpr.wrap("lead(", inner, ")")
     TypedExpr(frag, expr.codec.opt)
@@ -53,12 +61,14 @@ trait PgWindow {
 
   /** `lead(expr, offset, default)`. */
   inline def lead[T, A1, A2, A3](
-    expr:    TypedExpr[T, A1],
-    offset:  TypedExpr[Int, A2],
+    expr: TypedExpr[T, A1],
+    offset: TypedExpr[Int, A2],
     default: TypedExpr[T, A3]
   ): TypedExpr[T, Where.FoldConcat[A1 *: A2 *: A3 *: EmptyTuple]] =
     PgFunction.naryTypedFold[T, A1 *: A2 *: A3 *: EmptyTuple](
-      "lead", List(expr.fragment, offset.fragment, default.fragment), expr.codec
+      "lead",
+      List(expr.fragment, offset.fragment, default.fragment),
+      expr.codec
     )
 
   // ---- Value functions --------------------------------------------------------------------------

--- a/modules/core/src/main/scala/skunk/sharp/pg/functions/Shared.scala
+++ b/modules/core/src/main/scala/skunk/sharp/pg/functions/Shared.scala
@@ -53,8 +53,8 @@ private[functions] def stringToIntFn[T, A](name: String, e: TypedExpr[T, A])(usi
 
 private[functions] def twoArgDoubleFn[Y, X, AY, AX](
   name: String,
-  y:    TypedExpr[Y, AY],
-  x:    TypedExpr[X, AX]
+  y: TypedExpr[Y, AY],
+  x: TypedExpr[X, AX]
 ): TypedExpr[Double, Where.Concat[AY, AX]] = {
   // proj is only invoked when neither encoder is Void (runtime check in combineEnc), so the cast is safe.
   val inner = TypedExpr.combineSep(y.fragment, ", ", x.fragment, _.asInstanceOf[(AY, AX)])

--- a/modules/core/src/main/scala/skunk/sharp/where/Where.scala
+++ b/modules/core/src/main/scala/skunk/sharp/where/Where.scala
@@ -6,8 +6,8 @@ import skunk.util.Origin
 
 /**
  * `Where[A]` is a type alias for `TypedExpr[Boolean, A]` — a boolean-typed expression that contributes `A` to the
- * surrounding builder's WHERE / HAVING / ON args. Kept as a type alias for ergonomic call sites and
- * documentation; it's the same vocabulary as any other typed expression.
+ * surrounding builder's WHERE / HAVING / ON args. Kept as a type alias for ergonomic call sites and documentation; it's
+ * the same vocabulary as any other typed expression.
  */
 type Where[A] = TypedExpr[Boolean, A]
 
@@ -16,8 +16,8 @@ type Where[A] = TypedExpr[Boolean, A]
  */
 object Where {
 
-  private[sharp] val OR_KW:  String = " OR "
-  private[sharp] val AND_KW: String = " AND "
+  private[sharp] val OR_KW: String       = " OR "
+  private[sharp] val AND_KW: String      = " AND "
   private[sharp] val NOT_OPEN_KW: String = "NOT ("
 
   /** Construct directly from a typed Fragment + codec. Codec is fixed to bool. */
@@ -25,13 +25,13 @@ object Where {
     TypedExpr[Boolean, A](fragment, skunk.codec.all.bool)
 
   /**
-   * Normalise an `Args` type into a flat tuple shape: `Void` → `EmptyTuple`, an existing `Tuple` stays as-is,
-   * and any other scalar `X` becomes `X *: EmptyTuple`. The "every Args is a tuple" intermediate form lets
-   * [[Concat]] flatten via `Tuple.Concat` and produces flat user-facing tuples.
+   * Normalise an `Args` type into a flat tuple shape: `Void` → `EmptyTuple`, an existing `Tuple` stays as-is, and any
+   * other scalar `X` becomes `X *: EmptyTuple`. The "every Args is a tuple" intermediate form lets [[Concat]] flatten
+   * via `Tuple.Concat` and produces flat user-facing tuples.
    *
-   * Caveat: a leaf with tuple-typed Args (e.g. a hypothetical `Param[(Int, String)]`) is treated by `AsTuple`
-   * as an already-flattened 2-slot contribution. That matches its encoder's column structure, so it composes
-   * uniformly — but it means the user-facing call shape sees the tuple's elements, not the tuple itself.
+   * Caveat: a leaf with tuple-typed Args (e.g. a hypothetical `Param[(Int, String)]`) is treated by `AsTuple` as an
+   * already-flattened 2-slot contribution. That matches its encoder's column structure, so it composes uniformly — but
+   * it means the user-facing call shape sees the tuple's elements, not the tuple itself.
    */
   type AsTuple[X] <: Tuple = X match {
     case Void  => EmptyTuple
@@ -40,9 +40,9 @@ object Where {
   }
 
   /**
-   * Inverse of [[AsTuple]] for the visible `Args` type: empty tuple → `Void`, single-element tuple → its
-   * element, otherwise the tuple itself. Composed with `AsTuple` and `Tuple.Concat`, this gives the
-   * flat-but-Void-eliding visible shape callers see at `.compile`.
+   * Inverse of [[AsTuple]] for the visible `Args` type: empty tuple → `Void`, single-element tuple → its element,
+   * otherwise the tuple itself. Composed with `AsTuple` and `Tuple.Concat`, this gives the flat-but-Void-eliding
+   * visible shape callers see at `.compile`.
    */
   type FromTuple[T <: Tuple] = T match {
     case EmptyTuple      => Void
@@ -51,8 +51,8 @@ object Where {
   }
 
   /**
-   * Type-level concat with `Void` elision and **flat tuple flattening**. The lhs and rhs are each normalised
-   * to tuple shape via [[AsTuple]], concatenated, and unwrapped via [[FromTuple]]. Examples:
+   * Type-level concat with `Void` elision and **flat tuple flattening**. The lhs and rhs are each normalised to tuple
+   * shape via [[AsTuple]], concatenated, and unwrapped via [[FromTuple]]. Examples:
    *   - `Concat[Void, Void]              = Void`
    *   - `Concat[Void, T]                 = T`
    *   - `Concat[T, Void]                 = T`
@@ -60,20 +60,20 @@ object Where {
    *   - `Concat[(Int, String), Boolean]  = (Int, String, Boolean)` ← flat (was nested before)
    *   - `Concat[Int, (String, Boolean)]  = (Int, String, Boolean)`
    *
-   * Used by builders / operators to thread the combined `Args` parameter; chained `&&`/`combine` always
-   * collapses to a single flat user-facing tuple.
+   * Used by builders / operators to thread the combined `Args` parameter; chained `&&`/`combine` always collapses to a
+   * single flat user-facing tuple.
    */
   type Concat[A, B] = FromTuple[Tuple.Concat[AsTuple[A], AsTuple[B]]]
 
   /**
    * Singleton-Boolean tag indicating whether `T` reduces to `Void`. Used as the scrutinee of
-   * `inline scala.compiletime.constValue[IsVoidTag[T]]` to dispatch on `T`'s reduction — the upper-bound
-   * `<: Boolean` and the [[constValue]] wrapper force the compiler to fully reduce nested match types
-   * (`FoldConcat[(Void, Void)] = Void`, `Concat[Void, Void] = Void`, …) to a singleton `true` or `false`.
+   * `inline scala.compiletime.constValue[IsVoidTag[T]]` to dispatch on `T`'s reduction — the upper-bound `<: Boolean`
+   * and the [[constValue]] wrapper force the compiler to fully reduce nested match types (`FoldConcat[(Void, Void)] =
+   * Void`, `Concat[Void, Void] = Void`, …) to a singleton `true` or `false`.
    *
-   * Plain `inline erasedValue[T] match { case _: Void => … }` does NOT trigger this reduction — it
-   * pattern-matches on the un-reduced match-type form and falls through to the default arm whenever `T`
-   * isn't syntactically `Void`, even when it semantically reduces to `Void`.
+   * Plain `inline erasedValue[T] match { case _: Void => … }` does NOT trigger this reduction — it pattern-matches on
+   * the un-reduced match-type form and falls through to the default arm whenever `T` isn't syntactically `Void`, even
+   * when it semantically reduces to `Void`.
    */
   type IsVoidTag[T] <: Boolean = T match {
     case Void => true
@@ -82,8 +82,8 @@ object Where {
 
   /**
    * Companion to [[IsVoidTag]] for tuple-shape detection. `true` if `T` is a `Tuple` (including `EmptyTuple`,
-   * `Tuple1[_]`, `(A, B)`, …), `false` otherwise. Used by [[projectConcat]] to choose between scalar/tuple
-   * slicing of the flat result.
+   * `Tuple1[_]`, `(A, B)`, …), `false` otherwise. Used by [[projectConcat]] to choose between scalar/tuple slicing of
+   * the flat result.
    */
   type IsTupleTag[T] <: Boolean = T match {
     case Tuple => true
@@ -91,13 +91,12 @@ object Where {
   }
 
   /**
-   * Project a `Concat[A, B]` value (whatever shape it reduced to) back into a `(A, B)` tuple — the input shape
-   * an `Encoder[A].product(Encoder[B])` actually expects at execute time. With the smart-flat `Concat`, the
-   * runtime value is a flat tuple of `Tuple.Size[AsTuple[A]] + Tuple.Size[AsTuple[B]]` elements (or `Void`,
-   * or one of `A` / `B` if the other side is `Void`). Splitting requires knowing `A`'s arity at compile time
-   * — so this is an `inline def`, dispatched on `IsVoidTag[A]` / `IsVoidTag[B]` / `IsTupleTag[A]` /
-   * `IsTupleTag[B]` via `inline constValue`. Caller must be `inline` (or have `A`/`B` concrete) so the
-   * dispatch reduces.
+   * Project a `Concat[A, B]` value (whatever shape it reduced to) back into a `(A, B)` tuple — the input shape an
+   * `Encoder[A].product(Encoder[B])` actually expects at execute time. With the smart-flat `Concat`, the runtime value
+   * is a flat tuple of `Tuple.Size[AsTuple[A]] + Tuple.Size[AsTuple[B]]` elements (or `Void`, or one of `A` / `B` if
+   * the other side is `Void`). Splitting requires knowing `A`'s arity at compile time — so this is an `inline def`,
+   * dispatched on `IsVoidTag[A]` / `IsVoidTag[B]` / `IsTupleTag[A]` / `IsTupleTag[B]` via `inline constValue`. Caller
+   * must be `inline` (or have `A`/`B` concrete) so the dispatch reduces.
    */
   inline def projectConcat[A, B](c: Concat[A, B]): (A, B) =
     inline scala.compiletime.constValue[IsVoidTag[A]] match
@@ -110,10 +109,10 @@ object Where {
           case true  => (c, Void).asInstanceOf[(A, B)]
           case false =>
             // Both A, B non-Void. Concat reduces to a flat Tuple of size sizeA + sizeB (>= 2).
-            val sizeA = scala.compiletime.constValue[Tuple.Size[AsTuple[A]]]
-            val flat  = c.asInstanceOf[Tuple]
+            val sizeA        = scala.compiletime.constValue[Tuple.Size[AsTuple[A]]]
+            val flat         = c.asInstanceOf[Tuple]
             val (aTup, bTup) = flat.splitAt(sizeA)
-            val aOut = inline scala.compiletime.constValue[IsTupleTag[A]] match
+            val aOut         = inline scala.compiletime.constValue[IsTupleTag[A]] match
               case true  => aTup
               case false => aTup.productElement(0)
             val bOut = inline scala.compiletime.constValue[IsTupleTag[B]] match
@@ -123,19 +122,19 @@ object Where {
 
   /**
    * Right-fold of [[Concat]] over a tuple of Args types. Drops `Void` slots cleanly so
-   * `FoldConcat[(Void, Int, Void, String)] = (Int, String)`. Used by variadic builders / projection lists /
-   * RETURNING tuples to combine N typed-Args slots into one.
+   * `FoldConcat[(Void, Int, Void, String)] = (Int, String)`. Used by variadic builders / projection lists / RETURNING
+   * tuples to combine N typed-Args slots into one.
    */
   type FoldConcat[T <: Tuple] = T match {
-    case EmptyTuple        => Void
-    case h *: EmptyTuple   => h
-    case h *: t            => Concat[h, FoldConcat[t]]
+    case EmptyTuple      => Void
+    case h *: EmptyTuple => h
+    case h *: t          => Concat[h, FoldConcat[t]]
   }
 
   /**
-   * Project a `FoldConcat[T]` value back into a heterogeneous list of per-slot values, in tuple order — one
-   * entry per slot of `T`, including `Void` placeholders for slots whose Args is `Void`. Inline-dispatched on
-   * the tuple shape — caller must therefore be `inline` (or have `T` concrete) so the recursion reduces.
+   * Project a `FoldConcat[T]` value back into a heterogeneous list of per-slot values, in tuple order — one entry per
+   * slot of `T`, including `Void` placeholders for slots whose Args is `Void`. Inline-dispatched on the tuple shape —
+   * caller must therefore be `inline` (or have `T` concrete) so the recursion reduces.
    */
   inline def projectFoldConcat[T <: Tuple](c: FoldConcat[T]): List[Any] =
     inline scala.compiletime.erasedValue[T] match
@@ -146,12 +145,14 @@ object Where {
         pair._1 :: projectFoldConcat[t & Tuple](pair._2)
 
   /**
-   * Pair two encoders into one whose input shape matches `Concat[A, B]`. The caller-supplied `proj` re-pairs
-   * the `Concat[A, B]` value back into `(A, B)` — typically `c => projectConcat[A, B](c)` materialised at the
-   * caller's inline expansion site so the dispatch reduces with concrete `A` / `B`.
+   * Pair two encoders into one whose input shape matches `Concat[A, B]`. The caller-supplied `proj` re-pairs the
+   * `Concat[A, B]` value back into `(A, B)` — typically `c => projectConcat[A, B](c)` materialised at the caller's
+   * inline expansion site so the dispatch reduces with concrete `A` / `B`.
    */
   private[sharp] def concatEncoders[A, B](
-    a: Encoder[?], b: Encoder[?], proj: Concat[A, B] => (A, B)
+    a: Encoder[?],
+    b: Encoder[?],
+    proj: Concat[A, B] => (A, B)
   ): Encoder[Concat[A, B]] = {
     val productEnc: Encoder[(Any, Any)] =
       a.asInstanceOf[Encoder[Any]].product(b.asInstanceOf[Encoder[Any]])
@@ -172,8 +173,8 @@ object Where {
         List[Either[String, cats.data.State[Int, String]]](Left(opSql)) ++
         r.fragment.parts ++
         List[Either[String, cats.data.State[Int, String]]](Left(")"))
-    val enc                           = concatEncoders[A, B](l.fragment.encoder, r.fragment.encoder, proj)
-    val frag: Fragment[Concat[A, B]]  = Fragment(parts, enc, Origin.unknown)
+    val enc                          = concatEncoders[A, B](l.fragment.encoder, r.fragment.encoder, proj)
+    val frag: Fragment[Concat[A, B]] = Fragment(parts, enc, Origin.unknown)
     apply[Concat[A, B]](frag)
   }
 
@@ -187,8 +188,8 @@ object Where {
   }
 
   /**
-   * Adopt a `TypedExpr[Boolean, A]` as a `Where[A]` — identity now that Where is a type alias. Kept for source
-   * compat with code that previously called `Where(expr)` to lift a non-Where Boolean expression.
+   * Adopt a `TypedExpr[Boolean, A]` as a `Where[A]` — identity now that Where is a type alias. Kept for source compat
+   * with code that previously called `Where(expr)` to lift a non-Where Boolean expression.
    */
   def fromTypedExpr[A](expr: TypedExpr[Boolean, A]): TypedExpr[Boolean, A] = expr
 
@@ -204,7 +205,7 @@ object Where {
   // arg slots through the AST; collapsing them via Semigroup would defeat the typed-Args design.
 
   /** Identity element for [[allOf]] / `andMonoid` — renders as `TRUE` and is optimised away by Postgres. */
-  lazy val trueExpr: TypedExpr[Boolean, skunk.Void]  = TypedExpr.lit(true)
+  lazy val trueExpr: TypedExpr[Boolean, skunk.Void] = TypedExpr.lit(true)
 
   /** Identity element for [[anyOf]] / `orMonoid` — renders as `FALSE`. */
   lazy val falseExpr: TypedExpr[Boolean, skunk.Void] = TypedExpr.lit(false)
@@ -213,20 +214,26 @@ object Where {
   val andMonoid: cats.Monoid[TypedExpr[Boolean, skunk.Void]] =
     new cats.Monoid[TypedExpr[Boolean, skunk.Void]] {
       def empty: TypedExpr[Boolean, skunk.Void] = trueExpr
-      def combine(x: TypedExpr[Boolean, skunk.Void], y: TypedExpr[Boolean, skunk.Void]): TypedExpr[Boolean, skunk.Void] = x && y
+      def combine(
+        x: TypedExpr[Boolean, skunk.Void],
+        y: TypedExpr[Boolean, skunk.Void]
+      ): TypedExpr[Boolean, skunk.Void] = x && y
     }
 
   /** Monoid combining `Where[Void]`s with `OR`. Empty = `FALSE`. Not a `given` — pick explicitly. */
   val orMonoid: cats.Monoid[TypedExpr[Boolean, skunk.Void]] =
     new cats.Monoid[TypedExpr[Boolean, skunk.Void]] {
       def empty: TypedExpr[Boolean, skunk.Void] = falseExpr
-      def combine(x: TypedExpr[Boolean, skunk.Void], y: TypedExpr[Boolean, skunk.Void]): TypedExpr[Boolean, skunk.Void] = x || y
+      def combine(
+        x: TypedExpr[Boolean, skunk.Void],
+        y: TypedExpr[Boolean, skunk.Void]
+      ): TypedExpr[Boolean, skunk.Void] = x || y
     }
 
   /**
-   * AND-fold a `Foldable` of `Where[Void]`. Empty input collapses to [[trueExpr]] (`WHERE TRUE`), so callers
-   * don't need to special-case the empty list. Non-empty input avoids prepending the identity — the result
-   * for `List(a, b, c)` is `(a AND b) AND c`, not `((TRUE AND a) AND b) AND c`.
+   * AND-fold a `Foldable` of `Where[Void]`. Empty input collapses to [[trueExpr]] (`WHERE TRUE`), so callers don't need
+   * to special-case the empty list. Non-empty input avoids prepending the identity — the result for `List(a, b, c)` is
+   * `(a AND b) AND c`, not `((TRUE AND a) AND b) AND c`.
    */
   def allOf[F[_]: cats.Foldable](xs: F[TypedExpr[Boolean, skunk.Void]]): TypedExpr[Boolean, skunk.Void] =
     cats.Foldable[F].reduceLeftOption(xs)((acc, w) => acc && w).getOrElse(trueExpr)

--- a/modules/core/src/test/scala/skunk/sharp/ExprInterpolatorSuite.scala
+++ b/modules/core/src/test/scala/skunk/sharp/ExprInterpolatorSuite.scala
@@ -17,7 +17,7 @@ class ExprInterpolatorSuite extends munit.FunSuite {
   // -------- No-arg form ------------------------------------------------------------------------
 
   test("expr with no interpolations renders the literal SQL and Args = Void") {
-    val e = expr"now()".as[java.time.OffsetDateTime]
+    val e                                            = expr"now()".as[java.time.OffsetDateTime]
     val _: TypedExpr[java.time.OffsetDateTime, Void] = e
     assertEquals(e.fragment.sql, "now()")
   }
@@ -25,13 +25,13 @@ class ExprInterpolatorSuite extends munit.FunSuite {
   // -------- TypedExpr (column) interpolation ---------------------------------------------------
 
   test("expr splicing a single column ref preserves Args = Void") {
-    val q                              = users.select(u => expr"lower(${u.email})".asCodec(skunk.codec.all.text)).compile
+    val q = users.select(u => expr"lower(${u.email})".asCodec(skunk.codec.all.text)).compile
     val _: QueryTemplate[Void, String] = q
     assert(q.fragment.sql.contains("""lower("email")"""), q.fragment.sql)
   }
 
   test("expr splicing two column refs renders with literal separator + Args = Void") {
-    val q                              = users.select(u => expr"${u.email} || ${u.email}".asCodec(skunk.codec.all.text)).compile
+    val q = users.select(u => expr"${u.email} || ${u.email}".asCodec(skunk.codec.all.text)).compile
     val _: QueryTemplate[Void, String] = q
     assert(q.fragment.sql.contains(""""email" || "email""""), q.fragment.sql)
   }
@@ -39,35 +39,35 @@ class ExprInterpolatorSuite extends munit.FunSuite {
   // -------- Param interpolation (TypedExpr branch) ---------------------------------------------
 
   test("expr splicing a Param[T] threads Args = T") {
-    val q                                  = users.select(u => expr"lower(${u.email}) = lower(${Param[String]})".as[Boolean]).compile
+    val q = users.select(u => expr"lower(${u.email}) = lower(${Param[String]})".as[Boolean]).compile
     val _: QueryTemplate[String, Boolean] = q
     assert(q.fragment.sql.contains("$1"), q.fragment.sql)
   }
 
   test("expr splicing two Params via FoldConcat collapses to flat tuple Args") {
-    val q                                       = users.select(_ => expr"${Param[Int]} + ${Param[Int]}".as[Int]).compile
-    val _: QueryTemplate[(Int, Int), Int]       = q
+    val q                                 = users.select(_ => expr"${Param[Int]} + ${Param[Int]}".as[Int]).compile
+    val _: QueryTemplate[(Int, Int), Int] = q
     assert(q.fragment.sql.contains("$1 + $2"), q.fragment.sql)
   }
 
   test("expr splicing column + Param threads Args = the Param's type") {
-    val q                              = users.select(u => expr"${u.age} + ${Param[Int]}".as[Int]).compile
-    val _: QueryTemplate[Int, Int]     = q
+    val q                          = users.select(u => expr"${u.age} + ${Param[Int]}".as[Int]).compile
+    val _: QueryTemplate[Int, Int] = q
     assert(q.fragment.sql.contains(""""age" + $1"""), q.fragment.sql)
   }
 
   // -------- Value interpolation requires explicit wrapping ------------------------------------
 
   test("expr with lit(v) for a compile-time literal — Args = Void") {
-    val q                                = users.select(u => expr"${u.email} = ${lit("@example.com")}".as[Boolean]).compile
-    val _: QueryTemplate[Void, Boolean]  = q
+    val q = users.select(u => expr"${u.email} = ${lit("@example.com")}".as[Boolean]).compile
+    val _: QueryTemplate[Void, Boolean] = q
     assert(q.fragment.sql.contains("@example.com"), q.fragment.sql)
   }
 
   test("expr with Param.bind(v) for a runtime value — Args = Void") {
-    val n                                = 18
-    val q                                = users.select(u => expr"${u.age} >= ${Param.bind(n)}".as[Boolean]).compile
-    val _: QueryTemplate[Void, Boolean]  = q
+    val n                               = 18
+    val q                               = users.select(u => expr"${u.age} >= ${Param.bind(n)}".as[Boolean]).compile
+    val _: QueryTemplate[Void, Boolean] = q
     assert(q.fragment.sql.contains("$1"), q.fragment.sql)
   }
 
@@ -123,7 +123,7 @@ class ExprInterpolatorSuite extends munit.FunSuite {
   private val u_emailCodec: skunk.Codec[String] = skunk.codec.all.text
 
   test("expr.asCodec(e) reuses the spliced expression's codec without naming the codec") {
-    val q = users.select(u => expr"upper(${u.email})".asCodec(u.email)).compile
+    val q                              = users.select(u => expr"upper(${u.email})".asCodec(u.email)).compile
     val _: QueryTemplate[Void, String] = q
     assertEquals(q.fragment.sql.trim, """SELECT upper("email") FROM "users"""")
   }

--- a/modules/core/src/test/scala/skunk/sharp/ParamSuite.scala
+++ b/modules/core/src/test/scala/skunk/sharp/ParamSuite.scala
@@ -1108,8 +1108,8 @@ class ParamSuite extends munit.FunSuite {
 
   test("col.in(lits) preserves Args = Void") {
     case class User(id: UUID, email: String, age: Int)
-    val users                     = Table.of[User]("users")
-    val q                         = users.select.where(u => u.age.in(cats.data.NonEmptyList.of(lit(20), lit(21), lit(22)))).compile
+    val users = Table.of[User]("users")
+    val q     = users.select.where(u => u.age.in(cats.data.NonEmptyList.of(lit(20), lit(21), lit(22)))).compile
     val _: QueryTemplate[Void, ?] = q
   }
 

--- a/modules/core/src/test/scala/skunk/sharp/dsl/DistinctOnAnyAllSuite.scala
+++ b/modules/core/src/test/scala/skunk/sharp/dsl/DistinctOnAnyAllSuite.scala
@@ -116,8 +116,8 @@ class DistinctOnAnyAllSuite extends munit.FunSuite {
   }
 
   test("Pg.overlaps with two parameterised time bounds") {
-    val t1 = OffsetDateTime.parse("2020-01-01T00:00:00Z")
-    val t2 = OffsetDateTime.parse("2020-12-31T00:00:00Z")
+    val t1  = OffsetDateTime.parse("2020-01-01T00:00:00Z")
+    val t2  = OffsetDateTime.parse("2020-12-31T00:00:00Z")
     val sql = users.select(u => u.email)
       .where(u => Pg.overlaps(u.created_at, u.created_at, param(t1), param(t2)))
       .compile.fragment.sql

--- a/modules/core/src/test/scala/skunk/sharp/dsl/SetOpSuite.scala
+++ b/modules/core/src/test/scala/skunk/sharp/dsl/SetOpSuite.scala
@@ -111,17 +111,19 @@ class SetOpSuite extends munit.FunSuite {
     import skunk.sharp.{Param, *}
     val activeUsers = users.select.where(u => u.email === Param[String])
     val q           = activeUsers.union(admins.select).compile
-    val _: QueryTemplate[String, NamedRowOf[(Column[UUID, "id", false, EmptyTuple],
-                                              Column[String, "email", false, EmptyTuple],
-                                              Column[Int, "age", false, EmptyTuple])]] = q
+    val _: QueryTemplate[String, NamedRowOf[(
+      Column[UUID, "id", false, EmptyTuple],
+      Column[String, "email", false, EmptyTuple],
+      Column[Int, "age", false, EmptyTuple]
+    )]] = q
     assert(q.fragment.sql.contains("\"email\" = $1"), q.fragment.sql)
   }
 
   test("Both UNION arms carrying Params surface as Concat of both Args") {
     import skunk.sharp.{Param, *}
-    val left  = users.select.where(u => u.email === Param[String])
-    val right = admins.select.where(a => a.age === Param[Int])
-    val q     = left.union(right).compile
+    val left                               = users.select.where(u => u.email === Param[String])
+    val right                              = admins.select.where(a => a.age === Param[Int])
+    val q                                  = left.union(right).compile
     val _: QueryTemplate[(String, Int), ?] = q
     assert(q.fragment.sql.contains("\"email\" = $1") && q.fragment.sql.contains("\"age\" = $2"), q.fragment.sql)
   }

--- a/modules/core/src/test/scala/skunk/sharp/dsl/SrfSuite.scala
+++ b/modules/core/src/test/scala/skunk/sharp/dsl/SrfSuite.scala
@@ -28,7 +28,7 @@ class SrfSuite extends munit.FunSuite {
   }
 
   test("Pg.generateSeries with Param bounds threads typed Args into outer compile") {
-    val qt = Pg.generateSeries(Param[Int], Param[Int]).select.compile
+    val qt                              = Pg.generateSeries(Param[Int], Param[Int]).select.compile
     val _: QueryTemplate[(Int, Int), ?] = qt
     assert(qt.fragment.sql.contains("""generate_series($1, $2)"""), qt.fragment.sql)
   }

--- a/modules/example/src/main/scala/skunk/sharp/example/api/Dto.scala
+++ b/modules/example/src/main/scala/skunk/sharp/example/api/Dto.scala
@@ -32,20 +32,21 @@ case class CreateBookingRequest(
 case class ApiError(message: String) derives Codec.AsObject, Schema
 
 /**
- * Query-parameter bundle for `GET /api/v1/rooms`. Each `@query`-annotated field maps to one query string key
- * (the field name doubles as the param name); tapir's `EndpointInput.derived` flattens the case class into a
- * single composed `EndpointInput`. Field types drive parsing (`Option[T]` for one-or-zero, `List[T]` for
- * repeated keys like `?names=a&names=b`). Routes translate this DTO to a `List[RoomFilter]` via `.toFilters`.
+ * Query-parameter bundle for `GET /api/v1/rooms`. Each `@query`-annotated field maps to one query string key (the field
+ * name doubles as the param name); tapir's `EndpointInput.derived` flattens the case class into a single composed
+ * `EndpointInput`. Field types drive parsing (`Option[T]` for one-or-zero, `List[T]` for repeated keys like
+ * `?names=a&names=b`). Routes translate this DTO to a `List[RoomFilter]` via `.toFilters`.
  */
 case class RoomFilterQuery(
-  @query minCapacity:  Option[Int],
-  @query maxCapacity:  Option[Int],
+  @query minCapacity: Option[Int],
+  @query maxCapacity: Option[Int],
   @query nameContains: Option[String],
-  @query names:        List[String],
-  @query ids:          List[UUID]
+  @query names: List[String],
+  @query ids: List[UUID]
 )
 
 object RoomFilterQuery {
+
   /** No filters supplied — handy for tests or default routing. */
   val empty: RoomFilterQuery = RoomFilterQuery(None, None, None, Nil, Nil)
 }
@@ -53,17 +54,17 @@ object RoomFilterQuery {
 /**
  * Query-parameter bundle for `GET /api/v1/bookings`. Mirrors [[RoomFilterQuery]] in shape and intent.
  *
- * `overlapsFrom` and `overlapsTo` are paired: only when both are present does the routing layer turn them into
- * a single `OverlapsPeriod` filter. The half-bounded `startsOnOrAfter` / `endsOnOrBefore` are independent.
+ * `overlapsFrom` and `overlapsTo` are paired: only when both are present does the routing layer turn them into a single
+ * `OverlapsPeriod` filter. The half-bounded `startsOnOrAfter` / `endsOnOrBefore` are independent.
  */
 case class BookingFilterQuery(
-  @query roomIds:            List[UUID],
+  @query roomIds: List[UUID],
   @query bookerNameContains: Option[String],
-  @query titleContains:      Option[String],
-  @query overlapsFrom:       Option[LocalDate],
-  @query overlapsTo:         Option[LocalDate],
-  @query startsOnOrAfter:    Option[LocalDate],
-  @query endsOnOrBefore:     Option[LocalDate]
+  @query titleContains: Option[String],
+  @query overlapsFrom: Option[LocalDate],
+  @query overlapsTo: Option[LocalDate],
+  @query startsOnOrAfter: Option[LocalDate],
+  @query endsOnOrBefore: Option[LocalDate]
 )
 
 object BookingFilterQuery {

--- a/modules/example/src/main/scala/skunk/sharp/example/api/Endpoints.scala
+++ b/modules/example/src/main/scala/skunk/sharp/example/api/Endpoints.scala
@@ -14,15 +14,15 @@ object Endpoints {
 
   // Filter query bundles: each `@query`-annotated field becomes one query string key. Tapir derives a single
   // composed `EndpointInput[FilterQuery]` so endpoints receive one typed value rather than a 5- or 7-tuple.
-  private val roomFilterInput:    EndpointInput[RoomFilterQuery]    = EndpointInput.derived[RoomFilterQuery]
+  private val roomFilterInput: EndpointInput[RoomFilterQuery]       = EndpointInput.derived[RoomFilterQuery]
   private val bookingFilterInput: EndpointInput[BookingFilterQuery] = EndpointInput.derived[BookingFilterQuery]
 
   object rooms {
 
     /**
-     * GET /api/v1/rooms — list with optional filters bundled in [[RoomFilterQuery]]. Absent fields drop out of
-     * the WHERE; present fields AND-combine. Repeated keys (`?names=a&names=b`) produce a non-empty list which
-     * the routing layer turns into an `IN (…)` clause.
+     * GET /api/v1/rooms — list with optional filters bundled in [[RoomFilterQuery]]. Absent fields drop out of the
+     * WHERE; present fields AND-combine. Repeated keys (`?names=a&names=b`) produce a non-empty list which the routing
+     * layer turns into an `IN (…)` clause.
      */
     val list =
       base.get
@@ -59,8 +59,8 @@ object Endpoints {
 
     /**
      * GET /api/v1/bookings — list with optional filters bundled in [[BookingFilterQuery]]. `overlapsFrom` and
-     * `overlapsTo` together form an `OverlapsPeriod` filter (only applied when both are present); the
-     * one-sided `startsOnOrAfter` / `endsOnOrBefore` are independent.
+     * `overlapsTo` together form an `OverlapsPeriod` filter (only applied when both are present); the one-sided
+     * `startsOnOrAfter` / `endsOnOrBefore` are independent.
      */
     val list =
       base.get

--- a/modules/example/src/main/scala/skunk/sharp/example/api/Transformers.scala
+++ b/modules/example/src/main/scala/skunk/sharp/example/api/Transformers.scala
@@ -46,8 +46,8 @@ object Transformers {
   extension (q: RoomFilterQuery)
 
     /**
-     * Project the query DTO onto the repository's `RoomFilter` ADT — absent fields disappear, present fields
-     * become one filter case each. Multi-value fields turn into IN-style cases via `NonEmptyList`.
+     * Project the query DTO onto the repository's `RoomFilter` ADT — absent fields disappear, present fields become one
+     * filter case each. Multi-value fields turn into IN-style cases via `NonEmptyList`.
      */
     def toFilters: List[RoomFilter] = List(
       q.minCapacity.map(RoomFilter.CapacityAtLeast(_)),
@@ -60,8 +60,8 @@ object Transformers {
   extension (q: BookingFilterQuery)
 
     /**
-     * Project the booking query DTO onto `BookingFilter`. `overlapsFrom`/`overlapsTo` are paired — the
-     * `OverlapsPeriod` filter is only emitted when both bounds are present.
+     * Project the booking query DTO onto `BookingFilter`. `overlapsFrom`/`overlapsTo` are paired — the `OverlapsPeriod`
+     * filter is only emitted when both bounds are present.
      */
     def toFilters: List[BookingFilter] = {
       val overlap = (q.overlapsFrom, q.overlapsTo).tupled.map { case (f, t) =>

--- a/modules/example/src/main/scala/skunk/sharp/example/repository/BookingFilter.scala
+++ b/modules/example/src/main/scala/skunk/sharp/example/repository/BookingFilter.scala
@@ -6,12 +6,12 @@ import java.time.LocalDate
 import java.util.UUID
 
 /**
- * Domain-level filter ADT for booking listing. Mirrors [[RoomFilter]] — see that file for the rationale on
- * sealed ADTs versus a wide optional-fields payload. The translation to `Where[Void]` lives in
- * [[BookingRepository]] alongside the columns view it needs.
+ * Domain-level filter ADT for booking listing. Mirrors [[RoomFilter]] — see that file for the rationale on sealed ADTs
+ * versus a wide optional-fields payload. The translation to `Where[Void]` lives in [[BookingRepository]] alongside the
+ * columns view it needs.
  *
- * Date filters operate on the `period: PgRange[LocalDate]` column via the range operators (`@>`, `&&`, lower /
- * upper accessors). The repository handles the SQL details; this layer just names the predicate.
+ * Date filters operate on the `period: PgRange[LocalDate]` column via the range operators (`@>`, `&&`, lower / upper
+ * accessors). The repository handles the SQL details; this layer just names the predicate.
  */
 sealed trait BookingFilter
 

--- a/modules/example/src/main/scala/skunk/sharp/example/repository/BookingRepository.scala
+++ b/modules/example/src/main/scala/skunk/sharp/example/repository/BookingRepository.scala
@@ -69,9 +69,9 @@ object BookingRepository {
       t.delete.where(b => b.id === Param[UUID]).compile
 
     /**
-     * Translate one filter case to a `Where[Void]`. The half-bounded ranges for "starts on or after" / "ends
-     * on or before" use `<@` (containedBy) against an open-ended probe range — that lets Postgres use the
-     * GiST index on `period` if one exists.
+     * Translate one filter case to a `Where[Void]`. The half-bounded ranges for "starts on or after" / "ends on or
+     * before" use `<@` (containedBy) against an open-ended probe range — that lets Postgres use the GiST index on
+     * `period` if one exists.
      */
     private def toWhere(f: BookingFilter): Where[skunk.Void] = f match {
       case BookingFilter.RoomsIn(ids) =>

--- a/modules/example/src/main/scala/skunk/sharp/example/repository/RoomFilter.scala
+++ b/modules/example/src/main/scala/skunk/sharp/example/repository/RoomFilter.scala
@@ -6,17 +6,17 @@ import java.util.UUID
 
 /**
  * Domain-level filter ADT for room listing. Each case captures one runtime predicate the API can ask for; the
- * repository materialises a `List[RoomFilter]` into a single `WHERE` clause by translating each case to a
- * `Where[Void]` (values baked via `Param.bind`) and AND-folding the result. The translation lives in
- * [[RoomRepository]] alongside the columns view it needs.
+ * repository materialises a `List[RoomFilter]` into a single `WHERE` clause by translating each case to a `Where[Void]`
+ * (values baked via `Param.bind`) and AND-folding the result. The translation lives in [[RoomRepository]] alongside the
+ * columns view it needs.
  *
  * Why a sealed ADT and not just `case class RoomQuery(minCapacity: Option[Int], …)`:
  *
  *   - Each case stays self-contained — adding a new filter is one new `case class` and one extra arm in the
  *     repository's `toWhere` matcher, no fiddling with optional fields scattered across layers.
  *   - The exhaustiveness check on the `match` keeps the repository honest when the ADT grows.
- *   - Multi-value cases (`NamesIn`, `IdsIn`) are first-class — they translate to `IN (…)` (OR semantics) inside
- *     a single AND-combined clause, which is closer to the intent than parallel optional fields would be.
+ *   - Multi-value cases (`NamesIn`, `IdsIn`) are first-class — they translate to `IN (…)` (OR semantics) inside a
+ *     single AND-combined clause, which is closer to the intent than parallel optional fields would be.
  */
 sealed trait RoomFilter
 

--- a/modules/example/src/main/scala/skunk/sharp/example/repository/RoomRepository.scala
+++ b/modules/example/src/main/scala/skunk/sharp/example/repository/RoomRepository.scala
@@ -23,9 +23,9 @@ trait RoomRepository {
  * Static-template repository — every query that has a fixed shape is compiled exactly once at object construction.
  * Calls bind parameters and run; nothing is re-built per request.
  *
- * Two methods earn an exception: `.patch` (variable SET list per call) and `.findFiltered` (variable WHERE shape
- * driven by a runtime `List[RoomFilter]`). Both compile a fresh query per call and bake values via `Param.bind`,
- * so the user-facing `Args` collapses to `Void` and there's nothing to thread at execute time.
+ * Two methods earn an exception: `.patch` (variable SET list per call) and `.findFiltered` (variable WHERE shape driven
+ * by a runtime `List[RoomFilter]`). Both compile a fresh query per call and bake values via `Param.bind`, so the
+ * user-facing `Args` collapses to `Void` and there's nothing to thread at execute time.
  */
 object RoomRepository {
 
@@ -34,8 +34,8 @@ object RoomRepository {
 
     /**
      * Captured columns view, statically typed as `ColumnsView[<RoomRow.table.Cols>]` — `cv.id` / `cv.name` /
-     * `cv.capacity` resolve via the named-tuple selector. Kept on the impl so [[toWhere]] is a normal method
-     * (not nested inside a `where(c => …)` lambda). Safe for the unaliased single-source case used here.
+     * `cv.capacity` resolve via the named-tuple selector. Kept on the impl so [[toWhere]] is a normal method (not
+     * nested inside a `where(c => …)` lambda). Safe for the unaliased single-source case used here.
      */
     private val cv = t.columnsView
 
@@ -61,8 +61,8 @@ object RoomRepository {
       t.delete.where(r => r.id === Param[UUID]).compile
 
     /**
-     * Translate one filter case to a `Where[Void]`. Every arm bakes its runtime value via `Param.bind`, so the
-     * result has `Args = Void` and can be AND-folded with `dsl.allOf`.
+     * Translate one filter case to a `Where[Void]`. Every arm bakes its runtime value via `Param.bind`, so the result
+     * has `Args = Void` and can be AND-folded with `dsl.allOf`.
      */
     private def toWhere(f: RoomFilter): Where[skunk.Void] = f match {
       case RoomFilter.CapacityAtLeast(n) => cv.capacity >= Param.bind(n)
@@ -73,7 +73,7 @@ object RoomRepository {
     }
 
     def findFiltered(filters: List[RoomFilter]): Kleisli[Stream[IO, *], Session[IO], RoomRow] =
-      if filters.isEmpty then findAllQ.streamKF[IO]()  // hit the static-cache fast path
+      if filters.isEmpty then findAllQ.streamKF[IO]() // hit the static-cache fast path
       else
         // `allOf` AND-folds the per-filter Wheres; empty would have rendered `WHERE TRUE` but we
         // short-circuit above to keep the static cache.

--- a/modules/example/src/test/scala/skunk/sharp/example/ExampleAppFixture.scala
+++ b/modules/example/src/test/scala/skunk/sharp/example/ExampleAppFixture.scala
@@ -21,14 +21,14 @@ import sttp.model.Uri as SttpUri
 import sttp.tapir.client.sttp.SttpClientInterpreter
 
 /**
- * Integration-test fixture for the example app: spins up Postgres in a container, runs the example's own
- * dumbo migrations, builds the live `Routes`, and exposes an in-process **sttp `SttpBackend[IO, …]`** wired
- * to the route handler via `Http4sBackend.usingClient(Client.fromHttpApp(routes.orNotFound))`.
+ * Integration-test fixture for the example app: spins up Postgres in a container, runs the example's own dumbo
+ * migrations, builds the live `Routes`, and exposes an in-process **sttp `SttpBackend[IO, …]`** wired to the route
+ * handler via `Http4sBackend.usingClient(Client.fromHttpApp(routes.orNotFound))`.
  *
- * Tests use [[SttpClientInterpreter]] to derive typed sttp requests directly from the same
- * `Endpoints.rooms.list` / `Endpoints.bookings.list` / etc. values the server publishes — the input DTOs
- * (`RoomFilterQuery`, `BookingFilterQuery`, `CreateRoomRequest`, …) flow through unchanged on both sides.
- * No port is bound; everything runs in-process for speed and determinism.
+ * Tests use [[SttpClientInterpreter]] to derive typed sttp requests directly from the same `Endpoints.rooms.list` /
+ * `Endpoints.bookings.list` / etc. values the server publishes — the input DTOs (`RoomFilterQuery`,
+ * `BookingFilterQuery`, `CreateRoomRequest`, …) flow through unchanged on both sides. No port is bound; everything runs
+ * in-process for speed and determinism.
  */
 trait ExampleAppFixture extends CatsEffectSuite with TestContainerForAll {
 
@@ -65,12 +65,12 @@ trait ExampleAppFixture extends CatsEffectSuite with TestContainerForAll {
       .pooled(8)
 
   /**
-   * Truncate the example's tables (`bookings`, `rooms`) before each test. `TestContainerForAll` reuses one
-   * container across the suite to keep CI fast — but that means rows from one test leak into the next, so
-   * tests that assert "all rooms" or expect a specific count must run against an empty database.
+   * Truncate the example's tables (`bookings`, `rooms`) before each test. `TestContainerForAll` reuses one container
+   * across the suite to keep CI fast — but that means rows from one test leak into the next, so tests that assert "all
+   * rooms" or expect a specific count must run against an empty database.
    *
-   * Uses raw `skunk.command` because the truncate has no DSL representation in this codebase yet (no
-   * `Table#truncate` extension); it's a one-shot DDL-ish maintenance op.
+   * Uses raw `skunk.command` because the truncate has no DSL representation in this codebase yet (no `Table#truncate`
+   * extension); it's a one-shot DDL-ish maintenance op.
    */
   protected def truncateAll(c: containerDef.Container): IO[Unit] = {
     import skunk.implicits.*
@@ -84,8 +84,8 @@ trait ExampleAppFixture extends CatsEffectSuite with TestContainerForAll {
   protected val interpreter: SttpClientInterpreter = SttpClientInterpreter()
 
   /**
-   * Build an sttp backend wired in-process to the live app's routes. Tests should use this with
-   * [[interpreter]] to derive typed requests from the published [[skunk.sharp.example.api.Endpoints]] values.
+   * Build an sttp backend wired in-process to the live app's routes. Tests should use this with [[interpreter]] to
+   * derive typed requests from the published [[skunk.sharp.example.api.Endpoints]] values.
    */
   protected def appBackend(c: containerDef.Container): Resource[IO, SttpBackend[IO, Fs2Streams[IO]]] =
     sessionPool(c).map { pool =>
@@ -101,11 +101,12 @@ trait ExampleAppFixture extends CatsEffectSuite with TestContainerForAll {
   // threading the backend through every call.
 
   /**
-   * Send a request whose body is a tapir-derived `Either[E, O]` and unwrap the right side, raising on the
-   * left. Use for the happy-path assertions where a non-2xx is a test failure. Tapir-derived requests have
-   * capability `Any`; the backend's `Fs2Streams[IO] & Effect[IO]` trivially conforms.
+   * Send a request whose body is a tapir-derived `Either[E, O]` and unwrap the right side, raising on the left. Use for
+   * the happy-path assertions where a non-2xx is a test failure. Tapir-derived requests have capability `Any`; the
+   * backend's `Fs2Streams[IO] & Effect[IO]` trivially conforms.
    */
   extension [E, O](req: Request[Either[E, O], Any])
+
     protected def sendOk(using backend: SttpBackend[IO, Fs2Streams[IO]]): IO[O] =
       req.send(backend).flatMap(_.body match {
         case Right(o) => IO.pure(o)
@@ -114,6 +115,7 @@ trait ExampleAppFixture extends CatsEffectSuite with TestContainerForAll {
 
   /** Send and return the full response — for status-code assertions and error-envelope inspection. */
   extension [T](req: Request[T, Any])
+
     protected def sendResp(using backend: SttpBackend[IO, Fs2Streams[IO]]): IO[Response[T]] =
       req.send(backend)
 

--- a/modules/example/src/test/scala/skunk/sharp/example/api/BookingsFilterEndpointSuite.scala
+++ b/modules/example/src/test/scala/skunk/sharp/example/api/BookingsFilterEndpointSuite.scala
@@ -9,22 +9,26 @@ import java.time.LocalDate
 import java.util.UUID
 
 /**
- * End-to-end test for `GET /api/v1/bookings`. Mirrors [[RoomsFilterEndpointSuite]] but exercises the
- * date-range filter cases — `OverlapsPeriod` (paired bounds), `StartsOnOrAfter` / `EndsOnOrBefore`
- * (half-bounded), `RoomsIn`, `BookerNameContains`, `TitleContains`. The repository materialises these
- * via skunk-sharp's range operators (`&&`, `<@`); this test covers the full path back to JSON responses.
+ * End-to-end test for `GET /api/v1/bookings`. Mirrors [[RoomsFilterEndpointSuite]] but exercises the date-range filter
+ * cases — `OverlapsPeriod` (paired bounds), `StartsOnOrAfter` / `EndsOnOrBefore` (half-bounded), `RoomsIn`,
+ * `BookerNameContains`, `TitleContains`. The repository materialises these via skunk-sharp's range operators (`&&`,
+ * `<@`); this test covers the full path back to JSON responses.
  */
 class BookingsFilterEndpointSuite extends ExampleAppFixture {
 
-  private val createRoomReq    = interpreter.toRequestThrowDecodeFailures(Endpoints.rooms.create,    Some(baseUri))
+  private val createRoomReq    = interpreter.toRequestThrowDecodeFailures(Endpoints.rooms.create, Some(baseUri))
   private val createBookingReq = interpreter.toRequestThrowDecodeFailures(Endpoints.bookings.create, Some(baseUri))
-  private val listBookingsReq  = interpreter.toRequestThrowDecodeFailures(Endpoints.bookings.list,   Some(baseUri))
+  private val listBookingsReq  = interpreter.toRequestThrowDecodeFailures(Endpoints.bookings.list, Some(baseUri))
 
   private def createRoom(name: String, capacity: Int)(using SttpBackend[IO, Fs2Streams[IO]]): IO[RoomResponse] =
     createRoomReq(CreateRoomRequest(name, capacity)).sendOk
 
   private def createBooking(
-    roomId: UUID, booker: String, title: String, from: LocalDate, to: LocalDate
+    roomId: UUID,
+    booker: String,
+    title: String,
+    from: LocalDate,
+    to: LocalDate
   )(using SttpBackend[IO, Fs2Streams[IO]]): IO[BookingResponse] =
     createBookingReq(CreateBookingRequest(roomId, booker, title, from, to)).sendOk
 
@@ -34,16 +38,17 @@ class BookingsFilterEndpointSuite extends ExampleAppFixture {
   test("filter bookings by `roomIds` (IN)") {
     withContainers { containers =>
       appBackend(containers).use { case given SttpBackend[IO, Fs2Streams[IO]] =>
-        truncateAll(containers) *> (for {
-          a <- createRoom("A", 2)
-          b <- createRoom("B", 2)
-          c <- createRoom("C", 2)
-          _ <- createBooking(a.id, "alice", "ax", LocalDate.parse("2024-01-01"), LocalDate.parse("2024-01-10"))
-          _ <- createBooking(b.id, "bob", "bx", LocalDate.parse("2024-02-01"), LocalDate.parse("2024-02-10"))
-          _ <- createBooking(c.id, "carol", "cx", LocalDate.parse("2024-03-01"), LocalDate.parse("2024-03-10"))
-          rs <- listBookings(BookingFilterQuery.empty.copy(roomIds = List(a.id, b.id)))
-          _ = assertEquals(rs.map(_.title).toSet, Set("ax", "bx"))
-        } yield ())
+        truncateAll(containers) *>
+          (for {
+            a  <- createRoom("A", 2)
+            b  <- createRoom("B", 2)
+            c  <- createRoom("C", 2)
+            _  <- createBooking(a.id, "alice", "ax", LocalDate.parse("2024-01-01"), LocalDate.parse("2024-01-10"))
+            _  <- createBooking(b.id, "bob", "bx", LocalDate.parse("2024-02-01"), LocalDate.parse("2024-02-10"))
+            _  <- createBooking(c.id, "carol", "cx", LocalDate.parse("2024-03-01"), LocalDate.parse("2024-03-10"))
+            rs <- listBookings(BookingFilterQuery.empty.copy(roomIds = List(a.id, b.id)))
+            _ = assertEquals(rs.map(_.title).toSet, Set("ax", "bx"))
+          } yield ())
       }
     }
   }
@@ -51,16 +56,30 @@ class BookingsFilterEndpointSuite extends ExampleAppFixture {
   test("filter bookings by bookerNameContains and titleContains (case-insensitive)") {
     withContainers { containers =>
       appBackend(containers).use { case given SttpBackend[IO, Fs2Streams[IO]] =>
-        truncateAll(containers) *> (for {
-          r <- createRoom("only", 1)
-          _ <- createBooking(r.id, "Alice Smith", "team standup", LocalDate.parse("2024-01-01"), LocalDate.parse("2024-01-02"))
-          _ <- createBooking(r.id, "Bob Jones",   "1:1 sync",     LocalDate.parse("2024-01-03"), LocalDate.parse("2024-01-04"))
-          _ <- createBooking(r.id, "Alice Watt",  "design review",LocalDate.parse("2024-01-05"), LocalDate.parse("2024-01-06"))
-          alices <- listBookings(BookingFilterQuery.empty.copy(bookerNameContains = Some("alice")))
-          _ = assertEquals(alices.map(_.bookerName).toSet, Set("Alice Smith", "Alice Watt"))
-          syncs <- listBookings(BookingFilterQuery.empty.copy(titleContains = Some("sync")))
-          _ = assertEquals(syncs.map(_.title), List("1:1 sync"))
-        } yield ())
+        truncateAll(containers) *>
+          (for {
+            r <- createRoom("only", 1)
+            _ <- createBooking(
+              r.id,
+              "Alice Smith",
+              "team standup",
+              LocalDate.parse("2024-01-01"),
+              LocalDate.parse("2024-01-02")
+            )
+            _ <-
+              createBooking(r.id, "Bob Jones", "1:1 sync", LocalDate.parse("2024-01-03"), LocalDate.parse("2024-01-04"))
+            _ <- createBooking(
+              r.id,
+              "Alice Watt",
+              "design review",
+              LocalDate.parse("2024-01-05"),
+              LocalDate.parse("2024-01-06")
+            )
+            alices <- listBookings(BookingFilterQuery.empty.copy(bookerNameContains = Some("alice")))
+            _ = assertEquals(alices.map(_.bookerName).toSet, Set("Alice Smith", "Alice Watt"))
+            syncs <- listBookings(BookingFilterQuery.empty.copy(titleContains = Some("sync")))
+            _ = assertEquals(syncs.map(_.title), List("1:1 sync"))
+          } yield ())
       }
     }
   }
@@ -68,18 +87,19 @@ class BookingsFilterEndpointSuite extends ExampleAppFixture {
   test("filter bookings by overlapsPeriod (paired bounds — `period && [from, to)`)") {
     withContainers { containers =>
       appBackend(containers).use { case given SttpBackend[IO, Fs2Streams[IO]] =>
-        truncateAll(containers) *> (for {
-          r <- createRoom("ovr", 1)
-          _ <- createBooking(r.id, "x", "ancient", LocalDate.parse("2000-01-01"), LocalDate.parse("2000-01-31"))
-          _ <- createBooking(r.id, "x", "fresh",   LocalDate.parse("2024-06-01"), LocalDate.parse("2024-06-30"))
-          _ <- createBooking(r.id, "x", "future",  LocalDate.parse("2030-01-01"), LocalDate.parse("2030-01-31"))
-          probe = BookingFilterQuery.empty.copy(
-            overlapsFrom = Some(LocalDate.parse("2024-01-01")),
-            overlapsTo   = Some(LocalDate.parse("2024-12-31"))
-          )
-          hits <- listBookings(probe)
-          _ = assertEquals(hits.map(_.title), List("fresh"))
-        } yield ())
+        truncateAll(containers) *>
+          (for {
+            r <- createRoom("ovr", 1)
+            _ <- createBooking(r.id, "x", "ancient", LocalDate.parse("2000-01-01"), LocalDate.parse("2000-01-31"))
+            _ <- createBooking(r.id, "x", "fresh", LocalDate.parse("2024-06-01"), LocalDate.parse("2024-06-30"))
+            _ <- createBooking(r.id, "x", "future", LocalDate.parse("2030-01-01"), LocalDate.parse("2030-01-31"))
+            probe = BookingFilterQuery.empty.copy(
+              overlapsFrom = Some(LocalDate.parse("2024-01-01")),
+              overlapsTo = Some(LocalDate.parse("2024-12-31"))
+            )
+            hits <- listBookings(probe)
+            _ = assertEquals(hits.map(_.title), List("fresh"))
+          } yield ())
       }
     }
   }
@@ -87,16 +107,17 @@ class BookingsFilterEndpointSuite extends ExampleAppFixture {
   test("filter bookings by startsOnOrAfter (half-bounded — `period <@ [date, +∞)`)") {
     withContainers { containers =>
       appBackend(containers).use { case given SttpBackend[IO, Fs2Streams[IO]] =>
-        truncateAll(containers) *> (for {
-          r <- createRoom("sb", 1)
-          _ <- createBooking(r.id, "x", "early",  LocalDate.parse("2024-01-01"), LocalDate.parse("2024-01-31"))
-          _ <- createBooking(r.id, "x", "middle", LocalDate.parse("2024-06-01"), LocalDate.parse("2024-06-30"))
-          _ <- createBooking(r.id, "x", "late",   LocalDate.parse("2024-12-01"), LocalDate.parse("2024-12-31"))
-          rs <- listBookings(
-                  BookingFilterQuery.empty.copy(startsOnOrAfter = Some(LocalDate.parse("2024-06-01")))
-                )
-          _ = assertEquals(rs.map(_.title).toSet, Set("middle", "late"))
-        } yield ())
+        truncateAll(containers) *>
+          (for {
+            r  <- createRoom("sb", 1)
+            _  <- createBooking(r.id, "x", "early", LocalDate.parse("2024-01-01"), LocalDate.parse("2024-01-31"))
+            _  <- createBooking(r.id, "x", "middle", LocalDate.parse("2024-06-01"), LocalDate.parse("2024-06-30"))
+            _  <- createBooking(r.id, "x", "late", LocalDate.parse("2024-12-01"), LocalDate.parse("2024-12-31"))
+            rs <- listBookings(
+              BookingFilterQuery.empty.copy(startsOnOrAfter = Some(LocalDate.parse("2024-06-01")))
+            )
+            _ = assertEquals(rs.map(_.title).toSet, Set("middle", "late"))
+          } yield ())
       }
     }
   }
@@ -104,27 +125,31 @@ class BookingsFilterEndpointSuite extends ExampleAppFixture {
   test("AND-combination — roomIds + overlapsPeriod + bookerNameContains") {
     withContainers { containers =>
       appBackend(containers).use { case given SttpBackend[IO, Fs2Streams[IO]] =>
-        truncateAll(containers) *> (for {
-          a <- createRoom("RA", 1)
-          b <- createRoom("RB", 1)
-          // In room A: alice with booking that overlaps 2024-Q2 — match
-          _ <- createBooking(a.id, "alice", "match",       LocalDate.parse("2024-04-01"), LocalDate.parse("2024-04-15"))
-          // In room A: bob with booking that overlaps — wrong booker, no match
-          _ <- createBooking(a.id, "bob",   "wrong-booker",LocalDate.parse("2024-05-01"), LocalDate.parse("2024-05-15"))
-          // In room A: alice in Q1 — wrong period, no match
-          _ <- createBooking(a.id, "alice", "wrong-period",LocalDate.parse("2024-01-10"), LocalDate.parse("2024-01-20"))
-          // In room B: alice overlapping — wrong room, no match
-          _ <- createBooking(b.id, "alice", "wrong-room",  LocalDate.parse("2024-04-10"), LocalDate.parse("2024-04-20"))
-          rs <- listBookings(
-                  BookingFilterQuery.empty.copy(
-                    roomIds            = List(a.id),
-                    bookerNameContains = Some("alice"),
-                    overlapsFrom       = Some(LocalDate.parse("2024-04-01")),
-                    overlapsTo         = Some(LocalDate.parse("2024-06-30"))
-                  )
-                )
-          _ = assertEquals(rs.map(_.title), List("match"))
-        } yield ())
+        truncateAll(containers) *>
+          (for {
+            a <- createRoom("RA", 1)
+            b <- createRoom("RB", 1)
+            // In room A: alice with booking that overlaps 2024-Q2 — match
+            _ <- createBooking(a.id, "alice", "match", LocalDate.parse("2024-04-01"), LocalDate.parse("2024-04-15"))
+            // In room A: bob with booking that overlaps — wrong booker, no match
+            _ <-
+              createBooking(a.id, "bob", "wrong-booker", LocalDate.parse("2024-05-01"), LocalDate.parse("2024-05-15"))
+            // In room A: alice in Q1 — wrong period, no match
+            _ <-
+              createBooking(a.id, "alice", "wrong-period", LocalDate.parse("2024-01-10"), LocalDate.parse("2024-01-20"))
+            // In room B: alice overlapping — wrong room, no match
+            _ <-
+              createBooking(b.id, "alice", "wrong-room", LocalDate.parse("2024-04-10"), LocalDate.parse("2024-04-20"))
+            rs <- listBookings(
+              BookingFilterQuery.empty.copy(
+                roomIds = List(a.id),
+                bookerNameContains = Some("alice"),
+                overlapsFrom = Some(LocalDate.parse("2024-04-01")),
+                overlapsTo = Some(LocalDate.parse("2024-06-30"))
+              )
+            )
+            _ = assertEquals(rs.map(_.title), List("match"))
+          } yield ())
       }
     }
   }
@@ -132,13 +157,14 @@ class BookingsFilterEndpointSuite extends ExampleAppFixture {
   test("empty filter set returns the static `findAllQ` path — all bookings") {
     withContainers { containers =>
       appBackend(containers).use { case given SttpBackend[IO, Fs2Streams[IO]] =>
-        truncateAll(containers) *> (for {
-          r <- createRoom("e", 1)
-          _ <- createBooking(r.id, "x", "b1", LocalDate.parse("2024-01-01"), LocalDate.parse("2024-01-02"))
-          _ <- createBooking(r.id, "x", "b2", LocalDate.parse("2024-02-01"), LocalDate.parse("2024-02-02"))
-          all <- listBookings(BookingFilterQuery.empty)
-          _ = assertEquals(all.size, 2)
-        } yield ())
+        truncateAll(containers) *>
+          (for {
+            r   <- createRoom("e", 1)
+            _   <- createBooking(r.id, "x", "b1", LocalDate.parse("2024-01-01"), LocalDate.parse("2024-01-02"))
+            _   <- createBooking(r.id, "x", "b2", LocalDate.parse("2024-02-01"), LocalDate.parse("2024-02-02"))
+            all <- listBookings(BookingFilterQuery.empty)
+            _ = assertEquals(all.size, 2)
+          } yield ())
       }
     }
   }

--- a/modules/example/src/test/scala/skunk/sharp/example/api/RoomsFilterEndpointSuite.scala
+++ b/modules/example/src/test/scala/skunk/sharp/example/api/RoomsFilterEndpointSuite.scala
@@ -9,23 +9,23 @@ import sttp.model.StatusCode
 import java.util.UUID
 
 /**
- * End-to-end test for `GET /api/v1/rooms` with the dynamic-filter query DTO. Spins up Postgres + the live
- * app via [[ExampleAppFixture]], creates a known fixture set of rooms via `POST`, then exercises filter
- * combinations through tapir-derived sttp requests against the in-process backend.
+ * End-to-end test for `GET /api/v1/rooms` with the dynamic-filter query DTO. Spins up Postgres + the live app via
+ * [[ExampleAppFixture]], creates a known fixture set of rooms via `POST`, then exercises filter combinations through
+ * tapir-derived sttp requests against the in-process backend.
  *
- * The point is to verify the full path: tapir's `EndpointInput.derived[RoomFilterQuery]` correctly extracts
- * each query param shape on the *server* (`Option[T]`, repeated `List[T]`), and the *same* endpoint value
- * on the *client* side rebuilds those query params from the typed DTO via `SttpClientInterpreter` — both
- * sides exchange `RoomFilterQuery` values, no string-keying anywhere.
+ * The point is to verify the full path: tapir's `EndpointInput.derived[RoomFilterQuery]` correctly extracts each query
+ * param shape on the *server* (`Option[T]`, repeated `List[T]`), and the *same* endpoint value on the *client* side
+ * rebuilds those query params from the typed DTO via `SttpClientInterpreter` — both sides exchange `RoomFilterQuery`
+ * values, no string-keying anywhere.
  *
- * The `SttpBackend` is bound as a `given` per test via `case given …` in the resource-`use` lambda; the
- * helper methods take it as a context parameter so call sites stay close to "just call the endpoint".
+ * The `SttpBackend` is bound as a `given` per test via `case given …` in the resource-`use` lambda; the helper methods
+ * take it as a context parameter so call sites stay close to "just call the endpoint".
  */
 class RoomsFilterEndpointSuite extends ExampleAppFixture {
 
   private val createRoomReq = interpreter.toRequestThrowDecodeFailures(Endpoints.rooms.create, Some(baseUri))
-  private val listReq       = interpreter.toRequestThrowDecodeFailures(Endpoints.rooms.list,   Some(baseUri))
-  private val getByIdReq    = interpreter.toRequest(Endpoints.rooms.getById,                   Some(baseUri))
+  private val listReq       = interpreter.toRequestThrowDecodeFailures(Endpoints.rooms.list, Some(baseUri))
+  private val getByIdReq    = interpreter.toRequest(Endpoints.rooms.getById, Some(baseUri))
 
   private def createRoom(name: String, capacity: Int)(using SttpBackend[IO, Fs2Streams[IO]]): IO[RoomResponse] =
     createRoomReq(CreateRoomRequest(name, capacity)).sendOk
@@ -36,17 +36,18 @@ class RoomsFilterEndpointSuite extends ExampleAppFixture {
   test("filter rooms by minCapacity / maxCapacity") {
     withContainers { containers =>
       appBackend(containers).use { case given SttpBackend[IO, Fs2Streams[IO]] =>
-        truncateAll(containers) *> (for {
-          _ <- createRoom("small", 4)
-          _ <- createRoom("medium", 12)
-          _ <- createRoom("large", 50)
-          all <- listRooms(RoomFilterQuery.empty)
-          _ = assertEquals(all.map(_.name).toSet, Set("small", "medium", "large"))
-          big <- listRooms(RoomFilterQuery.empty.copy(minCapacity = Some(10)))
-          _ = assertEquals(big.map(_.name).toSet, Set("medium", "large"))
-          mid <- listRooms(RoomFilterQuery.empty.copy(minCapacity = Some(5), maxCapacity = Some(20)))
-          _ = assertEquals(mid.map(_.name).toSet, Set("medium"))
-        } yield ())
+        truncateAll(containers) *>
+          (for {
+            _   <- createRoom("small", 4)
+            _   <- createRoom("medium", 12)
+            _   <- createRoom("large", 50)
+            all <- listRooms(RoomFilterQuery.empty)
+            _ = assertEquals(all.map(_.name).toSet, Set("small", "medium", "large"))
+            big <- listRooms(RoomFilterQuery.empty.copy(minCapacity = Some(10)))
+            _ = assertEquals(big.map(_.name).toSet, Set("medium", "large"))
+            mid <- listRooms(RoomFilterQuery.empty.copy(minCapacity = Some(5), maxCapacity = Some(20)))
+            _ = assertEquals(mid.map(_.name).toSet, Set("medium"))
+          } yield ())
       }
     }
   }
@@ -54,15 +55,16 @@ class RoomsFilterEndpointSuite extends ExampleAppFixture {
   test("filter rooms by nameContains (ILIKE substring)") {
     withContainers { containers =>
       appBackend(containers).use { case given SttpBackend[IO, Fs2Streams[IO]] =>
-        truncateAll(containers) *> (for {
-          _ <- createRoom("Atrium-A", 8)
-          _ <- createRoom("Atrium-B", 8)
-          _ <- createRoom("Lounge", 4)
-          atria <- listRooms(RoomFilterQuery.empty.copy(nameContains = Some("atrium")))
-          _ = assertEquals(atria.map(_.name).toSet, Set("Atrium-A", "Atrium-B"))
-          lounges <- listRooms(RoomFilterQuery.empty.copy(nameContains = Some("lou")))
-          _ = assertEquals(lounges.map(_.name), List("Lounge"))
-        } yield ())
+        truncateAll(containers) *>
+          (for {
+            _     <- createRoom("Atrium-A", 8)
+            _     <- createRoom("Atrium-B", 8)
+            _     <- createRoom("Lounge", 4)
+            atria <- listRooms(RoomFilterQuery.empty.copy(nameContains = Some("atrium")))
+            _ = assertEquals(atria.map(_.name).toSet, Set("Atrium-A", "Atrium-B"))
+            lounges <- listRooms(RoomFilterQuery.empty.copy(nameContains = Some("lou")))
+            _ = assertEquals(lounges.map(_.name), List("Lounge"))
+          } yield ())
       }
     }
   }
@@ -70,13 +72,14 @@ class RoomsFilterEndpointSuite extends ExampleAppFixture {
   test("filter rooms by repeated `names` query param (IN)") {
     withContainers { containers =>
       appBackend(containers).use { case given SttpBackend[IO, Fs2Streams[IO]] =>
-        truncateAll(containers) *> (for {
-          _ <- createRoom("alpha", 2)
-          _ <- createRoom("beta", 2)
-          _ <- createRoom("gamma", 2)
-          rs <- listRooms(RoomFilterQuery.empty.copy(names = List("alpha", "gamma")))
-          _ = assertEquals(rs.map(_.name).toSet, Set("alpha", "gamma"))
-        } yield ())
+        truncateAll(containers) *>
+          (for {
+            _  <- createRoom("alpha", 2)
+            _  <- createRoom("beta", 2)
+            _  <- createRoom("gamma", 2)
+            rs <- listRooms(RoomFilterQuery.empty.copy(names = List("alpha", "gamma")))
+            _ = assertEquals(rs.map(_.name).toSet, Set("alpha", "gamma"))
+          } yield ())
       }
     }
   }
@@ -84,13 +87,14 @@ class RoomsFilterEndpointSuite extends ExampleAppFixture {
   test("filter rooms by `ids` (IN) — restrict the listing to a known UUID set") {
     withContainers { containers =>
       appBackend(containers).use { case given SttpBackend[IO, Fs2Streams[IO]] =>
-        truncateAll(containers) *> (for {
-          a <- createRoom("A", 1)
-          b <- createRoom("B", 2)
-          _ <- createRoom("C", 3)
-          rs <- listRooms(RoomFilterQuery.empty.copy(ids = List(a.id, b.id)))
-          _ = assertEquals(rs.map(_.name).toSet, Set("A", "B"))
-        } yield ())
+        truncateAll(containers) *>
+          (for {
+            a  <- createRoom("A", 1)
+            b  <- createRoom("B", 2)
+            _  <- createRoom("C", 3)
+            rs <- listRooms(RoomFilterQuery.empty.copy(ids = List(a.id, b.id)))
+            _ = assertEquals(rs.map(_.name).toSet, Set("A", "B"))
+          } yield ())
       }
     }
   }
@@ -98,22 +102,23 @@ class RoomsFilterEndpointSuite extends ExampleAppFixture {
   test("AND-combination — minCapacity + nameContains + names list") {
     withContainers { containers =>
       appBackend(containers).use { case given SttpBackend[IO, Fs2Streams[IO]] =>
-        truncateAll(containers) *> (for {
-          _ <- createRoom("Hub-North", 30)
-          _ <- createRoom("Hub-South", 5)
-          _ <- createRoom("Hub-East", 30)
-          _ <- createRoom("Plaza", 40)
-          rs <- listRooms(
-                  RoomFilterQuery(
-                    minCapacity  = Some(10),
-                    maxCapacity  = None,
-                    nameContains = Some("hub"),
-                    names        = List("Hub-North", "Hub-East"),
-                    ids          = Nil
-                  )
-                )
-          _ = assertEquals(rs.map(_.name).toSet, Set("Hub-North", "Hub-East"))
-        } yield ())
+        truncateAll(containers) *>
+          (for {
+            _  <- createRoom("Hub-North", 30)
+            _  <- createRoom("Hub-South", 5)
+            _  <- createRoom("Hub-East", 30)
+            _  <- createRoom("Plaza", 40)
+            rs <- listRooms(
+              RoomFilterQuery(
+                minCapacity = Some(10),
+                maxCapacity = None,
+                nameContains = Some("hub"),
+                names = List("Hub-North", "Hub-East"),
+                ids = Nil
+              )
+            )
+            _ = assertEquals(rs.map(_.name).toSet, Set("Hub-North", "Hub-East"))
+          } yield ())
       }
     }
   }
@@ -121,12 +126,13 @@ class RoomsFilterEndpointSuite extends ExampleAppFixture {
   test("empty filter set returns the static `findAllQ` path — all rooms") {
     withContainers { containers =>
       appBackend(containers).use { case given SttpBackend[IO, Fs2Streams[IO]] =>
-        truncateAll(containers) *> (for {
-          _ <- createRoom("x1", 1)
-          _ <- createRoom("x2", 1)
-          all <- listRooms(RoomFilterQuery.empty)
-          _ = assertEquals(all.size, 2)
-        } yield ())
+        truncateAll(containers) *>
+          (for {
+            _   <- createRoom("x1", 1)
+            _   <- createRoom("x2", 1)
+            all <- listRooms(RoomFilterQuery.empty)
+            _ = assertEquals(all.size, 2)
+          } yield ())
       }
     }
   }

--- a/modules/example/src/test/scala/skunk/sharp/example/api/TransformersFilterSuite.scala
+++ b/modules/example/src/test/scala/skunk/sharp/example/api/TransformersFilterSuite.scala
@@ -8,9 +8,9 @@ import java.time.LocalDate
 import java.util.UUID
 
 /**
- * Pure unit tests for the query DTO ↔ filter ADT projection. The SQL-rendering side of each filter case is
- * already covered by core suites (`WhereSuite`, `ParamSuite`, `RangeSuite`) — what's specific to the example
- * module is the `q.toFilters` extension's logic, especially the paired-field rule for `OverlapsPeriod`.
+ * Pure unit tests for the query DTO ↔ filter ADT projection. The SQL-rendering side of each filter case is already
+ * covered by core suites (`WhereSuite`, `ParamSuite`, `RangeSuite`) — what's specific to the example module is the
+ * `q.toFilters` extension's logic, especially the paired-field rule for `OverlapsPeriod`.
  */
 class TransformersFilterSuite extends munit.FunSuite {
 
@@ -20,12 +20,12 @@ class TransformersFilterSuite extends munit.FunSuite {
 
   test("RoomFilterQuery — every field translates to its filter case") {
     val ids = List(UUID.randomUUID, UUID.randomUUID)
-    val q = RoomFilterQuery(
-      minCapacity  = Some(10),
-      maxCapacity  = Some(50),
+    val q   = RoomFilterQuery(
+      minCapacity = Some(10),
+      maxCapacity = Some(50),
       nameContains = Some("hub"),
-      names        = List("alpha", "beta"),
-      ids          = ids
+      names = List("alpha", "beta"),
+      ids = ids
     )
     assertEquals(
       q.toFilters,
@@ -41,11 +41,11 @@ class TransformersFilterSuite extends munit.FunSuite {
 
   test("RoomFilterQuery — empty multi-value lists drop out (no IN clause)") {
     val q = RoomFilterQuery(
-      minCapacity  = Some(1),
-      maxCapacity  = None,
+      minCapacity = Some(1),
+      maxCapacity = None,
       nameContains = None,
-      names        = Nil,
-      ids          = Nil
+      names = Nil,
+      ids = Nil
     )
     assertEquals(q.toFilters, List(RoomFilter.CapacityAtLeast(1)))
   }
@@ -58,14 +58,14 @@ class TransformersFilterSuite extends munit.FunSuite {
     val rids = List(UUID.randomUUID, UUID.randomUUID)
     val from = LocalDate.parse("2024-01-01")
     val to   = LocalDate.parse("2024-12-31")
-    val q = BookingFilterQuery(
-      roomIds            = rids,
+    val q    = BookingFilterQuery(
+      roomIds = rids,
       bookerNameContains = Some("alice"),
-      titleContains      = Some("standup"),
-      overlapsFrom       = Some(from),
-      overlapsTo         = Some(to),
-      startsOnOrAfter    = Some(from),
-      endsOnOrBefore     = Some(to)
+      titleContains = Some("standup"),
+      overlapsFrom = Some(from),
+      overlapsTo = Some(to),
+      startsOnOrAfter = Some(from),
+      endsOnOrBefore = Some(to)
     )
     assertEquals(
       q.toFilters,
@@ -92,7 +92,7 @@ class TransformersFilterSuite extends munit.FunSuite {
 
   test("BookingFilterQuery — half-bounded startsOnOrAfter is independent of the OverlapsPeriod pair") {
     val date = LocalDate.parse("2024-06-15")
-    val q = BookingFilterQuery.empty.copy(startsOnOrAfter = Some(date))
+    val q    = BookingFilterQuery.empty.copy(startsOnOrAfter = Some(date))
     assertEquals(q.toFilters, List(BookingFilter.StartsOnOrAfter(date)))
   }
 }

--- a/modules/tests/src/test/scala/skunk/sharp/tests/GroupBySuite.scala
+++ b/modules/tests/src/test/scala/skunk/sharp/tests/GroupBySuite.scala
@@ -140,7 +140,9 @@ class GroupBySuite extends PgFixture {
             (id = UUID.randomUUID, email = "sa2@x", age = bucket, deleted_at = Option.empty[OffsetDateTime])
           ).compile.run(s)
           concat <-
-            users.select(u => Pg.stringAgg(u.email, lit(", "))).where(u => u.age === Param.bind(bucket)).compile.unique(s)
+            users.select(u => Pg.stringAgg(u.email, lit(", "))).where(u => u.age === Param.bind(bucket)).compile.unique(
+              s
+            )
           _ = assert(concat.contains("sa1@x") && concat.contains("sa2@x"), s"got '$concat'")
           _ = assert(concat.contains(", "), s"separator missing: '$concat'")
         } yield ()

--- a/modules/tests/src/test/scala/skunk/sharp/tests/InListSizesSuite.scala
+++ b/modules/tests/src/test/scala/skunk/sharp/tests/InListSizesSuite.scala
@@ -12,14 +12,13 @@ object InListSizesSuite {
 }
 
 /**
- * Dynamically-sized IN lists. Exercises the new `col.in(NonEmptyList[TypedExpr[T, Void]])` API across a range
- * of list sizes — both `Param.bind`-baked (the realistic runtime case) and `lit`-rendered (compile-time).
+ * Dynamically-sized IN lists. Exercises the new `col.in(NonEmptyList[TypedExpr[T, Void]])` API across a range of list
+ * sizes — both `Param.bind`-baked (the realistic runtime case) and `lit`-rendered (compile-time).
  *
- * The risk being verified: skunk's prepared-statement protocol historically struggles with variable-arity
- * `IN` lists because every `$N` placeholder needs an encoder slot. Our design has each `Param.bind(v)`
- * carry its own Void-args encoder (the value is baked via `contramap[Void](_ => v)`), so the visible
- * `Args` stays `Void` regardless of list size — execution should bind the right placeholders without
- * growing the user-facing tuple.
+ * The risk being verified: skunk's prepared-statement protocol historically struggles with variable-arity `IN` lists
+ * because every `$N` placeholder needs an encoder slot. Our design has each `Param.bind(v)` carry its own Void-args
+ * encoder (the value is baked via `contramap[Void](_ => v)`), so the visible `Args` stays `Void` regardless of list
+ * size — execution should bind the right placeholders without growing the user-facing tuple.
  */
 class InListSizesSuite extends PgFixture {
   import InListSizesSuite.*
@@ -28,7 +27,7 @@ class InListSizesSuite extends PgFixture {
 
   /** Insert N users with sequential emails, return their generated UUIDs in insert order. */
   private def seedUsers(s: skunk.Session[IO], n: Int, prefix: String): IO[List[UUID]] = {
-    val ids = (1 to n).map(_ => UUID.randomUUID()).toList
+    val ids  = (1 to n).map(_ => UUID.randomUUID()).toList
     val rows = ids.zipWithIndex.map { case (id, i) =>
       (id = id, email = s"$prefix-$i@x", age = 20 + i, deleted_at = Option.empty[OffsetDateTime])
     }
@@ -44,13 +43,13 @@ class InListSizesSuite extends PgFixture {
         session(containers).use { s =>
           val pfx = s"in-bind-$n"
           for {
-            ids   <- seedUsers(s, n, pfx)
+            ids <- seedUsers(s, n, pfx)
             // Pick a subset (every other id) so we can prove the IN really filtered.
             wanted = ids.zipWithIndex.collect { case (id, i) if i % 2 == 0 => id }
             nel    = NonEmptyList.fromListUnsafe(wanted.map(Param.bind(_)))
-            rows  <- users.select(u => u.id).where(u => u.id.in(nel)).compile.run(s)
-            _      = assertEquals(rows.toSet, wanted.toSet, s"n=$n returned wrong subset")
-            _      = assertEquals(rows.size, wanted.size, s"n=$n returned wrong row count")
+            rows <- users.select(u => u.id).where(u => u.id.in(nel)).compile.run(s)
+            _ = assertEquals(rows.toSet, wanted.toSet, s"n=$n returned wrong subset")
+            _ = assertEquals(rows.size, wanted.size, s"n=$n returned wrong row count")
           } yield ()
         }
       }
@@ -64,15 +63,15 @@ class InListSizesSuite extends PgFixture {
       session(containers).use { s =>
         val pfx = "in-lit"
         for {
-          _    <- users.insert.values(
-                    (id = UUID.randomUUID, email = s"$pfx-21@x", age = 21, deleted_at = Option.empty[OffsetDateTime]),
-                    (id = UUID.randomUUID, email = s"$pfx-22@x", age = 22, deleted_at = Option.empty[OffsetDateTime]),
-                    (id = UUID.randomUUID, email = s"$pfx-99@x", age = 99, deleted_at = Option.empty[OffsetDateTime])
-                  ).compile.run(s)
+          _ <- users.insert.values(
+            (id = UUID.randomUUID, email = s"$pfx-21@x", age = 21, deleted_at = Option.empty[OffsetDateTime]),
+            (id = UUID.randomUUID, email = s"$pfx-22@x", age = 22, deleted_at = Option.empty[OffsetDateTime]),
+            (id = UUID.randomUUID, email = s"$pfx-99@x", age = 99, deleted_at = Option.empty[OffsetDateTime])
+          ).compile.run(s)
           rows <- users
-                    .select(u => u.email)
-                    .where(u => u.email.like(Param.bind(s"$pfx-%")) && u.age.in(NonEmptyList.of(lit(21), lit(22))))
-                    .compile.run(s)
+            .select(u => u.email)
+            .where(u => u.email.like(Param.bind(s"$pfx-%")) && u.age.in(NonEmptyList.of(lit(21), lit(22))))
+            .compile.run(s)
           _ = assertEquals(rows.toSet, Set(s"$pfx-21@x", s"$pfx-22@x"))
         } yield ()
       }
@@ -85,12 +84,12 @@ class InListSizesSuite extends PgFixture {
     withContainers { containers =>
       session(containers).use { s =>
         for {
-          ids  <- seedUsers(s, 3, "in-one")
-          one   = ids.head
+          ids <- seedUsers(s, 3, "in-one")
+          one = ids.head
           rows <- users
-                    .select(u => u.id)
-                    .where(u => u.id.in(NonEmptyList.one(Param.bind(one))))
-                    .compile.run(s)
+            .select(u => u.id)
+            .where(u => u.id.in(NonEmptyList.one(Param.bind(one))))
+            .compile.run(s)
           _ = assertEquals(rows, List(one))
         } yield ()
       }
@@ -103,16 +102,16 @@ class InListSizesSuite extends PgFixture {
     withContainers { containers =>
       session(containers).use { s =>
         for {
-          ids  <- seedUsers(s, 6, "in-mix")
-          want  = ids.take(3)
-          q     = users
-                    .select(u => u.id)
-                    .where(u => u.id.in(NonEmptyList.fromListUnsafe(want.map(Param.bind(_)))))
-                    .where(u => u.age >= Param[Int])
-                    .compile
+          ids <- seedUsers(s, 6, "in-mix")
+          want = ids.take(3)
+          q    = users
+            .select(u => u.id)
+            .where(u => u.id.in(NonEmptyList.fromListUnsafe(want.map(Param.bind(_)))))
+            .where(u => u.age >= Param[Int])
+            .compile
           // The Param.bind values bake into Void — only the `Param[Int]` shows up in the bind tuple.
           rows <- q.run(s)(0)
-          _     = assertEquals(rows.toSet, want.toSet)
+          _ = assertEquals(rows.toSet, want.toSet)
         } yield ()
       }
     }
@@ -126,16 +125,16 @@ class InListSizesSuite extends PgFixture {
         session(containers).use { s =>
           val pfx = s"in-paramlist-$n"
           for {
-            ids   <- seedUsers(s, n, pfx)
+            ids <- seedUsers(s, n, pfx)
             wanted = ids.zipWithIndex.collect { case (id, i) if i % 2 == 0 => id }
             // Build a query for exactly `wanted.size` ids — single prepared statement bound once.
-            q      = users.select(u => u.id).where(u => u.id.in(Param.list[UUID](wanted.size))).compile
-            _      = {
+            q = users.select(u => u.id).where(u => u.id.in(Param.list[UUID](wanted.size))).compile
+            _ = {
               val _: skunk.sharp.dsl.QueryTemplate[List[UUID], UUID] = q
             }
-            rows  <- q.run(s)(wanted)
-            _      = assertEquals(rows.toSet, wanted.toSet)
-            _      = assertEquals(rows.size, wanted.size)
+            rows <- q.run(s)(wanted)
+            _ = assertEquals(rows.toSet, wanted.toSet)
+            _ = assertEquals(rows.size, wanted.size)
           } yield ()
         }
       }
@@ -147,14 +146,14 @@ class InListSizesSuite extends PgFixture {
       session(containers).use { s =>
         for {
           all <- seedUsers(s, 8, "in-paramlist-reuse")
-          q    = users.select(u => u.id).where(u => u.id.in(Param.list[UUID](3))).compile
+          q = users.select(u => u.id).where(u => u.id.in(Param.list[UUID](3))).compile
           // Three calls with three different lists of size 3 — same prepared statement.
-          r1  <- q.run(s)(all.take(3))
-          r2  <- q.run(s)(all.slice(2, 5))
-          r3  <- q.run(s)(all.takeRight(3))
-          _    = assertEquals(r1.toSet, all.take(3).toSet)
-          _    = assertEquals(r2.toSet, all.slice(2, 5).toSet)
-          _    = assertEquals(r3.toSet, all.takeRight(3).toSet)
+          r1 <- q.run(s)(all.take(3))
+          r2 <- q.run(s)(all.slice(2, 5))
+          r3 <- q.run(s)(all.takeRight(3))
+          _ = assertEquals(r1.toSet, all.take(3).toSet)
+          _ = assertEquals(r2.toSet, all.slice(2, 5).toSet)
+          _ = assertEquals(r3.toSet, all.takeRight(3).toSet)
         } yield ()
       }
     }
@@ -165,16 +164,16 @@ class InListSizesSuite extends PgFixture {
       session(containers).use { s =>
         for {
           ids <- seedUsers(s, 6, "in-paramlist-mix")
-          q    = users
-                   .select(u => u.id)
-                   .where(u => u.id.in(Param.list[UUID](3)))
-                   .where(u => u.age >= Param[Int])
-                   .compile
-          _    = {
+          q = users
+            .select(u => u.id)
+            .where(u => u.id.in(Param.list[UUID](3)))
+            .where(u => u.age >= Param[Int])
+            .compile
+          _ = {
             val _: skunk.sharp.dsl.QueryTemplate[(List[UUID], Int), UUID] = q
           }
           rows <- q.run(s)((ids.take(3), 0))
-          _     = assertEquals(rows.toSet, ids.take(3).toSet)
+          _ = assertEquals(rows.toSet, ids.take(3).toSet)
         } yield ()
       }
     }
@@ -194,9 +193,9 @@ class InListSizesSuite extends PgFixture {
         val pfx = "in-reuse"
         for {
           allIds <- seedUsers(s, 64, pfx)
-          first   <- runFor(s,allIds.take(1))
-          some    <- runFor(s,allIds.take(7))
-          all     <- runFor(s,allIds)
+          first  <- runFor(s, allIds.take(1))
+          some   <- runFor(s, allIds.take(7))
+          all    <- runFor(s, allIds)
           _ = assertEquals(first.size, 1)
           _ = assertEquals(some.size, 7)
           _ = assertEquals(all.size, 64)

--- a/modules/tests/src/test/scala/skunk/sharp/tests/PgFunctionSuite.scala
+++ b/modules/tests/src/test/scala/skunk/sharp/tests/PgFunctionSuite.scala
@@ -130,7 +130,8 @@ class PgFunctionSuite extends PgFixture {
         for {
           _ <- assertIO(empty.select(_ => Pg.replace(param("a-b-c"), lit("-"), lit("/"))).compile.unique(s), "a/b/c")
           _ <- assertIO(empty.select(_ => Pg.substring(param("hello world"), lit(7))).compile.unique(s), "world")
-          _ <- assertIO(empty.select(_ => Pg.substring(param("hello world"), lit(1), lit(5))).compile.unique(s), "hello")
+          _ <-
+            assertIO(empty.select(_ => Pg.substring(param("hello world"), lit(1), lit(5))).compile.unique(s), "hello")
           _ <- assertIO(empty.select(_ => Pg.left(param("hello"), lit(3))).compile.unique(s), "hel")
           _ <- assertIO(empty.select(_ => Pg.right(param("hello"), lit(3))).compile.unique(s), "llo")
           _ <- assertIO(empty.select(_ => Pg.repeat(param("ab"), lit(3))).compile.unique(s), "ababab")

--- a/modules/tests/src/test/scala/skunk/sharp/tests/SetOpSuite.scala
+++ b/modules/tests/src/test/scala/skunk/sharp/tests/SetOpSuite.scala
@@ -77,7 +77,9 @@ class SetOpSuite extends PgFixture {
         for {
           _      <- f.insert.run(s)
           result <- users.select(u => u.email).where(u => u.age >= lit(30) && u.email.like(Param.bind(s"%-${f.tag}@x")))
-            .intersect(users.select(u => u.email).where(u => u.age <= lit(50) && u.email.like(Param.bind(s"%-${f.tag}@x"))))
+            .intersect(users.select(u => u.email).where(u =>
+              u.age <= lit(50) && u.email.like(Param.bind(s"%-${f.tag}@x"))
+            ))
             .compile.run(s).map(_.toSet)
           _ = assertEquals(result, Set(s"mid-${f.tag}@x"))
         } yield ()
@@ -92,7 +94,9 @@ class SetOpSuite extends PgFixture {
         for {
           _      <- f.insert.run(s)
           result <- users.select(u => u.email).where(u => u.age >= lit(30) && u.email.like(Param.bind(s"%-${f.tag}@x")))
-            .except(users.select(u => u.email).where(u => u.age >= lit(50) && u.email.like(Param.bind(s"%-${f.tag}@x"))))
+            .except(users.select(u => u.email).where(u =>
+              u.age >= lit(50) && u.email.like(Param.bind(s"%-${f.tag}@x"))
+            ))
             .compile.run(s).map(_.toSet)
           _ = assertEquals(result, Set(s"mid-${f.tag}@x"))
         } yield ()
@@ -109,7 +113,9 @@ class SetOpSuite extends PgFixture {
           // UNION of (>=30) and (<=50) = all three; EXCEPT (==70) → two rows.
           result <- users.select(u => u.email).where(u => u.age >= lit(30) && u.email.like(Param.bind(s"%-${f.tag}@x")))
             .union(users.select(u => u.email).where(u => u.age <= lit(50) && u.email.like(Param.bind(s"%-${f.tag}@x"))))
-            .except(users.select(u => u.email).where(u => u.age === lit(70) && u.email.like(Param.bind(s"%-${f.tag}@x"))))
+            .except(users.select(u => u.email).where(u =>
+              u.age === lit(70) && u.email.like(Param.bind(s"%-${f.tag}@x"))
+            ))
             .compile.run(s).map(_.toSet)
           _ = assertEquals(result, Set(s"mid-${f.tag}@x", s"young-${f.tag}@x"))
         } yield ()

--- a/modules/tests/src/test/scala/skunk/sharp/tests/WindowFunctionSuite.scala
+++ b/modules/tests/src/test/scala/skunk/sharp/tests/WindowFunctionSuite.scala
@@ -120,7 +120,9 @@ class WindowFunctionSuite extends PgFixture {
         for {
           _    <- seed(s, pfx)
           rows <- users
-            .select(u => (u.age, Pg.lag(u.age, lit(1), lit(0)).over(WindowSpec.orderBy(u.age.asc).orderBy(u.email.asc))))
+            .select(u =>
+              (u.age, Pg.lag(u.age, lit(1), lit(0)).over(WindowSpec.orderBy(u.age.asc).orderBy(u.email.asc)))
+            )
             .where(u => u.email.like(Param.bind(s"$pfx-%")))
             .orderBy(u => (u.age.asc, u.email.asc))
             .compile.run(s)


### PR DESCRIPTION
## Summary

CI's `scalafmtCheckAll` was failing because the `RedundantParens` rewrite in `.scalafmt.conf` strips parens around refinement types in `given X[T]: (Trait[T] { type Out = … }) = …` declarations — and the Scala 3 parser then misreads `: Trait[T] { … }` as the start of a `given X with { … }` body (\`'with' expected, but '{' found\`). The pattern shows up in `dsl/ProjArgsOf.scala`, `dsl/Cte.scala`, `dsl/Join.scala`.

Fix is configuration-level: drop `RedundantParens` from `rewrite.rules` (keep `SortImports`), with an inline comment explaining the trap so future edits don't reintroduce it. The rest of the diff is the one-time reformat that CI was demanding (pure whitespace / line-break / docstring-wrap shuffles, zero semantic changes).

This should also unblock the runs for #76 and #78 retroactively (same root cause).

## Test plan

- [x] `sbt scalafmtCheckAll` — clean
- [x] `sbt core/test` — 510 pass
- [x] `sbt example/test` — 21 pass

> Note: `Submit Dependencies` is a separate failure unrelated to this PR — GitHub Dependency Graph is disabled at the repo level. Enable it in repo settings, or remove that workflow step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)