### PR TITLE
Publish unsigned jars to GitHub Packages (gpgWarnOnFailure)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -36,6 +36,10 @@ ThisBuild / githubWorkflowPublish := Seq(
 )
 // GitHub Packages doesn't take signed artifacts — drop the PGP "import signing key" preamble.
 ThisBuild / githubWorkflowPublishPreamble := Seq.empty
+// sbt-typelevel still wires GPG signing into the `publish` task, but CI has no signing key (and
+// GitHub Packages neither needs nor wants signatures). Make a missing key a warning instead of a
+// fatal error so `publish` uploads unsigned jars rather than failing on `gpg: No secret key`.
+ThisBuild / gpgWarnOnFailure := true
 // This repo has GitHub's Dependency Graph feature disabled, so the submission job 404s. Drop it.
 ThisBuild / tlCiDependencyGraphJob := false
 


### PR DESCRIPTION
The `v0.0.1` publish failed with:

```
gpg: signing failed: No secret key
java.lang.RuntimeException: GPG reported an error. Artifacts won't be signed.
```

sbt-typelevel still wires GPG signing into the `publish` task, but CI has no signing key — and GitHub Packages neither needs nor wants signatures (the build already drops the import-signing-key preamble).

Set `ThisBuild / gpgWarnOnFailure := true` so a missing key is a warning rather than a fatal error, and `publish` uploads unsigned jars. Verified the key resolves to `true` across all projects locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)