### PR TITLE
Bump tlBaseVersion to 0.0 for the 0.0.x release line

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 import org.typelevel.scalacoptions.{ScalaVersion, ScalacOptions}
 
-ThisBuild / tlBaseVersion    := "0.1"
+ThisBuild / tlBaseVersion    := "0.0"
 ThisBuild / organization     := "io.github.ragb"
 ThisBuild / organizationName := "Rui Batista"
 ThisBuild / tlGitHubRepo     := Some("skunk-sharp")


### PR DESCRIPTION
Prep for the first tagged release (`v0.0.1`).

sbt-typelevel-versioning takes `tlBaseVersion` as the `MAJOR.MINOR` prefix and gets the patch from a `v*` tag. With `tlBaseVersion := "0.1"`, a `v0.0.1` tag would still publish `0.0.1` (the tag wins), but post-release snapshots would derive from `0.1` again — visibly off-by-one from the released artifact. `"0.0"` keeps both halves consistent.

Verified locally: `core/version` now resolves to `0.0-c88dc93-…-SNAPSHOT` (was `0.1-…-SNAPSHOT`).

After merge: tag `v0.0.1` on `main`, push, and the publish job (proven by the snapshot publish from #86) will drop `io.github.ragb:skunk-sharp-{core,iron,refined,circe,postgis}_3:0.0.1` into GitHub Packages.

Why `0.0.x` and not `0.1.0`: the README still says *"mostly an experiment"* and *"APIs will change"* — `0.0.x` signals that honestly. Issue #17 reserves the `0.1.0`-ish milestone for the API-stability commitment that would also justify the move to Maven Central proper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)