### PR TITLE
Publish to GitHub Packages instead of Maven Central

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,11 +75,11 @@ jobs:
 
       - name: Make target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
-        run: mkdir -p modules/refined/target modules/iron/target modules/circe/target modules/core/target project/target
+        run: mkdir -p modules/refined/target modules/postgis/target modules/iron/target modules/circe/target modules/core/target project/target
 
       - name: Compress target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
-        run: tar cf targets.tar modules/refined/target modules/iron/target modules/circe/target modules/core/target project/target
+        run: tar cf targets.tar modules/refined/target modules/postgis/target modules/iron/target modules/circe/target modules/core/target project/target
 
       - name: Upload target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
@@ -129,65 +129,8 @@ jobs:
           tar xf targets.tar
           rm targets.tar
 
-      - name: Import signing key
-        if: env.PGP_SECRET != '' && env.PGP_PASSPHRASE == ''
-        env:
-          PGP_SECRET: ${{ secrets.PGP_SECRET }}
-          PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
-        run: echo $PGP_SECRET | base64 -d -i - | gpg --import
-
-      - name: Import signing key and strip passphrase
-        if: env.PGP_SECRET != '' && env.PGP_PASSPHRASE != ''
-        env:
-          PGP_SECRET: ${{ secrets.PGP_SECRET }}
-          PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
-        run: |
-          echo "$PGP_SECRET" | base64 -d -i - > /tmp/signing-key.gpg
-          echo "$PGP_PASSPHRASE" | gpg --pinentry-mode loopback --passphrase-fd 0 --import /tmp/signing-key.gpg
-          (echo "$PGP_PASSPHRASE"; echo; echo) | gpg --command-fd 0 --pinentry-mode loopback --change-passphrase $(gpg --list-secret-keys --with-colons 2> /dev/null | grep '^sec:' | cut --delimiter ':' --fields 5 | tail -n 1)
-
-      - name: Publish
-        env:
-          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
-          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
-          SONATYPE_CREDENTIAL_HOST: ${{ secrets.SONATYPE_CREDENTIAL_HOST }}
-        run: sbt tlCiRelease
-
-  dependency-submission:
-    name: Submit Dependencies
-    if: github.event.repository.fork == false && github.event_name != 'pull_request'
-    strategy:
-      matrix:
-        os: [ubuntu-22.04]
-        java: [temurin@17]
-    runs-on: ${{ matrix.os }}
-    steps:
-      - name: Checkout current branch (full)
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-
-      - name: Setup sbt
-        uses: sbt/setup-sbt@v1
-
-      - name: Setup Java (temurin@17)
-        id: setup-java-temurin-17
-        if: matrix.java == 'temurin@17'
-        uses: actions/setup-java@v5
-        with:
-          distribution: temurin
-          java-version: 17
-          cache: sbt
-
-      - name: sbt update
-        if: matrix.java == 'temurin@17' && steps.setup-java-temurin-17.outputs.cache-hit == 'false'
-        run: sbt +update
-
-      - name: Submit Dependencies
-        uses: scalacenter/sbt-dependency-submission@v2
-        with:
-          modules-ignore: rootjs_3 skunk-sharp-docs_3 skunk-sharp-tests_3 rootjvm_3 rootnative_3 skunk-sharp-example_3
-          configs-ignore: test scala-tool scala-doc-tool test-internal
+      - name: Publish to GitHub Packages
+        run: sbt publish
 
   site:
     name: Generate Site

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -53,6 +53,14 @@ pull_request_rules:
       add:
       - iron
       remove: []
+- name: Label postgis PRs
+  conditions:
+  - files~=^modules/postgis/
+  actions:
+    label:
+      add:
+      - postgis
+      remove: []
 - name: Label refined PRs
   conditions:
   - files~=^modules/refined/

--- a/build.sbt
+++ b/build.sbt
@@ -1,9 +1,9 @@
-import org.typelevel.scalacoptions.{ScalacOptions, ScalaVersion}
+import org.typelevel.scalacoptions.{ScalaVersion, ScalacOptions}
 
-ThisBuild / tlBaseVersion       := "0.1"
-ThisBuild / organization        := "io.github.ragb"
-ThisBuild / organizationName    := "Rui Batista"
-ThisBuild / tlGitHubRepo        := Some("skunk-sharp")
+ThisBuild / tlBaseVersion    := "0.1"
+ThisBuild / organization     := "io.github.ragb"
+ThisBuild / organizationName := "Rui Batista"
+ThisBuild / tlGitHubRepo     := Some("skunk-sharp")
 // scmInfo/homepage are derived from the git remote, not tlGitHubRepo — pin it anyway, silence lintUnused.
 Global / excludeLintKeys += tlGitHubRepo
 ThisBuild / licenses            := Seq(License.Apache2)
@@ -22,7 +22,7 @@ ThisBuild / tlFatalWarnings := true
 // SIP-71 `into` modifier — preview feature in Scala 3.8.x, stabilises in 3.9. Added via the typed `ScalacOption`
 // builder from `org.typelevel.scalac-options` so it's pinned to the right Scala range; drop once we move to 3.9+.
 ThisBuild / scalacOptions ++= {
-  val sv = ScalaVersion.fromString(scalaVersion.value).toOption
+  val sv  = ScalaVersion.fromString(scalaVersion.value).toOption
   val opt = ScalacOptions.other("-preview", _.isAtLeast(ScalaVersion(3, 8, 0)))
   sv.filter(opt.isSupported).fold(Seq.empty[String])(_ => opt.option :: opt.args)
 }

--- a/build.sbt
+++ b/build.sbt
@@ -1,8 +1,11 @@
 import org.typelevel.scalacoptions.{ScalacOptions, ScalaVersion}
 
 ThisBuild / tlBaseVersion       := "0.1"
-ThisBuild / organization        := "com.ruiandrebatista"
+ThisBuild / organization        := "io.github.ragb"
 ThisBuild / organizationName    := "Rui Batista"
+ThisBuild / tlGitHubRepo        := Some("skunk-sharp")
+// scmInfo/homepage are derived from the git remote, not tlGitHubRepo — pin it anyway, silence lintUnused.
+Global / excludeLintKeys += tlGitHubRepo
 ThisBuild / licenses            := Seq(License.Apache2)
 ThisBuild / headerCreate / skip := true
 ThisBuild / headerCheck / skip  := true
@@ -24,6 +27,32 @@ ThisBuild / scalacOptions ++= {
   sv.filter(opt.isSupported).fold(Seq.empty[String])(_ => opt.option :: opt.args)
 }
 
+// --- Publishing: GitHub Packages -------------------------------------------------
+// sbt-typelevel's release pipeline (tlCiRelease) is hard-wired to Sonatype. We override the
+// generated publish step + publishTo to target GitHub Packages instead. Switching back to
+// Maven Central later = delete this block and re-run githubWorkflowGenerate.
+ThisBuild / githubWorkflowPublish := Seq(
+  WorkflowStep.Sbt(List("publish"), name = Some("Publish to GitHub Packages"))
+)
+// GitHub Packages doesn't take signed artifacts — drop the PGP "import signing key" preamble.
+ThisBuild / githubWorkflowPublishPreamble := Seq.empty
+// This repo has GitHub's Dependency Graph feature disabled, so the submission job 404s. Drop it.
+ThisBuild / tlCiDependencyGraphJob := false
+
+// publishTo is set per-project by sbt-typelevel's Sonatype plugin, so it must be overridden
+// per-project (a ThisBuild fallback would be shadowed). CI authenticates via the GITHUB_TOKEN
+// secret, already exposed build-wide in the generated workflow's env block.
+lazy val githubPackagesPublish = Seq(
+  publishTo         := Some("GitHub Packages" at "https://maven.pkg.github.com/ragb/skunk-sharp"),
+  publishMavenStyle := true,
+  credentials += Credentials(
+    "GitHub Package Registry",
+    "maven.pkg.github.com",
+    "ragb",
+    sys.env.getOrElse("GITHUB_TOKEN", "")
+  )
+)
+
 val skunkV           = "1.0.0"
 val skunkCirceV      = "1.0.0"
 val circeV           = "0.14.15"
