### PR TITLE
Update README and docs to match the current feature surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,219 +39,73 @@ A Scala 3 library for **compile-time checked Postgres queries** on top of [skunk
 
 ## Modules
 
-- `skunk-sharp-core` — the DSL: table/view descriptions, WHERE / ORDER BY / GROUP BY / HAVING / LIMIT / OFFSET, SELECT / INSERT / UPDATE / DELETE, N-way INNER / LEFT / CROSS JOINs with auto-alias, row locking, `ON CONFLICT`, `RETURNING`, aggregates, subqueries (scalar / `IN` / `EXISTS`, correlated or uncorrelated), and the schema validator.
+- `skunk-sharp-core` — the DSL: table/view descriptions, WHERE / ORDER BY / GROUP BY / HAVING / LIMIT / OFFSET, SELECT / INSERT / UPDATE / DELETE, N-way INNER / LEFT / RIGHT / FULL / CROSS / LATERAL JOINs with auto-alias, row locking, `ON CONFLICT` (`DO NOTHING` / `DO UPDATE` / `DO UPDATE … FROM EXCLUDED`), `RETURNING`, `UPDATE … FROM` / `DELETE … USING`, `INSERT … FROM SELECT`, aggregates with `GROUP BY` / `HAVING` (incl. `ROLLUP` / `CUBE` / `GROUPING SETS`), window functions (`OVER (…)`), CTEs (`WITH …`), set operations (`UNION` / `INTERSECT` / `EXCEPT`, with `ALL`), set-returning functions (`generate_series`, `unnest`), subqueries (scalar / `IN` / `EXISTS` / `ANY` / `ALL`, correlated or uncorrelated), in-core Postgres-extension contribs (citext, ltree, hstore, pg_trgm, pgcrypto, fuzzystrmatch), and the schema validator.
 - `skunk-sharp-iron` — optional [Iron](https://iltotore.github.io/iron/) refinement support (e.g. `String :| MaxLength[256]` maps to `varchar(256)`).
+- `skunk-sharp-refined` — optional [refined](https://github.com/fthomas/refined) refinement support.
 - `skunk-sharp-circe` — Postgres `json` / `jsonb` via [skunk-circe](https://typelevel.org/skunk), with parametric `Jsonb[A]` / `Json[A]` tags that round-trip typed case classes.
+- `skunk-sharp-postgis` — [PostGIS](https://postgis.net/) spatial types and `ST_*` operators on top of [skunk-postgis](https://github.com/typelevel/skunk/tree/main/modules/postgis).
 
-## Quick tour
+## Installation
 
-### Describe a table
-
-Two paths, same result:
-
-```scala
-import skunk.sharp.*
-import skunk.sharp.pg.tags.*
-
-// (a) Derive from a case class. Tag types (`Varchar[N]`, `Int2`, `Numeric[P, S]`, …)
-//     pick an unambiguous Postgres codec; bare `String`/`Int` fall back to `text`/`int4`.
-case class User(
-  id:         UUID,
-  email:      Varchar[256],
-  age:        Int,
-  created_at: OffsetDateTime,
-  deleted_at: Option[OffsetDateTime]
-)
-
-val users = Table.of[User]("users")
-  .withPrimary("id")
-  .withUnique("email")
-  .withDefault("created_at")
-
-// (b) Column-by-column — no case class needed; the default row type is a named tuple.
-val users2 = Table.builder("users")
-  .column[UUID]("id", primary = true)
-  .column[Varchar[256]]("email", unique = true)
-  .column[Int]("age")
-  .columnDefaulted[OffsetDateTime]("created_at")
-  .columnOpt[OffsetDateTime]("deleted_at")
-  .build
-```
-
-### Describe a view
+Published to [GitHub Packages](https://maven.pkg.github.com/ragb/skunk-sharp):
 
 ```scala
-case class ActiveUser(id: UUID, email: Varchar[256], age: Int)
-val active = View.of[ActiveUser]("active_users")
-// `active.select` works; `active.insert` / `.update` / `.delete` are compile errors.
+resolvers += "skunk-sharp @ GitHub Packages" at
+  "https://maven.pkg.github.com/ragb/skunk-sharp"
+
+libraryDependencies += "io.github.ragb" %% "skunk-sharp-core" % "<version>"
 ```
 
-### Build queries
+GitHub Packages requires authentication even for public packages, and there are optional modules (`-iron`, `-refined`, `-circe`, `-postgis`). See **[Getting Started](docs/docs/getting-started.md)** for the auth setup and the full dependency list.
 
-Every builder terminates in `.compile`, which returns a `CompiledQuery[R]` or `CompiledCommand`. Execution methods (`.run`, `.unique`, `.option`, `.stream`, `.cursor`) live as extensions on those.
+## A taste
 
 ```scala
 import skunk.sharp.*
 import skunk.sharp.dsl.*
-import skunk.sharp.where.*
+import skunk.sharp.pg.tags.*
 
-// SELECT
+case class User(id: UUID, email: Varchar[256], age: Int, deleted_at: Option[OffsetDateTime])
+
+val users = Table.of[User]("users").withPrimary("id").withUnique("email")
+
 users.select
   .where(u => u.age >= 18 && u.email.like("%@example.com"))
-  .orderBy(u => u.created_at.desc.nullsLast)
+  .orderBy(u => u.age.desc)
   .limit(20)
   .compile
-  .run(session)   // F[List[(id: UUID, email: Varchar[256], age: Int, created_at: OffsetDateTime, deleted_at: Option[OffsetDateTime])]]
-
-// Projections + mapping to a case class
-case class UserSnap(email: String, age: Int)
-users.select(u => (u.email, u.age)).as[UserSnap].compile.stream(session)
-
-// INSERT — subset named tuple; defaulted columns can be omitted
-users.insert((id = UUID.randomUUID(), email = Varchar[256]("a@b"), age = 30, deleted_at = None)).compile.run(session)
-
-// Batch INSERT via any cats `Reducible`
-import cats.data.NonEmptyList
-users.insert.values(NonEmptyList.of(row1, row2, row3)).compile.run(session)
-
-// ON CONFLICT
-users
-  .insert(row)
-  .onConflict(u => u.id)
-  .doUpdateFromExcluded((t, ex) => (t.email := ex.email))
-  .compile.run(session)
-
-// UPDATE — staged: `.set` is required before `.where` / `.updateAll`
-users.update
-  .set(u => (u.email := "new@example.com", u.age := 31))
-  .where(u => u.id === someId)
-  .compile.run(session)
-
-// DELETE — `.compile` without `.where` or `.deleteAll` is a compile error
-users.delete.where(u => u.deleted_at.isNotNull).compile.run(session)
-
-// RETURNING — lifts a command to a CompiledQuery so `.unique` / `.stream` work
-users.delete.where(u => u.id === id).returningAll.compile.unique(session)
+  .run(session)   // F[List[(id: UUID, email: Varchar[256], age: Int, deleted_at: Option[OffsetDateTime])]]
 ```
 
-### JOINs
+Column names, value types, nullability, INSERT completeness, and table-vs-view mutability are all checked by the compiler — a typo or a type mismatch is a compile error, not a runtime surprise.
 
-Auto-alias — the alias defaults to the table's name, so `.alias("u")` is optional:
+## Documentation
 
-```scala
-users
-  .innerJoin(posts).on(r => r.users.id === r.posts.user_id)
-  .select(r => (r.users.email, r.posts.title))
-  .where(r => r.posts.created_at > cutoff)
-  .compile.run(session)
+Full guides live on the **[documentation site](docs/docs/)** — every snippet is type-checked against the live library at build time:
 
-// LEFT JOIN flips right-side nullability at the type level.
-users
-  .leftJoin(posts).on(r => r.users.id === r.posts.user_id)
-  .select(r => (r.users.email, Pg.count(r.posts.id).as("n")))
-  .groupBy(r => r.users.email)
-  .compile.run(session)
-
-// CROSS JOIN — no `.on(...)` required. Same for chaining N sources.
-users.crossJoin(posts).select(r => (r.users.email, r.posts.title)).compile.run(session)
-
-// Chained after a single-source WHERE, and 3+ source joins:
-users.select.where(u => u.age >= 18)
-  .innerJoin(posts).on(r => r.users.id === r.posts.user_id)
-  .leftJoin(tags).on(r => r.posts.id === r.tags.post_id)
-  .select(r => (r.users.email, r.posts.title, r.tags.name))
-  .compile.run(session)
-
-// Explicit aliases still work when the same table appears twice.
-users.alias("u1").innerJoin(users.alias("u2")).on(r => r.u1.id === r.u2.id)
-```
-
-### Subqueries
-
-`TypedExpr`-unified: scalar subqueries, `IN`, and `EXISTS` all take a builder — no inner `.compile` needed, correlation is automatic through lexical scope.
-
-```scala
-// Scalar subquery in projection (correlated — inner WHERE closes over outer `u.id`)
-users.alias("u").select(u =>
-  (u.email, posts.select(_ => Pg.countAll).where(p => p.user_id === u.id).asExpr)
-).compile.run(session)
-
-// IN subquery
-users.select.where(u => u.id.in(posts.select(p => p.user_id))).compile.run(session)
-
-// EXISTS — `Pg.exists` returns a TypedExpr[Boolean] usable directly in WHERE
-users.alias("u")
-  .select(u => u.email)
-  .where(u => u.age >= 18 && Pg.exists(posts.select(_ => lit(1)).where(p => p.user_id === u.id)))
-  .compile.run(session)
-```
-
-### Row locking (tables only)
-
-```scala
-users.select.where(u => u.id === id).forUpdate.skipLocked.compile.option(session)
-// `.forUpdate` on a View is a compile error.
-```
-
-### Compile-time checks
-
-```scala
-users.withPrimary("nope")           // ERROR: unknown column
-u.age === "not an int"              // ERROR: type mismatch
-u.age.isNull                        // ERROR: `isNull` needs a nullable column
-u.deleted_at === None               // ERROR: use .isNull instead
-u.age.like("%")                     // ERROR: LIKE requires a string column
-active.insert(row)                  // ERROR: views are read-only
-users.insert((age = 30))            // ERROR: required column `id` is missing
-users.update.compile                // ERROR: `.set` has not been called
-users.delete.compile                // ERROR: neither `.where` nor `.deleteAll` was called
-```
-
-### Validate the schema at boot
-
-```scala
-import skunk.sharp.validation.*
-
-// Report-only — decide what to do with mismatches:
-SchemaValidator.validate[IO](session, users, active).flatMap { report =>
-  if report.isValid then IO.unit
-  else IO.println(report.mismatches.map(_.pretty).mkString("\n"))
-}
-
-// Fail-fast — raise SchemaValidationException if anything is off:
-SchemaValidator.validateOrRaise[IO](session, users, active)
-```
-
-`Mismatch` cases: `RelationMissing`, `RelationKindMismatch` (table vs view), `ColumnMissing`, `ExtraColumn`, `TypeMismatch` (including parametric drift like declared `varchar(256)` vs DB `varchar(1024)`), `NullabilityMismatch`.
-
-## Extensibility
-
-Everything operators and functions consume/produce is a `TypedExpr[T]`. Third-party modules add operators by shipping `extension` methods — no changes to core. For example, a hypothetical `skunk-sharp-jsonb` could add:
-
-```scala
-opaque type Jsonb = io.circe.Json
-given skunk.Codec[Jsonb] = ...
-given skunk.sharp.pg.PgTypeFor[Jsonb] = ...
-
-extension (e: skunk.sharp.TypedExpr[Jsonb])
-  def ->>(key: String): skunk.sharp.TypedExpr[String] =
-    skunk.sharp.PgOperator.infix[Jsonb, String, String]("->>")(e, skunk.sharp.TypedExpr.lit(key))
-```
-
-Planned companion modules: `skunk-sharp-json` (based on skunk-circe, for `json`/`jsonb`), `skunk-sharp-refined`, `skunk-sharp-ltree`, `skunk-sharp-arrays`, `skunk-sharp-fts`, eventually `skunk-sharp-postgis`.
+- **[Getting started](docs/docs/getting-started.md)** — install, GitHub Packages auth, first query.
+- **[Tables & views](docs/docs/tables.md)** — describing relations, tag types, constraints, the `Table.of` / `Table.builder` paths.
+- **[Select](docs/docs/select.md)** — WHERE, projections, ORDER BY, GROUP BY / HAVING, JOINs (INNER / LEFT / RIGHT / FULL / CROSS / LATERAL), subqueries, window functions, CTEs, set operations, row locking.
+- **[Insert](docs/docs/insert.md)** — single / batch, `ON CONFLICT`, `RETURNING`, `INSERT … FROM SELECT`.
+- **[Update](docs/docs/update.md)** & **[Delete](docs/docs/delete.md)** — staged builders, `… FROM` / `… USING`, `RETURNING`.
+- **[Schema validation](docs/docs/schema-validation.md)** — diff declared tables against `information_schema` at boot, report-only or fail-fast.
+- **[Contrib modules](docs/docs/contrib.md)** — in-core citext, ltree, hstore, pg_trgm, pgcrypto, fuzzystrmatch.
+- **[PostGIS](docs/docs/postgis.md)** — spatial types and `ST_*` operators.
+- **[Extensibility](docs/docs/extensibility.md)** — add your own Postgres types and operators via `extension` methods, no core changes.
 
 ## Roadmap
 
-See [CLAUDE.md](CLAUDE.md) for the design notes.
+The common SELECT / INSERT / UPDATE / DELETE / JOIN surface — including window functions, CTEs,
+set operations (`UNION` / `INTERSECT` / `EXCEPT`), `FULL` / `RIGHT` / `LATERAL` joins, set-returning
+functions, `ON CONFLICT`, `RETURNING`, `UPDATE … FROM` / `DELETE … USING`, the iron / refined / circe /
+postgis modules, and the Laika + mdoc docs site — has shipped. See [CLAUDE.md](CLAUDE.md) for the design
+notes and [the docs site](docs/docs/) for usage.
 
-- Window functions (`OVER (…)`).
-- CTEs (`WITH …`).
-- `UNION` / `INTERSECT` / `EXCEPT`.
-- `FULL` / `RIGHT JOIN` (trivial additions to the existing join kinds).
-- Compile-time `GROUP BY` coverage check.
-- Companion modules for JSON (`skunk-sharp-json`, based on skunk-circe), ltree, arrays, full-text search, and PostGIS.
-- Move more of the SQL assembly into macros so only user-supplied parameters flow at runtime.
-- Laika + mdoc docs site.
+Open items (no scheduled date — picked up when motivation arrives):
+
+- Compile-time enforcement that all bare SELECT columns appear in `GROUP BY` (currently caught at runtime by Postgres).
+- Companion modules: `skunk-sharp-fts` (full-text search), arrays, broader PostGIS coverage.
+- Owner-macro that collapses a structurally-static query to a single interned `Fragment[Args]` (research item — see CLAUDE.md).
 
 ## Development
 

--- a/docs/docs/extensibility.md
+++ b/docs/docs/extensibility.md
@@ -97,7 +97,8 @@ val q = users.select(u => lower(u.email))
 
 ## Writing a companion module
 
-The pattern for a hypothetical `skunk-sharp-jsonb` module:
+The pattern, illustrated with a jsonb module (the shipped `skunk-sharp-circe` module
+is built exactly like this):
 
 ```scala
 // 1. Opaque type + codec + PgTypeFor (with extension hint if needed)
@@ -140,4 +141,5 @@ Set(...)` for `SchemaValidator.validate`.
 | `skunk-sharp-iron` | [Iron](https://iltotore.github.io/iron/) refinement bridges |
 | `skunk-sharp-refined` | [Refined](https://github.com/fthomas/refined) refinement bridges |
 | `skunk-sharp-circe` | `json` / `jsonb` codecs via skunk-circe |
+| `skunk-sharp-postgis` | PostGIS spatial types and `ST_*` operators — see [PostGIS](postgis.md) |
 | `skunk.sharp.contrib.*` | In-core contribs: citext, ltree, hstore, pg_trgm, pgcrypto, fuzzystrmatch — see [Contrib modules](contrib.md) |


### PR DESCRIPTION
The top-level `README.md` described an old feature set and duplicated the docs site. This brings it current and points to the docs instead of repeating them.

## README
- **Modules** — add `skunk-sharp-refined` and `skunk-sharp-postgis` (both publish now); expand the core bullet to the real surface: RIGHT/FULL/LATERAL joins, CTEs, window functions, set operations, set-returning functions, `UPDATE … FROM` / `DELETE … USING`, `ON CONFLICT DO UPDATE … FROM EXCLUDED`, ANY/ALL subqueries, in-core contribs.
- Replace the **Quick tour** and standalone **Extensibility** section (each a near-copy of a docs page) with one short "A taste" example plus a **Documentation** index that links every docs page.
- Trim **Installation** to the resolver + core dep, pointing to Getting Started for auth and the optional-module list.
- **Roadmap** — drop shipped items (window fns, CTEs, set ops, FULL/RIGHT join, docs site, the modules); keep the genuinely-open items.

## docs/docs/extensibility.md
- Add the `skunk-sharp-postgis` row to the built-in-modules table.
- Reword the "hypothetical jsonb" example so it doesn't imply jsonb is unavailable (it ships via `skunk-sharp-circe`).

## Verification
`sbt docs/mdoc` passes with 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)