@@ -44,6 +73,7 @@ lazy val root = tlCrossRootProject.aggregate(core, iron, refined, circe, postgis
 
 lazy val core = project
   .in(file("modules/core"))
+  .settings(githubPackagesPublish)
   .settings(
     name := "skunk-sharp-core",
     libraryDependencies ++= Seq(
@@ -57,6 +87,7 @@ lazy val core = project
 lazy val iron = project
   .in(file("modules/iron"))
   .dependsOn(core)
+  .settings(githubPackagesPublish)
   .settings(
     name := "skunk-sharp-iron",
     libraryDependencies ++= Seq(
@@ -69,6 +100,7 @@ lazy val iron = project
 lazy val refined = project
   .in(file("modules/refined"))
   .dependsOn(core)
+  .settings(githubPackagesPublish)
   .settings(
     name := "skunk-sharp-refined",
     libraryDependencies ++= Seq(
@@ -81,6 +113,7 @@ lazy val refined = project
 lazy val circe = project
   .in(file("modules/circe"))
   .dependsOn(core)
+  .settings(githubPackagesPublish)
   .settings(
     name := "skunk-sharp-circe",
     libraryDependencies ++= Seq(
@@ -94,6 +127,7 @@ lazy val circe = project
 lazy val postgis = project
   .in(file("modules/postgis"))
   .dependsOn(core)
+  .settings(githubPackagesPublish)
   .settings(
     name := "skunk-sharp-postgis",
     libraryDependencies ++= Seq(

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -2,15 +2,34 @@
 
 ## Installation
 
+skunk-sharp is published to **GitHub Packages**, so add the resolver alongside the
+dependencies:
+
 ```scala
 // build.sbt
-libraryDependencies += "com.ruiandrebatista" %% "skunk-sharp-core" % "@VERSION@"
+resolvers += "skunk-sharp @ GitHub Packages" at
+  "https://maven.pkg.github.com/ragb/skunk-sharp"
+
+libraryDependencies += "io.github.ragb" %% "skunk-sharp-core" % "@VERSION@"
 
 // Optional modules
-libraryDependencies += "com.ruiandrebatista" %% "skunk-sharp-iron"    % "@VERSION@"
-libraryDependencies += "com.ruiandrebatista" %% "skunk-sharp-refined" % "@VERSION@"
-libraryDependencies += "com.ruiandrebatista" %% "skunk-sharp-circe"   % "@VERSION@"
-libraryDependencies += "com.ruiandrebatista" %% "skunk-sharp-postgis" % "@VERSION@"
+libraryDependencies += "io.github.ragb" %% "skunk-sharp-iron"    % "@VERSION@"
+libraryDependencies += "io.github.ragb" %% "skunk-sharp-refined" % "@VERSION@"
+libraryDependencies += "io.github.ragb" %% "skunk-sharp-circe"   % "@VERSION@"
+libraryDependencies += "io.github.ragb" %% "skunk-sharp-postgis" % "@VERSION@"
+```
+
+GitHub Packages requires authentication **even for public packages**. Add a GitHub
+[personal access token](https://github.com/settings/tokens) with the `read:packages`
+scope to your sbt credentials — e.g. in `~/.sbt/1.0/github.sbt`:
+
+```scala
+credentials += Credentials(
+  "GitHub Package Registry",
+  "maven.pkg.github.com",
+  "YOUR_GITHUB_USERNAME",
+  sys.env("GITHUB_TOKEN")
+)
 ```
 
 Requires **Scala 3.7+** (uses named tuples, stable since 3.7).

--- a/docs/docs/postgis.md
+++ b/docs/docs/postgis.md
@@ -5,7 +5,7 @@ Spatial types and `ST_*` operators, layered on top of [skunk-postgis](https://gi
 that not every consumer wants, so the bridge module follows the same separation:
 
 ```scala
-libraryDependencies += "com.ruiandrebatista" %% "skunk-sharp-postgis" % "@VERSION@"
+libraryDependencies += "io.github.ragb" %% "skunk-sharp-postgis" % "@VERSION@"
 ```
 
 Requires `CREATE EXTENSION postgis;` on the target database. The schema validator picks

--- a/modules/core/src/main/scala/skunk/sharp/Relation.scala
+++ b/modules/core/src/main/scala/skunk/sharp/Relation.scala
@@ -101,8 +101,8 @@ trait Relation[Cols <: Tuple] {
    *   2. The column's own `tpe.name` looked up in [[skunk.sharp.pg.PgTypes.extensionByType]] — fires for every column
    *      construction path, including explicit codec passes (`.column("loc", LTree.codec)`).
    *
-   * Derived / subquery / VALUES relations inherit the extensions of whatever they refer to via their `columns` tuple
-   * — no special handling needed. The schema validator reads this and emits
+   * Derived / subquery / VALUES relations inherit the extensions of whatever they refer to via their `columns` tuple —
+   * no special handling needed. The schema validator reads this and emits
    * [[skunk.sharp.validation.Mismatch.ExtensionMissing]] for anything not installed in `pg_extension`.
    */
   def requiredExtensions: Set[String] = {

--- a/modules/core/src/main/scala/skunk/sharp/TypedExpr.scala
+++ b/modules/core/src/main/scala/skunk/sharp/TypedExpr.scala
@@ -79,20 +79,21 @@ object TypedExpr {
   /**
    * Runtime counterpart of the [[lit]] macro — build a `TypedExpr[T, Void]` whose fragment carries `sqlText` inline in
    * its `parts` (no `$N` placeholders, no encoder side effects). Used by the singleton-typed `given Conversion`s in
-   * [[skunk.sharp.syntax.literal]] so that `col === 42` (and the like) produce the same SQL form as
-   * `col === 42`. Callers are responsible for the SQL spelling: pre-format primitives with [[renderInt]],
-   * [[renderString]], etc.
+   * [[skunk.sharp.syntax.literal]] so that `col === 42` (and the like) produce the same SQL form as `col === 42`.
+   * Callers are responsible for the SQL spelling: pre-format primitives with [[renderInt]], [[renderString]], etc.
    */
   def litRendered[T](sqlText: String)(using pf: PgTypeFor[T]): TypedExpr[T, Void] =
     apply[T, Void](voidFragment(sqlText), pf.codec)
 
-  /** SQL rendering for primitive literals — mirrors the cases handled by `litMacro` so the runtime conversions stay
-   *  byte-identical to the macro-produced output. */
-  def renderInt(v: Int): String       = v.toString
-  def renderLong(v: Long): String     = v.toString
-  def renderShort(v: Short): String   = v.toString
-  def renderByte(v: Byte): String     = v.toString
-  def renderBool(v: Boolean): String  = if v then "TRUE" else "FALSE"
+  /**
+   * SQL rendering for primitive literals — mirrors the cases handled by `litMacro` so the runtime conversions stay
+   * byte-identical to the macro-produced output.
+   */
+  def renderInt(v: Int): String      = v.toString
+  def renderLong(v: Long): String    = v.toString
+  def renderShort(v: Short): String  = v.toString
+  def renderByte(v: Byte): String    = v.toString
+  def renderBool(v: Boolean): String = if v then "TRUE" else "FALSE"
 
   /** SQL-string literal with single quotes, doubling internal single quotes per the Postgres escape rule. */
   def renderString(v: String): String = s"'${v.replace("'", "''")}'"

--- a/modules/core/src/main/scala/skunk/sharp/contrib/citext/Citext.scala
+++ b/modules/core/src/main/scala/skunk/sharp/contrib/citext/Citext.scala
@@ -3,9 +3,9 @@ package skunk.sharp.contrib.citext
 import skunk.sharp.contrib.TextTag
 
 /**
- * `citext` — case-insensitive text. Comparison, hashing, `=` / `LIKE` are all case-insensitive at the storage layer,
- * so declaring `email: Citext` (instead of bare `String`) gives Scala-side type safety without any per-call
- * `lower(...)` ceremony.
+ * `citext` — case-insensitive text. Comparison, hashing, `=` / `LIKE` are all case-insensitive at the storage layer, so
+ * declaring `email: Citext` (instead of bare `String`) gives Scala-side type safety without any per-call `lower(...)`
+ * ceremony.
  *
  * Requires `CREATE EXTENSION citext;` — picked up by the schema validator automatically through the `PgTypeFor`
  * registered on the companion.

--- a/modules/core/src/main/scala/skunk/sharp/contrib/fuzzystrmatch/PgFuzzy.scala
+++ b/modules/core/src/main/scala/skunk/sharp/contrib/fuzzystrmatch/PgFuzzy.scala
@@ -27,10 +27,10 @@ trait PgFuzzy {
     delCost: TypedExpr[Int, D],
     subCost: TypedExpr[Int, E]
   ): TypedExpr[Int, Where.Concat[A, Where.Concat[B, Where.Concat[C, Where.Concat[D, E]]]]] = {
-    val deTail = TypedExpr.combineSepInl[D, E](delCost.fragment, ", ", subCost.fragment)
-    val cdeTail = TypedExpr.combineSepInl[C, Where.Concat[D, E]](insCost.fragment, ", ", deTail)
+    val deTail   = TypedExpr.combineSepInl[D, E](delCost.fragment, ", ", subCost.fragment)
+    val cdeTail  = TypedExpr.combineSepInl[C, Where.Concat[D, E]](insCost.fragment, ", ", deTail)
     val bcdeTail = TypedExpr.combineSepInl[B, Where.Concat[C, Where.Concat[D, E]]](b.fragment, ", ", cdeTail)
-    val inner = TypedExpr
+    val inner    = TypedExpr
       .combineSepInl[A, Where.Concat[B, Where.Concat[C, Where.Concat[D, E]]]](a.fragment, ", ", bcdeTail)
     val frag = TypedExpr.wrap("levenshtein(", inner, ")")
     TypedExpr[Int, Where.Concat[A, Where.Concat[B, Where.Concat[C, Where.Concat[D, E]]]]](frag, skunk.codec.all.int4)

--- a/modules/core/src/main/scala/skunk/sharp/contrib/hstore/Hstore.scala
+++ b/modules/core/src/main/scala/skunk/sharp/contrib/hstore/Hstore.scala
@@ -23,7 +23,7 @@ object Hstore {
   val RequiredExtension: String = "hstore"
 
   def apply(entries: Map[String, Option[String]]): Hstore = entries
-  def apply(entries: (String, Option[String])*): Hstore  = entries.toMap
+  def apply(entries: (String, Option[String])*): Hstore   = entries.toMap
 
   val codec: Codec[Hstore] =
     Codec.simple[Hstore](encode, decode(_).map(apply), Type("hstore"))
@@ -31,8 +31,8 @@ object Hstore {
   given PgTypeFor[Hstore] = PgTypeFor.instanceWithExtension(codec, RequiredExtension)
 
   private def encode(h: Hstore): String = {
-    val sb       = new StringBuilder
-    var first    = true
+    val sb    = new StringBuilder
+    var first = true
     h.iterator.foreach { case (k, vOpt) =>
       if (first) first = false else sb ++= ", "
       sb += '"'
@@ -70,8 +70,8 @@ object Hstore {
       if (i >= len || s.charAt(i) != '"') Left(s"hstore: expected '\"' at offset $i")
       else {
         i += 1
-        val buf = new StringBuilder
-        var done = false
+        val buf         = new StringBuilder
+        var done        = false
         var err: String = null
         while (!done && err == null) {
           if (i >= len) err = "hstore: unterminated quoted token"
@@ -100,8 +100,10 @@ object Hstore {
             i += 2
             skipWs()
             // Value is either NULL (case-insensitive, unquoted) or a quoted string.
-            if (i + 3 < len && s.regionMatches(true, i, "NULL", 0, 4) &&
-                (i + 4 == len || !isUnquotedTail(s.charAt(i + 4)))) {
+            if (
+              i + 3 < len && s.regionMatches(true, i, "NULL", 0, 4) &&
+              (i + 4 == len || !isUnquotedTail(s.charAt(i + 4)))
+            ) {
               i += 4
               out.put(k, None)
             } else

--- a/modules/core/src/main/scala/skunk/sharp/contrib/ltree/LTree.scala
+++ b/modules/core/src/main/scala/skunk/sharp/contrib/ltree/LTree.scala
@@ -9,10 +9,10 @@ import skunk.sharp.pg.PgTypeFor
 /**
  * `ltree` — hierarchical label tree (`top.science.astronomy`). Requires `CREATE EXTENSION ltree;`.
  *
- * `LTree <: String` so it flows through every `Stripped[T] <:< String`-gated operator (`ilike`, `like`, trigram, …)
- * and lives in implicit scope for `Table.of[T]` derivation. **Underlying validation and codec delegate to skunk**:
- * `apply` / `wrap` runs every string through `skunk.data.LTree.fromString` so an invalid path is rejected at construction
- * time, and the [[codec]] piggybacks on skunk's bundled `pg.ltree` codec via `.imap` — no second parser to keep in sync.
+ * `LTree <: String` so it flows through every `Stripped[T] <:< String`-gated operator (`ilike`, `like`, trigram, …) and
+ * lives in implicit scope for `Table.of[T]` derivation. **Underlying validation and codec delegate to skunk**: `apply`
+ * / `wrap` runs every string through `skunk.data.LTree.fromString` so an invalid path is rejected at construction time,
+ * and the [[codec]] piggybacks on skunk's bundled `pg.ltree` codec via `.imap` — no second parser to keep in sync.
  */
 opaque type LTree <: String = String
 
@@ -21,9 +21,8 @@ object LTree {
   val RequiredExtension: String = "ltree"
 
   /**
-   * Validate via skunk's parser, then return the canonical text form as an `LTree`. Throws
-   * `IllegalArgumentException` on a bad path — matches the failure mode of [[skunk.data.LTree.fromString]] used as a
-   * total constructor.
+   * Validate via skunk's parser, then return the canonical text form as an `LTree`. Throws `IllegalArgumentException`
+   * on a bad path — matches the failure mode of [[skunk.data.LTree.fromString]] used as a total constructor.
    */
   def apply(s: String): LTree =
     data.LTree.fromString(s).fold(

--- a/modules/core/src/main/scala/skunk/sharp/contrib/ltree/package.scala
+++ b/modules/core/src/main/scala/skunk/sharp/contrib/ltree/package.scala
@@ -7,10 +7,9 @@ package skunk.sharp.contrib
  *   - The `<: String` subtyping lets every string operator that uses `Stripped[T] <:< String` evidence — `ilike`,
  *     `like`, the trigram operators in [[skunk.sharp.contrib.pgtrgm.ops]], …— apply directly to an `LTree`-typed
  *     expression. Skunk's `skunk.data.LTree` is not a `String` subtype, so those operators would refuse it.
- *
  *   - Implicit / `given` scope: the `PgTypeFor[LTree]` carrying the required-extension hint must live in either the
- *     companion of `LTree` or the companion of one of its supertypes for `Table.of[T]` / inferred-codec column paths
- *     to find it automatically. We can only put it on our own `LTree` — we don't own `skunk.data.LTree`'s companion.
+ *     companion of `LTree` or the companion of one of its supertypes for `Table.of[T]` / inferred-codec column paths to
+ *     find it automatically. We can only put it on our own `LTree` — we don't own `skunk.data.LTree`'s companion.
  *
  * Wire format and semantics are otherwise identical. If you have an existing pile of `skunk.data.LTree` values, the
  * conversion is just `LTree(d.toString)` / `skunk.data.LTree.fromString(myLTree)`.

--- a/modules/core/src/main/scala/skunk/sharp/contrib/pgtrgm/PgTrgm.scala
+++ b/modules/core/src/main/scala/skunk/sharp/contrib/pgtrgm/PgTrgm.scala
@@ -8,8 +8,8 @@ import skunk.sharp.where.Where
  * matching.
  *
  * Requires `CREATE EXTENSION pg_trgm;` — the validator picks this up if any tag column needs it, but for typical use
- * (function calls + operator extensions on `String`-typed columns), pass `extraExtensions = Set(PgTrgm.RequiredExtension)`
- * to `SchemaValidator.validate`.
+ * (function calls + operator extensions on `String`-typed columns), pass
+ * `extraExtensions = Set(PgTrgm.RequiredExtension)` to `SchemaValidator.validate`.
  */
 trait PgTrgm {
 

--- a/modules/core/src/main/scala/skunk/sharp/contrib/pgtrgm/ops.scala
+++ b/modules/core/src/main/scala/skunk/sharp/contrib/pgtrgm/ops.scala
@@ -7,8 +7,8 @@ import skunk.sharp.where.Where
 
 /**
  * Trigram operators on `String`-shaped expressions. Method names use plain English (`.similarTrgm`, `.trgmDistance`)
- * instead of Postgres's symbolic operators (`%`, `<->`, …) so they don't fight for namespace with anything else and stay
- * obviously trigram-specific at the call site.
+ * instead of Postgres's symbolic operators (`%`, `<->`, …) so they don't fight for namespace with anything else and
+ * stay obviously trigram-specific at the call site.
  *
  * The `Stripped[T] <:< String` evidence lets the operators apply to any tag whose underlying type is `String`
  * (`Citext`, `Varchar[N]`, `LTree`, …) without ceremony.

--- a/modules/core/src/main/scala/skunk/sharp/ops/ExprOps.scala
+++ b/modules/core/src/main/scala/skunk/sharp/ops/ExprOps.scala
@@ -57,10 +57,10 @@ private inline def opCombine[T, U, A, B](
 extension [T, A](lhs: TypedExpr[T, A]) {
 
   /**
-   * `lhs = rhs` — RHS is a `TypedExpr` (`Param[T]`, `lit(v)`, another column). Primitive literals (and
-   * singleton-typed values) of `T` also work directly — the singleton-typed `Conversion` instances in
-   * [[skunk.sharp.TypedExpr]]'s companion fire automatically because `TypedExpr` is declared `into trait`. No
-   * import or `language.implicitConversions` needed.
+   * `lhs = rhs` — RHS is a `TypedExpr` (`Param[T]`, `lit(v)`, another column). Primitive literals (and singleton-typed
+   * values) of `T` also work directly — the singleton-typed `Conversion` instances in [[skunk.sharp.TypedExpr]]'s
+   * companion fire automatically because `TypedExpr` is declared `into trait`. No import or
+   * `language.implicitConversions` needed.
    */
   inline def ===[B](rhs: TypedExpr[T, B]): Where[Where.Concat[A, B]] = opCombine(lhs, " = ", rhs)
 

--- a/modules/core/src/main/scala/skunk/sharp/pg/PgTypeFor.scala
+++ b/modules/core/src/main/scala/skunk/sharp/pg/PgTypeFor.scala
@@ -41,7 +41,7 @@ object PgTypeFor {
   def instanceWithExtension[T](c: Codec[T], extension: String): PgTypeFor[T] = {
     val ext = extension
     new PgTypeFor[T] {
-      val codec                                  = c
+      val codec                                      = c
       override val requiredExtension: Option[String] = Some(ext)
     }
   }
@@ -69,4 +69,5 @@ object PgTypeFor {
       override val requiredExtension: Option[String] = inner.requiredExtension
     }
   }
+
 }

--- a/modules/core/src/main/scala/skunk/sharp/validation/SchemaValidator.scala
+++ b/modules/core/src/main/scala/skunk/sharp/validation/SchemaValidator.scala
@@ -110,9 +110,9 @@ object SchemaValidator {
           ValidationReport(missing.map(Mismatch.ExtensionMissing(_)))
         }
     for {
-      ext     <- extensionsCheck
-      perRel  <- relations.toList.traverse(validateOne(session, _))
-      relRep  = ValidationReport(perRel.flatMap(_.mismatches))
+      ext    <- extensionsCheck
+      perRel <- relations.toList.traverse(validateOne(session, _))
+      relRep = ValidationReport(perRel.flatMap(_.mismatches))
     } yield ext ++ relRep
   }
 

--- a/modules/core/src/main/scala/skunk/sharp/validation/ValidationReport.scala
+++ b/modules/core/src/main/scala/skunk/sharp/validation/ValidationReport.scala
@@ -99,8 +99,8 @@ object Mismatch {
 
   /**
    * A Postgres extension required by one of the declared relations (via a column with `requiredExtension` set) or
-   * supplied explicitly to [[skunk.sharp.validation.SchemaValidator.validate]] is not installed (`pg_extension` has
-   * no row with this name). `relation` is `"<database>"` because the extension is database-wide, not relation-local.
+   * supplied explicitly to [[skunk.sharp.validation.SchemaValidator.validate]] is not installed (`pg_extension` has no
+   * row with this name). `relation` is `"<database>"` because the extension is database-wide, not relation-local.
    */
   final case class ExtensionMissing(name: String) extends Mismatch {
     val relation: String = "<database>"

--- a/modules/core/src/test/scala/skunk/sharp/contrib/ContribSuite.scala
+++ b/modules/core/src/test/scala/skunk/sharp/contrib/ContribSuite.scala
@@ -95,7 +95,7 @@ class ContribSuite extends munit.FunSuite {
   }
 
   test("trigram operators render correct SQL") {
-    val t    = Table.of[(Int, String)]("dummy")
+    val t = Table.of[(Int, String)]("dummy")
     // Bypass Table.of[Tuple]; use builder explicitly for a string col
     val users = Table.builder("docs").column[String]("body").build
     val cols  = ColumnsView(users.columns)

--- a/modules/core/src/test/scala/skunk/sharp/syntax/LiteralSyntaxSuite.scala
+++ b/modules/core/src/test/scala/skunk/sharp/syntax/LiteralSyntaxSuite.scala
@@ -11,10 +11,10 @@ object LiteralSyntaxSuite {
 }
 
 /**
- * Covers the singleton-typed `given Conversion`s shipped from `TypedExpr`'s companion object. Because they live
- * there — and because `TypedExpr` is declared `into trait` — primitive literals slot directly into any operator's
- * `TypedExpr` RHS slot without needing an import or `language.implicitConversions`. The conversion fires only for
- * singleton-typed sources (true literals and stable `val`s); method calls, vars and widened expressions are rejected.
+ * Covers the singleton-typed `given Conversion`s shipped from `TypedExpr`'s companion object. Because they live there —
+ * and because `TypedExpr` is declared `into trait` — primitive literals slot directly into any operator's `TypedExpr`
+ * RHS slot without needing an import or `language.implicitConversions`. The conversion fires only for singleton-typed
+ * sources (true literals and stable `val`s); method calls, vars and widened expressions are rejected.
  */
 class LiteralSyntaxSuite extends munit.FunSuite {
   import LiteralSyntaxSuite.User

--- a/modules/example/src/main/scala/skunk/sharp/example/api/Dto.scala
+++ b/modules/example/src/main/scala/skunk/sharp/example/api/Dto.scala
@@ -23,8 +23,8 @@ case class PatchBuildingRequest(name: Option[String], address: Option[String], l
 
 /**
  * Query-parameter bundle for `GET /api/v1/buildings`. The trio `nearLat` / `nearLon` / `radiusMeters` ties together to
- * form a `WithinMetersOf` filter; the spatial primitive (`ST_DWithin`) wants all three or none. The routing layer
- * emits the filter only when all three are present.
+ * form a `WithinMetersOf` filter; the spatial primitive (`ST_DWithin`) wants all three or none. The routing layer emits
+ * the filter only when all three are present.
  */
 case class BuildingFilterQuery(
   @query nameContains: Option[String],
@@ -104,8 +104,8 @@ case class ApiError(message: String) derives Codec.AsObject, Schema
 // ---------- Cross-resource search ---------------------------------------------------------------
 
 /**
- * Wide-row response for `GET /api/v1/search/rooms` — every room field plus its parent building's id, name, and
- * location so the front end doesn't need a follow-up `GET /buildings/{id}` for each row.
+ * Wide-row response for `GET /api/v1/search/rooms` — every room field plus its parent building's id, name, and location
+ * so the front end doesn't need a follow-up `GET /buildings/{id}` for each row.
  */
 case class RoomWithBuildingResponse(
   id: UUID,
@@ -141,8 +141,8 @@ case class BuildingAvailabilityResponse(
 ) derives Codec.AsObject, Schema
 
 /**
- * Required query bundle for `GET /api/v1/search/availability`. All five fields are required — without dates we have
- * no notion of "free", and without a spatial probe the result is unbounded.
+ * Required query bundle for `GET /api/v1/search/availability`. All five fields are required — without dates we have no
+ * notion of "free", and without a spatial probe the result is unbounded.
  */
 case class AvailabilityQuery(
   @query nearLat: Double,

--- a/modules/example/src/main/scala/skunk/sharp/example/api/Endpoints.scala
+++ b/modules/example/src/main/scala/skunk/sharp/example/api/Endpoints.scala
@@ -128,9 +128,9 @@ object Endpoints {
   object search {
 
     /**
-     * GET /api/v1/search/rooms — rooms within a radius of `(nearLat, nearLon)` matching the supplied room criteria
-     * and, if a date range is given, free during it. Backed by an `INNER JOIN rooms × buildings` with `ST_DWithin`
-     * on the building's geometry; results carry the parent building's id / name / location inline.
+     * GET /api/v1/search/rooms — rooms within a radius of `(nearLat, nearLon)` matching the supplied room criteria and,
+     * if a date range is given, free during it. Backed by an `INNER JOIN rooms × buildings` with `ST_DWithin` on the
+     * building's geometry; results carry the parent building's id / name / location inline.
      */
     val rooms =
       base.get
@@ -153,4 +153,5 @@ object Endpoints {
 
   lazy val all: List[sttp.tapir.AnyEndpoint] =
     buildings.all ++ rooms.all ++ bookings.all ++ search.all
+
 }

--- a/modules/example/src/main/scala/skunk/sharp/example/api/Routes.scala
+++ b/modules/example/src/main/scala/skunk/sharp/example/api/Routes.scala
@@ -96,7 +96,7 @@ object Routes {
       Endpoints.rooms.create.serverLogic[IO] { case (buildingId, req) =>
         pool.useKleisli(
           (for {
-            _    <- EitherT.fromOptionF(
+            _ <- EitherT.fromOptionF(
               buildings.findById(buildingId),
               notFound(s"Building $buildingId not found")
             )

--- a/modules/example/src/main/scala/skunk/sharp/example/domain/Building.scala
+++ b/modules/example/src/main/scala/skunk/sharp/example/domain/Building.scala
@@ -7,11 +7,11 @@ import skunk.sharp.postgis.given
 import java.util.UUID
 
 /**
- * A physical building hosting one or more rooms. The `geom` is a WGS84 (SRID 4326) `Point`; queries like
- * "within N metres of (lat, lon)" use `ST_DWithin` against this column, with a GiST index from V3 keeping it fast.
+ * A physical building hosting one or more rooms. The `geom` is a WGS84 (SRID 4326) `Point`; queries like "within N
+ * metres of (lat, lon)" use `ST_DWithin` against this column, with a GiST index from V3 keeping it fast.
  *
- * Rooms reference Buildings via `rooms.building_id` (cascade on delete) so removing a building cleans up its rooms
- * — and via the existing FK on bookings, the bookings beneath them.
+ * Rooms reference Buildings via `rooms.building_id` (cascade on delete) so removing a building cleans up its rooms —
+ * and via the existing FK on bookings, the bookings beneath them.
  */
 case class BuildingRow(id: UUID, name: String, address: String, geom: Point)
 

--- a/modules/example/src/main/scala/skunk/sharp/example/repository/BookingFilter.scala
+++ b/modules/example/src/main/scala/skunk/sharp/example/repository/BookingFilter.scala
@@ -27,9 +27,9 @@ object BookingFilter {
   final case class TitleContains(substring: String) extends BookingFilter
 
   /**
-   * `booker_name % q` — trigram-similarity match. Catches typos and partials (`"katleen"` matches `"Kathleen"`)
-   * where the plain `ILIKE '%katleen%'` form would miss. Backed by the trigram GIN index from the V2 migration; the
-   * threshold comes from Postgres's session-level `pg_trgm.similarity_threshold` (default 0.3).
+   * `booker_name % q` — trigram-similarity match. Catches typos and partials (`"katleen"` matches `"Kathleen"`) where
+   * the plain `ILIKE '%katleen%'` form would miss. Backed by the trigram GIN index from the V2 migration; the threshold
+   * comes from Postgres's session-level `pg_trgm.similarity_threshold` (default 0.3).
    */
   final case class BookerNameSimilar(q: String) extends BookingFilter
 

--- a/modules/example/src/main/scala/skunk/sharp/example/repository/BuildingFilter.scala
+++ b/modules/example/src/main/scala/skunk/sharp/example/repository/BuildingFilter.scala
@@ -5,8 +5,8 @@ import cats.data.NonEmptyList
 import java.util.UUID
 
 /**
- * Domain-level filter ADT for building listing. Mirrors [[RoomFilter]] / [[BookingFilter]]; the repository
- * materialises a `List[BuildingFilter]` into a single AND-combined WHERE.
+ * Domain-level filter ADT for building listing. Mirrors [[RoomFilter]] / [[BookingFilter]]; the repository materialises
+ * a `List[BuildingFilter]` into a single AND-combined WHERE.
  */
 sealed trait BuildingFilter
 
@@ -20,9 +20,9 @@ object BuildingFilter {
 
   /**
    * `ST_DWithin(geom, ST_SetSRID(ST_MakePoint(lon, lat), 4326), meters)` — buildings within `meters` of the given
-   * lat/lon. The 4326 SRID is taken to match the column type; PostGIS does the spherical distance math when the
-   * column is geography, or planar math when it's geometry — we use geometry here, fine for short distances at
-   * non-extreme latitudes.
+   * lat/lon. The 4326 SRID is taken to match the column type; PostGIS does the spherical distance math when the column
+   * is geography, or planar math when it's geometry — we use geometry here, fine for short distances at non-extreme
+   * latitudes.
    */
   final case class WithinMetersOf(lat: Double, lon: Double, meters: Double) extends BuildingFilter
 }

--- a/modules/example/src/main/scala/skunk/sharp/example/repository/BuildingRepository.scala
+++ b/modules/example/src/main/scala/skunk/sharp/example/repository/BuildingRepository.scala
@@ -51,8 +51,8 @@ object BuildingRepository {
      * uniformly with the other filter cases.
      */
     private def toWhere(f: BuildingFilter): Where[skunk.Void] = f match {
-      case BuildingFilter.NameContains(s) => cv.name.ilike(Param.bind(s"%$s%"))
-      case BuildingFilter.IdsIn(ids)      => cv.id.in(ids.map(Param.bind(_)))
+      case BuildingFilter.NameContains(s)                  => cv.name.ilike(Param.bind(s"%$s%"))
+      case BuildingFilter.IdsIn(ids)                       => cv.id.in(ids.map(Param.bind(_)))
       case BuildingFilter.WithinMetersOf(lat, lon, meters) =>
         val probe = PgPostgis.setSRID(
           PgPostgis.makePoint(Param.bind(lon), Param.bind(lat)),

--- a/modules/example/src/main/scala/skunk/sharp/example/repository/RoomRepository.scala
+++ b/modules/example/src/main/scala/skunk/sharp/example/repository/RoomRepository.scala
@@ -73,11 +73,11 @@ object RoomRepository {
 
     /** Translate one user filter to a `Where[Void]`. The building-id scope is added on top in [[findFiltered]]. */
     private def toWhere(f: RoomFilter): Where[skunk.Void] = f match {
-      case RoomFilter.CapacityAtLeast(n)   => cv.capacity >= Param.bind(n)
-      case RoomFilter.CapacityAtMost(n)    => cv.capacity <= Param.bind(n)
-      case RoomFilter.NameContains(s)      => cv.name.ilike(Param.bind(s"%$s%"))
-      case RoomFilter.NamesIn(ns)          => cv.name.in(ns.map(Param.bind(_)))
-      case RoomFilter.IdsIn(ids)           => cv.id.in(ids.map(Param.bind(_)))
+      case RoomFilter.CapacityAtLeast(n)    => cv.capacity >= Param.bind(n)
+      case RoomFilter.CapacityAtMost(n)     => cv.capacity <= Param.bind(n)
+      case RoomFilter.NameContains(s)       => cv.name.ilike(Param.bind(s"%$s%"))
+      case RoomFilter.NamesIn(ns)           => cv.name.in(ns.map(Param.bind(_)))
+      case RoomFilter.IdsIn(ids)            => cv.id.in(ids.map(Param.bind(_)))
       case RoomFilter.LocationUnder(prefix) =>
         cv.location.isDescendantOf(Param.bind(prefix))
       case RoomFilter.HasAmenity(key) =>
@@ -91,8 +91,7 @@ object RoomRepository {
       if filters.isEmpty then findAllInBuildingQ.streamKF[IO](buildingId, 64)
       else {
         // AND-fold the per-filter Wheres on top of the `building_id = $1` scope.
-        val scoped: List[Where[skunk.Void]] =
-          (cv.building_id === Param.bind(buildingId)) :: filters.map(toWhere)
+        val scoped: List[Where[skunk.Void]] = (cv.building_id === Param.bind(buildingId)) :: filters.map(toWhere)
         selectRow.where(_ => allOf(scoped*)).compile.streamKF[IO]()
       }
 

--- a/modules/example/src/main/scala/skunk/sharp/example/repository/SearchRepository.scala
+++ b/modules/example/src/main/scala/skunk/sharp/example/repository/SearchRepository.scala
@@ -19,9 +19,9 @@ import java.time.LocalDate
 import java.util.UUID
 
 /**
- * Cross-resource read-side queries: cross-building room search + per-building availability counts. Each method
- * composes a single skunk-sharp query that joins two or three tables, applies spatial / temporal / domain filters,
- * and ships the matching rows back as a stream.
+ * Cross-resource read-side queries: cross-building room search + per-building availability counts. Each method composes
+ * a single skunk-sharp query that joins two or three tables, applies spatial / temporal / domain filters, and ships the
+ * matching rows back as a stream.
  */
 trait SearchRepository {
 
@@ -41,8 +41,8 @@ trait SearchRepository {
   ): Kleisli[Stream[IO, *], Session[IO], SearchRepository.RoomWithBuilding]
 
   /**
-   * Buildings within a radius of `(lat, lon)`, with the count of rooms that are NOT booked during `[from, to)`.
-   * Ordered by free-room count descending — perfect for a "find a meeting room" landing page.
+   * Buildings within a radius of `(lat, lon)`, with the count of rooms that are NOT booked during `[from, to)`. Ordered
+   * by free-room count descending — perfect for a "find a meeting room" landing page.
    */
   def buildingsWithAvailability(
     near: (Double, Double),
@@ -162,19 +162,21 @@ object SearchRepository {
       buildings.leftJoin(rooms)
         .on { j =>
           j.rooms.building_id === j.buildings.id &&
-            Pg.notExists(
-              bookings.select(_ => lit(1)).where(bk =>
-                bk.room_id === j.rooms.id && bk.period.overlaps(period)
-              )
+          Pg.notExists(
+            bookings.select(_ => lit(1)).where(bk =>
+              bk.room_id === j.rooms.id && bk.period.overlaps(period)
             )
+          )
         }
-        .select(j => (
-          j.buildings.id,
-          j.buildings.name,
-          j.buildings.address,
-          j.buildings.geom,
-          Pg.count(j.rooms.id)
-        ))
+        .select(j =>
+          (
+            j.buildings.id,
+            j.buildings.name,
+            j.buildings.address,
+            j.buildings.geom,
+            Pg.count(j.rooms.id)
+          )
+        )
         .where(j => j.buildings.geom.dWithin(probe, radius))
         .groupBy(j => (j.buildings.id, j.buildings.name, j.buildings.address, j.buildings.geom))
         .orderBy(j => (Pg.count(j.rooms.id).desc, j.buildings.name.asc))
@@ -193,4 +195,5 @@ object SearchRepository {
       buildingsWithAvailabilityQ.streamKF[IO]((period, lon, lat, radius), 64)
     }
   }
+
 }

--- a/modules/example/src/test/scala/skunk/sharp/example/ExampleAppFixture.scala
+++ b/modules/example/src/test/scala/skunk/sharp/example/ExampleAppFixture.scala
@@ -59,8 +59,8 @@ trait ExampleAppFixture extends CatsEffectSuite with TestContainerForAll {
   }
 
   /**
-   * A skunk session pool resource against the running container. `TypingStrategy.SearchPath` is required because the
-   * V2 migration introduces user-defined types (citext, ltree, hstore) that aren't in skunk's built-in oid table.
+   * A skunk session pool resource against the running container. `TypingStrategy.SearchPath` is required because the V2
+   * migration introduces user-defined types (citext, ltree, hstore) that aren't in skunk's built-in oid table.
    */
   protected def sessionPool(c: containerDef.Container): Resource[IO, Resource[IO, Session[IO]]] =
     Session
@@ -101,7 +101,7 @@ trait ExampleAppFixture extends CatsEffectSuite with TestContainerForAll {
     sessionPool(c).map { pool =>
       val routes: HttpRoutes[IO] =
         Routes(pool, BuildingRepository.live, RoomRepository.live, BookingRepository.live, SearchRepository.live)
-      val client: Client[IO]     = Client.fromHttpApp(routes.orNotFound)
+      val client: Client[IO] = Client.fromHttpApp(routes.orNotFound)
       Http4sBackend.usingClient(client)
     }
 

--- a/modules/example/src/test/scala/skunk/sharp/example/api/BookingsFilterEndpointSuite.scala
+++ b/modules/example/src/test/scala/skunk/sharp/example/api/BookingsFilterEndpointSuite.scala
@@ -23,7 +23,9 @@ class BookingsFilterEndpointSuite extends ExampleAppFixture {
   private def createBuilding(using SttpBackend[IO, Fs2Streams[IO]]): IO[BuildingResponse] =
     createBuildingReq(CreateBuildingRequest("HQ", "HQ address", LatLon(53.34, -6.26))).sendOk
 
-  private def createRoom(buildingId: UUID, name: String, capacity: Int)(using SttpBackend[IO, Fs2Streams[IO]])
+  private def createRoom(buildingId: UUID, name: String, capacity: Int)(using
+    SttpBackend[IO, Fs2Streams[IO]]
+  )
     : IO[RoomResponse] =
     createRoomReq((buildingId, CreateRoomRequest(name, capacity, location = "unsorted", amenities = Map.empty))).sendOk
 
@@ -44,13 +46,13 @@ class BookingsFilterEndpointSuite extends ExampleAppFixture {
       appBackend(containers).use { case given SttpBackend[IO, Fs2Streams[IO]] =>
         truncateAll(containers) *>
           (for {
-            b <- createBuilding
-            a <- createRoom(b.id, "A", 2)
-            r <- createRoom(b.id, "B", 2)
-            c <- createRoom(b.id, "C", 2)
-            _ <- createBooking(a.id, "alice", "ax", LocalDate.parse("2024-01-01"), LocalDate.parse("2024-01-10"))
-            _ <- createBooking(r.id, "bob", "bx", LocalDate.parse("2024-02-01"), LocalDate.parse("2024-02-10"))
-            _ <- createBooking(c.id, "carol", "cx", LocalDate.parse("2024-03-01"), LocalDate.parse("2024-03-10"))
+            b  <- createBuilding
+            a  <- createRoom(b.id, "A", 2)
+            r  <- createRoom(b.id, "B", 2)
+            c  <- createRoom(b.id, "C", 2)
+            _  <- createBooking(a.id, "alice", "ax", LocalDate.parse("2024-01-01"), LocalDate.parse("2024-01-10"))
+            _  <- createBooking(r.id, "bob", "bx", LocalDate.parse("2024-02-01"), LocalDate.parse("2024-02-10"))
+            _  <- createBooking(c.id, "carol", "cx", LocalDate.parse("2024-03-01"), LocalDate.parse("2024-03-10"))
             rs <- listBookings(BookingFilterQuery.empty.copy(roomIds = List(a.id, r.id)))
             _ = assertEquals(rs.map(_.title).toSet, Set("ax", "bx"))
           } yield ())
@@ -174,7 +176,13 @@ class BookingsFilterEndpointSuite extends ExampleAppFixture {
               LocalDate.parse("2024-01-02")
             )
             _ <-
-              createBooking(r.id, "Robert Smith", "team standup", LocalDate.parse("2024-01-03"), LocalDate.parse("2024-01-04"))
+              createBooking(
+                r.id,
+                "Robert Smith",
+                "team standup",
+                LocalDate.parse("2024-01-03"),
+                LocalDate.parse("2024-01-04")
+              )
             typo <- listBookings(BookingFilterQuery.empty.copy(bookerNameSimilar = Some("Katleen")))
             _ = assertEquals(typo.map(_.bookerName), List("Kathleen O'Brien"))
             sub <- listBookings(BookingFilterQuery.empty.copy(bookerNameContains = Some("Robert")))
@@ -189,9 +197,9 @@ class BookingsFilterEndpointSuite extends ExampleAppFixture {
       appBackend(containers).use { case given SttpBackend[IO, Fs2Streams[IO]] =>
         truncateAll(containers) *>
           (for {
-            b <- createBuilding
-            r <- createRoom(b.id, "c", 1)
-            _ <- createBooking(r.id, "ALICE", "x", LocalDate.parse("2024-01-01"), LocalDate.parse("2024-01-02"))
+            b    <- createBuilding
+            r    <- createRoom(b.id, "c", 1)
+            _    <- createBooking(r.id, "ALICE", "x", LocalDate.parse("2024-01-01"), LocalDate.parse("2024-01-02"))
             hits <- listBookings(BookingFilterQuery.empty.copy(bookerNameContains = Some("alice")))
             _ = assertEquals(hits.map(_.bookerName), List("ALICE"))
           } yield ())

--- a/modules/example/src/test/scala/skunk/sharp/example/api/BuildingsFilterEndpointSuite.scala
+++ b/modules/example/src/test/scala/skunk/sharp/example/api/BuildingsFilterEndpointSuite.scala
@@ -12,9 +12,8 @@ import java.util.UUID
  * End-to-end test for the buildings resource at `GET /api/v1/buildings`. Covers the PostGIS-backed `WithinMetersOf`
  * filter (`ST_DWithin`) plus the simpler name/id-set filters.
  *
- * Distance assertions use real-world coordinates: Dublin city centre, Trinity College, and Cork city — far enough
- * apart that the radius math is unambiguous even with the Cartesian-on-SRID-4326 caveat in the BuildingRepository
- * docs.
+ * Distance assertions use real-world coordinates: Dublin city centre, Trinity College, and Cork city — far enough apart
+ * that the radius math is unambiguous even with the Cartesian-on-SRID-4326 caveat in the BuildingRepository docs.
  */
 class BuildingsFilterEndpointSuite extends ExampleAppFixture {
 
@@ -23,9 +22,9 @@ class BuildingsFilterEndpointSuite extends ExampleAppFixture {
   private val getByIdReq = interpreter.toRequestThrowDecodeFailures(Endpoints.buildings.getById, Some(baseUri))
 
   // Approximate WGS84 lat/lon for a few places we can reason about.
-  private val DublinCentre  = LatLon(53.3498, -6.2603)
+  private val DublinCentre   = LatLon(53.3498, -6.2603)
   private val TrinityCollege = LatLon(53.3438, -6.2546)
-  private val CorkCity      = LatLon(51.8985, -8.4756)
+  private val CorkCity       = LatLon(51.8985, -8.4756)
 
   private def createBuilding(name: String, l: LatLon)(using SttpBackend[IO, Fs2Streams[IO]]): IO[BuildingResponse] =
     createReq(CreateBuildingRequest(name, address = s"$name address", location = l)).sendOk
@@ -88,8 +87,8 @@ class BuildingsFilterEndpointSuite extends ExampleAppFixture {
       appBackend(containers).use { case given SttpBackend[IO, Fs2Streams[IO]] =>
         truncateAll(containers) *>
           (for {
-            a <- createBuilding("Atrium", DublinCentre)
-            _ <- createBuilding("Lounge", TrinityCollege)
+            a    <- createBuilding("Atrium", DublinCentre)
+            _    <- createBuilding("Lounge", TrinityCollege)
             hits <- listBuildings(
               BuildingFilterQuery.empty.copy(nameContains = Some("atrium"), nearLat = Some(53.0))
             )

--- a/modules/example/src/test/scala/skunk/sharp/example/api/RoomsFilterEndpointSuite.scala
+++ b/modules/example/src/test/scala/skunk/sharp/example/api/RoomsFilterEndpointSuite.scala
@@ -39,7 +39,9 @@ class RoomsFilterEndpointSuite extends ExampleAppFixture {
   )(using SttpBackend[IO, Fs2Streams[IO]]): IO[RoomResponse] =
     createRoomReq((buildingId, CreateRoomRequest(name, capacity, location, amenities))).sendOk
 
-  private def listRooms(buildingId: UUID, q: RoomFilterQuery)(using SttpBackend[IO, Fs2Streams[IO]])
+  private def listRooms(buildingId: UUID, q: RoomFilterQuery)(using
+    SttpBackend[IO, Fs2Streams[IO]]
+  )
     : IO[List[RoomResponse]] = listReq((buildingId, q)).sendOk
 
   test("filter rooms by minCapacity / maxCapacity within a building") {
@@ -85,10 +87,10 @@ class RoomsFilterEndpointSuite extends ExampleAppFixture {
       appBackend(containers).use { case given SttpBackend[IO, Fs2Streams[IO]] =>
         truncateAll(containers) *>
           (for {
-            ba <- createBuilding("A")
-            bb <- createBuilding("B")
-            _  <- createRoom(ba.id, "room-in-A", 2)
-            _  <- createRoom(bb.id, "room-in-B", 2)
+            ba  <- createBuilding("A")
+            bb  <- createBuilding("B")
+            _   <- createRoom(ba.id, "room-in-A", 2)
+            _   <- createRoom(bb.id, "room-in-B", 2)
             inA <- listRooms(ba.id, RoomFilterQuery.empty)
             inB <- listRooms(bb.id, RoomFilterQuery.empty)
             _ = assertEquals(inA.map(_.name), List("room-in-A"))
@@ -103,13 +105,13 @@ class RoomsFilterEndpointSuite extends ExampleAppFixture {
       appBackend(containers).use { case given SttpBackend[IO, Fs2Streams[IO]] =>
         truncateAll(containers) *>
           (for {
-            b    <- createBuilding()
-            _    <- createRoom(b.id, "dub-1", 4, location = "acme.dublin.floor3.r1")
-            _    <- createRoom(b.id, "dub-2", 4, location = "acme.dublin.floor2.r1")
-            _    <- createRoom(b.id, "cork-1", 4, location = "acme.cork.floor1.r1")
-            dub  <- listRooms(b.id, RoomFilterQuery.empty.copy(locationUnder = Some("acme.dublin")))
+            b   <- createBuilding()
+            _   <- createRoom(b.id, "dub-1", 4, location = "acme.dublin.floor3.r1")
+            _   <- createRoom(b.id, "dub-2", 4, location = "acme.dublin.floor2.r1")
+            _   <- createRoom(b.id, "cork-1", 4, location = "acme.cork.floor1.r1")
+            dub <- listRooms(b.id, RoomFilterQuery.empty.copy(locationUnder = Some("acme.dublin")))
             _ = assertEquals(dub.map(_.name).toSet, Set("dub-1", "dub-2"))
-            f3   <- listRooms(b.id, RoomFilterQuery.empty.copy(locationUnder = Some("acme.dublin.floor3")))
+            f3 <- listRooms(b.id, RoomFilterQuery.empty.copy(locationUnder = Some("acme.dublin.floor3")))
             _ = assertEquals(f3.map(_.name), List("dub-1"))
           } yield ())
       }
@@ -121,10 +123,10 @@ class RoomsFilterEndpointSuite extends ExampleAppFixture {
       appBackend(containers).use { case given SttpBackend[IO, Fs2Streams[IO]] =>
         truncateAll(containers) *>
           (for {
-            b <- createBuilding()
-            _ <- createRoom(b.id, "A", 4, amenities = Map("projector" -> "4k", "whiteboard" -> "true"))
-            _ <- createRoom(b.id, "B", 4, amenities = Map("whiteboard" -> "true"))
-            _ <- createRoom(b.id, "C", 4, amenities = Map.empty)
+            b    <- createBuilding()
+            _    <- createRoom(b.id, "A", 4, amenities = Map("projector" -> "4k", "whiteboard" -> "true"))
+            _    <- createRoom(b.id, "B", 4, amenities = Map("whiteboard" -> "true"))
+            _    <- createRoom(b.id, "C", 4, amenities = Map.empty)
             proj <- listRooms(b.id, RoomFilterQuery.empty.copy(hasAmenity = Some("projector")))
             _ = assertEquals(proj.map(_.name), List("A"))
             wb <- listRooms(b.id, RoomFilterQuery.empty.copy(hasAmenity = Some("whiteboard")))

--- a/modules/example/src/test/scala/skunk/sharp/example/api/SearchEndpointSuite.scala
+++ b/modules/example/src/test/scala/skunk/sharp/example/api/SearchEndpointSuite.scala
@@ -19,7 +19,8 @@ class SearchEndpointSuite extends ExampleAppFixture {
   private val createRoomReq     = interpreter.toRequestThrowDecodeFailures(Endpoints.rooms.create, Some(baseUri))
   private val createBookingReq  = interpreter.toRequestThrowDecodeFailures(Endpoints.bookings.create, Some(baseUri))
   private val searchRoomsReq    = interpreter.toRequestThrowDecodeFailures(Endpoints.search.rooms, Some(baseUri))
-  private val availabilityReq   =
+
+  private val availabilityReq =
     interpreter.toRequestThrowDecodeFailures(Endpoints.search.availability, Some(baseUri))
 
   private val DublinCentre = LatLon(53.3498, -6.2603)
@@ -37,7 +38,9 @@ class SearchEndpointSuite extends ExampleAppFixture {
   )(using SttpBackend[IO, Fs2Streams[IO]]): IO[RoomResponse] =
     createRoomReq((buildingId, CreateRoomRequest(name, capacity, location, amenities))).sendOk
 
-  private def createBooking(roomId: UUID, from: LocalDate, to: LocalDate)(using SttpBackend[IO, Fs2Streams[IO]])
+  private def createBooking(roomId: UUID, from: LocalDate, to: LocalDate)(using
+    SttpBackend[IO, Fs2Streams[IO]]
+  )
     : IO[BookingResponse] =
     createBookingReq(CreateBookingRequest(roomId, "booker", "title", from, to)).sendOk
 
@@ -53,7 +56,7 @@ class SearchEndpointSuite extends ExampleAppFixture {
             _    <- createRoom(dub.id, "DubRoom1", 4)
             _    <- createRoom(dub.id, "DubRoom2", 8)
             _    <- createRoom(cork.id, "CorkRoom1", 6)
-            rs <- searchRoomsReq(RoomSearchQuery(
+            rs   <- searchRoomsReq(RoomSearchQuery(
               nearLat = DublinCentre.lat,
               nearLon = DublinCentre.lon,
               radiusMeters = 0.05, // ~5 km in degrees at this latitude
@@ -78,9 +81,16 @@ class SearchEndpointSuite extends ExampleAppFixture {
         truncateAll(containers) *>
           (for {
             dub <- createBuilding("Dublin HQ", DublinCentre)
-            _   <- createRoom(dub.id, "ProjF3", 4, location = "acme.dublin.floor3.r1", amenities = Map("projector" -> "4k"))
-            _   <- createRoom(dub.id, "NoProjF3", 4, location = "acme.dublin.floor3.r2", amenities = Map())
-            _   <- createRoom(dub.id, "ProjF2", 4, location = "acme.dublin.floor2.r1", amenities = Map("projector" -> "1080p"))
+            _   <-
+              createRoom(dub.id, "ProjF3", 4, location = "acme.dublin.floor3.r1", amenities = Map("projector" -> "4k"))
+            _ <- createRoom(dub.id, "NoProjF3", 4, location = "acme.dublin.floor3.r2", amenities = Map())
+            _ <- createRoom(
+              dub.id,
+              "ProjF2",
+              4,
+              location = "acme.dublin.floor2.r1",
+              amenities = Map("projector" -> "1080p")
+            )
             // Combined filter: has a projector AND on floor 3.
             rs <- searchRoomsReq(RoomSearchQuery(
               nearLat = DublinCentre.lat,
@@ -109,7 +119,7 @@ class SearchEndpointSuite extends ExampleAppFixture {
             r1  <- createRoom(dub.id, "Free", 4)
             r2  <- createRoom(dub.id, "Booked", 4)
             _   <- createBooking(r2.id, LocalDate.parse("2024-06-01"), LocalDate.parse("2024-06-30"))
-            rs <- searchRoomsReq(RoomSearchQuery(
+            rs  <- searchRoomsReq(RoomSearchQuery(
               nearLat = DublinCentre.lat,
               nearLon = DublinCentre.lon,
               radiusMeters = 0.05,
@@ -146,8 +156,8 @@ class SearchEndpointSuite extends ExampleAppFixture {
             _   <- createRoom(tri.id, "T1", 2)
             // Cork building: 5 rooms — outside radius, must not appear.
             cork <- createBuilding("Cork Office", CorkCity)
-            _ <- (1 to 5).toList.traverse(i => createRoom(cork.id, s"C$i", 2))
-            res <- availabilityReq(AvailabilityQuery(
+            _    <- (1 to 5).toList.traverse(i => createRoom(cork.id, s"C$i", 2))
+            res  <- availabilityReq(AvailabilityQuery(
               nearLat = DublinCentre.lat,
               nearLon = DublinCentre.lon,
               radiusMeters = 0.05,
@@ -186,11 +196,11 @@ class SearchEndpointSuite extends ExampleAppFixture {
       appBackend(containers).use { case given SttpBackend[IO, Fs2Streams[IO]] =>
         truncateAll(containers) *>
           (for {
-            b  <- createBuilding("Fully Booked", DublinCentre)
-            r1 <- createRoom(b.id, "R1", 2)
-            r2 <- createRoom(b.id, "R2", 2)
-            _ <- createBooking(r1.id, LocalDate.parse("2024-06-01"), LocalDate.parse("2024-06-30"))
-            _ <- createBooking(r2.id, LocalDate.parse("2024-06-01"), LocalDate.parse("2024-06-30"))
+            b   <- createBuilding("Fully Booked", DublinCentre)
+            r1  <- createRoom(b.id, "R1", 2)
+            r2  <- createRoom(b.id, "R2", 2)
+            _   <- createBooking(r1.id, LocalDate.parse("2024-06-01"), LocalDate.parse("2024-06-30"))
+            _   <- createBooking(r2.id, LocalDate.parse("2024-06-01"), LocalDate.parse("2024-06-30"))
             res <- availabilityReq(AvailabilityQuery(
               nearLat = DublinCentre.lat,
               nearLon = DublinCentre.lon,

--- a/modules/example/src/test/scala/skunk/sharp/example/api/TransformersFilterSuite.scala
+++ b/modules/example/src/test/scala/skunk/sharp/example/api/TransformersFilterSuite.scala
@@ -10,8 +10,8 @@ import java.util.UUID
 
 /**
  * Pure unit tests for the query DTO ↔ filter ADT projection. The SQL-rendering side of each filter case is already
- * covered by core suites; what's specific to the example module is the `q.toFilters` extension's logic, especially
- * the paired-field rules (`overlapsFrom`/`overlapsTo`, `nearLat`/`nearLon`/`radiusMeters`).
+ * covered by core suites; what's specific to the example module is the `q.toFilters` extension's logic, especially the
+ * paired-field rules (`overlapsFrom`/`overlapsTo`, `nearLat`/`nearLon`/`radiusMeters`).
  */
 class TransformersFilterSuite extends munit.FunSuite {
 

--- a/modules/postgis/src/main/scala/skunk/sharp/postgis/ops.scala
+++ b/modules/postgis/src/main/scala/skunk/sharp/postgis/ops.scala
@@ -6,8 +6,8 @@ import skunk.sharp.where.Where
 
 /**
  * Operator surface on `TypedExpr[T <: Geometry, A]`. Method names spell out the operator (`.bboxOverlaps`,
- * `.bboxContains`) instead of taking the symbolic forms (`&&`, `~`, `@`); same convention as the other contribs.
- * `ST_*` predicates also have method aliases (`.distance`, `.contains`, …) for shorter call sites.
+ * `.bboxContains`) instead of taking the symbolic forms (`&&`, `~`, `@`); same convention as the other contribs. `ST_*`
+ * predicates also have method aliases (`.distance`, `.contains`, …) for shorter call sites.
  */
 extension [T <: Geometry, A](lhs: TypedExpr[T, A]) {
 

--- a/modules/postgis/src/main/scala/skunk/sharp/postgis/package.scala
+++ b/modules/postgis/src/main/scala/skunk/sharp/postgis/package.scala
@@ -3,8 +3,8 @@ package skunk.sharp
 /**
  * `skunk-sharp-postgis` — PostGIS support layered on top of [[skunk.postgis]].
  *
- * skunk-postgis owns the value types (`Geometry`, `Point`, `LineString`, `Polygon`, …) and the EWKB codecs; this
- * module adds the bits skunk-sharp users need:
+ * skunk-postgis owns the value types (`Geometry`, `Point`, `LineString`, `Polygon`, …) and the EWKB codecs; this module
+ * adds the bits skunk-sharp users need:
  *
  *   - `PgTypeFor[Geometry]` and per-shape `PgTypeFor`s, each tagged with `requiredExtension = Some("postgis")` so the
  *     schema validator surfaces a missing extension as a [[skunk.sharp.validation.Mismatch.ExtensionMissing]].

--- a/modules/postgis/src/test/scala/skunk/sharp/postgis/PostgisSuite.scala
+++ b/modules/postgis/src/test/scala/skunk/sharp/postgis/PostgisSuite.scala
@@ -35,8 +35,8 @@ class PostgisSuite extends munit.FunSuite {
   }
 
   test("ST_DWithin renders correct SQL") {
-    val t    = Table.of[Site]("sites")
-    val cols = ColumnsView(t.columns)
+    val t     = Table.of[Site]("sites")
+    val cols  = ColumnsView(t.columns)
     val probe = PgPostgis.setSRID(
       PgPostgis.makePoint(Param.bind(-6.26), Param.bind(53.34)),
       Param.bind(4326)

--- a/modules/tests/src/test/scala/skunk/sharp/tests/ContribIntegrationSuite.scala
+++ b/modules/tests/src/test/scala/skunk/sharp/tests/ContribIntegrationSuite.scala
@@ -59,7 +59,7 @@ class ContribIntegrationSuite extends PgFixture {
     withContainers { containers =>
       session(containers).use { s =>
         for {
-          _ <- accounts.insert((id = 1, email = Citext("Alice@Example.COM"), body = "hello")).compile.run(s)
+          _     <- accounts.insert((id = 1, email = Citext("Alice@Example.COM"), body = "hello")).compile.run(s)
           found <- accounts.select(_.id)
             .where(a => a.email === Param.bind(Citext("alice@example.com")))
             .compile.option(s)
@@ -158,7 +158,7 @@ class ContribIntegrationSuite extends PgFixture {
       session(containers).use { s =>
         val payload = Hstore("color" -> Some("blue"), "size" -> Some("xl"), "missing" -> None)
         for {
-          _ <- things.insert((id = 30, props = payload)).compile.run(s)
+          _    <- things.insert((id = 30, props = payload)).compile.run(s)
           back <- things.select(_.props).where(t => t.id === Param.bind(30)).compile.unique(s)
           _ = assertEquals(back, payload)
           found <- things.select(_.id)
@@ -191,7 +191,7 @@ class ContribIntegrationSuite extends PgFixture {
         for {
           report <- SchemaValidator.validate[IO](s, Seq.empty, Set("definitely_not_installed"))
           missing = report.mismatches.collect { case Mismatch.ExtensionMissing(n) => n }
-          _ = assertEquals(missing, List("definitely_not_installed"))
+          _       = assertEquals(missing, List("definitely_not_installed"))
         } yield ()
       }
     }
@@ -201,7 +201,8 @@ class ContribIntegrationSuite extends PgFixture {
     withContainers { containers =>
       session(containers).use { s =>
         for {
-          report <- SchemaValidator.validate[IO](s, Seq.empty, Set(PgCrypto.RequiredExtension, PgFuzzy.RequiredExtension))
+          report <-
+            SchemaValidator.validate[IO](s, Seq.empty, Set(PgCrypto.RequiredExtension, PgFuzzy.RequiredExtension))
           _ = assert(
             !report.mismatches.exists(_.isInstanceOf[Mismatch.ExtensionMissing]),
             s"unexpected ExtensionMissing entries: ${report.mismatches}"


### PR DESCRIPTION
Closes the interim publishing question from #17 by wiring up **GitHub Packages** instead of Maven Central. No GPG keys, no Sonatype account, no domain verification — and forward-compatible coordinates if we later move to Maven Central.

## What changed

- **`build.sbt`**: override `githubWorkflowPublish` → `sbt publish` and drop the PGP signing preamble (GH Packages doesn't want signed artifacts). Per-module `publishTo` + `credentials` (reads `GITHUB_TOKEN`) — has to be per-project because sbt-typelevel's Sonatype plugin sets `publishTo` project-scoped, so a `ThisBuild` fallback gets shadowed.
- **`organization`**: `com.ruiandrebatista` → **`io.github.ragb`**. This namespace is what Maven Central grants for free via GitHub identity, so a later move to Maven Central needs no coordinate change.
- **Submit Dependencies job removed**: `tlCiDependencyGraphJob := false`. The job 404'd on every run because the repo has GitHub's Dependency Graph feature disabled.
- **`tlGitHubRepo`** pinned (defensive — `scmInfo` actually comes from the git remote, so it's also added to `excludeLintKeys` to silence the unused-key lint).
- **Regenerated `ci.yml` + `.mergify.yml`** via sbt (`githubWorkflowGenerate` / `mergifyGenerate`) — never hand-edited. This also fixed two latent bugs:
  - `.mergify.yml` was stale since #81 added postgis — that was the actual cause of the red Test job (mergify-sync check).
  - `ci.yml`'s artifact tar was missing `modules/postgis/target`, which would have broken the postgis publish.
- **Docs**: `getting-started.md` and `postgis.md` install snippets updated with the new coordinates plus the GH Packages resolver and the PAT/`read:packages` auth note (the unavoidable consumer-side tax for GH Packages).

## Verified

- Build loads clean, no lint warnings.
- `githubWorkflowCheck` passes (workflow files match what sbt generates — that's the check CI runs).
- `core/projectID` → `io.github.ragb:skunk-sharp-core:…`.
- Not actually published yet — first real publish happens on merge to `main` or a `v*` tag.

## Caveats

- **`packages: write` permission**: the workflow uses the repo's default `GITHUB_TOKEN` perms. The gh-pages site deploy already works on `main`, which proves the token has write access — so this should publish without further config. If it 403s, that's the place to look (Settings → Actions → Workflow permissions).
- **Consumer auth**: GH Packages requires a PAT with `read:packages` even for public packages. Documented in `getting-started.md` honestly rather than papered over.

🤖 Generated with [Claude Code](https://claude.com/claude-code)