### PR TITLE
Update dependencies, sbt, and enable Scala 3.8.4

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,6 +14,8 @@ ThisBuild / developers          := List(
   tlGitHubDev("ragb", "Rui Batista")
 )
 
+// Pinned to 3.8.3: 3.8.4 emits [E184] "match type reduction failed" warnings for the DSL's
+// single-TypedExpr projection machinery (ExprOutputs), which -Werror turns fatal. Revisit on 3.9.
 ThisBuild / scalaVersion := "3.8.3"
 
 ThisBuild / tlJdkRelease    := Some(17)
@@ -72,17 +74,17 @@ val skunkV           = "1.0.0"
 val skunkCirceV      = "1.0.0"
 val circeV           = "0.14.15"
 val catsEffectV      = "3.7.0"
-val munitV           = "1.2.4"
-val munitCatsEffectV = "2.1.0"
-val ironV            = "3.0.2"
+val munitV           = "1.3.2"
+val munitCatsEffectV = "2.2.0"
+val ironV            = "3.3.1"
 val refinedV         = "0.11.3"
 val testcontainersV  = "0.44.1"
-val dumboV           = "0.9.0"
-val otel4sV          = "0.16.0"
-val tapirV           = "1.11.9"
-val http4sV          = "0.23.30"
-val cirisV           = "3.6.0"
-val ducktapeV        = "0.2.12"
+val dumboV           = "0.10.1"
+val otel4sV          = "0.16.0" // pinned: skunk 1.0.0 depends on otel4s 0.16.x; 1.0.0 splits the modules (binary-incompatible)
+val tapirV           = "1.13.19"
+val http4sV          = "0.23.34"
+val cirisV           = "3.15.0"
+val ducktapeV        = "0.2.13"
 
 lazy val root = tlCrossRootProject.aggregate(core, iron, refined, circe, postgis, tests, example, docs)
 
@@ -172,7 +174,7 @@ lazy val example = project
       "com.dimafeng"                  %% "testcontainers-scala-munit"      % testcontainersV  % Test,
       "com.dimafeng"                  %% "testcontainers-scala-postgresql" % testcontainersV  % Test,
       "com.softwaremill.sttp.tapir"   %% "tapir-sttp-client"               % tapirV           % Test,
-      "com.softwaremill.sttp.client3" %% "http4s-backend"                  % "3.9.8"          % Test,
+      "com.softwaremill.sttp.client3" %% "http4s-backend"                  % "3.11.0"         % Test,
       "io.circe"                      %% "circe-parser"                    % circeV           % Test
     )
   )

--- a/build.sbt
+++ b/build.sbt
@@ -78,7 +78,6 @@ val ironV            = "3.3.1"
 val refinedV         = "0.11.3"
 val testcontainersV  = "0.44.1"
 val dumboV           = "0.10.1"
-val otel4sV          = "0.16.0" // pinned: skunk 1.0.0 depends on otel4s 0.16.x; 1.0.0 splits the modules (binary-incompatible)
 val tapirV           = "1.13.19"
 val http4sV          = "0.23.34"
 val cirisV           = "3.15.0"
@@ -166,7 +165,6 @@ lazy val example = project
       "is.cir"                        %% "ciris"                           % cirisV,
       "io.github.arainko"             %% "ducktape"                        % ducktapeV,
       "dev.rolang"                    %% "dumbo"                           % dumboV,
-      "org.typelevel"                 %% "otel4s-core"                     % otel4sV,
       "org.scalameta"                 %% "munit"                           % munitV           % Test,
       "org.typelevel"                 %% "munit-cats-effect"               % munitCatsEffectV % Test,
       "com.dimafeng"                  %% "testcontainers-scala-munit"      % testcontainersV  % Test,
@@ -199,7 +197,6 @@ lazy val tests = project
       "org.typelevel" %% "munit-cats-effect"               % munitCatsEffectV % Test,
       "com.dimafeng"  %% "testcontainers-scala-munit"      % testcontainersV  % Test,
       "com.dimafeng"  %% "testcontainers-scala-postgresql" % testcontainersV  % Test,
-      "dev.rolang"    %% "dumbo"                           % dumboV           % Test,
-      "org.typelevel" %% "otel4s-core"                     % otel4sV          % Test
+      "dev.rolang"    %% "dumbo"                           % dumboV           % Test
     )
   )

--- a/build.sbt
+++ b/build.sbt
@@ -14,9 +14,7 @@ ThisBuild / developers          := List(
   tlGitHubDev("ragb", "Rui Batista")
 )
 
-// Pinned to 3.8.3: 3.8.4 emits [E184] "match type reduction failed" warnings for the DSL's
-// single-TypedExpr projection machinery (ExprOutputs), which -Werror turns fatal. Revisit on 3.9.
-ThisBuild / scalaVersion := "3.8.3"
+ThisBuild / scalaVersion := "3.8.4"
 
 ThisBuild / tlJdkRelease    := Some(17)
 ThisBuild / tlFatalWarnings := true

--- a/modules/core/src/main/scala/skunk/sharp/dsl/Select.scala
+++ b/modules/core/src/main/scala/skunk/sharp/dsl/Select.scala
@@ -389,10 +389,16 @@ final class SelectBuilder[Ss <: Tuple, Groups <: Tuple, WArgs, HArgs] @scala.ann
     }
   }
 
-  /** Same as [[select]]; supports `users.select(u => …)` syntax via apply. */
-  transparent inline def apply[X](
-    @scala.annotation.unused inline f: SelectView[Ss] => X
-  ) = select[X](f)
+  /**
+   * Same as [[select]]; supports `users.select(u => …)` syntax via apply.
+   *
+   * `f` is deliberately a plain (non-`inline`) parameter, unlike [[select]]'s. As a pure forwarder this method only
+   * passes `f` to `select`; with an `inline` `f` here, Scala 3.8.4 spuriously reports it as an "unused local
+   * definition" (at this definition site `X` is abstract, so `select`'s `erasedValue[X]` dispatch can't reduce and the
+   * inlined `f(v)` uses elaborate away). A concrete `f` is a use the unused-checker sees; `select` still inlines and
+   * the `transparent` result type is unaffected.
+   */
+  transparent inline def apply[X](f: SelectView[Ss] => X) = select[X](f)
 
   /**
    * Whole-row `.compile` — only on single-source builders. Threads `CArgs` (CTE preamble), `SArgs` (from any inner
@@ -1583,9 +1589,15 @@ final case class Locking(mode: LockMode, waitPolicy: WaitPolicy = WaitPolicy.Wai
   def sql: String = mode.sql + waitPolicy.sql
 }
 
+// The trailing `case _ => EmptyTuple` is only reachable for the effectively-uninhabited `<single-expr> & Tuple`
+// intersections that the `transparent inline` projection dispatch (see `select`) forms in its *dead* branches: a
+// single-`TypedExpr` projection elaborated against the plain-tuple branch yields `TypedExpr[…] & Tuple`, which is
+// disjoint from both real cases. Without the catch-all, Scala 3.8.4 emits a fatal `[E184]` "matches none of the
+// cases" warning for those dead elaborations. Real projections are genuine tuples and never reach it.
 type ExprOutputs[T <: Tuple] <: Tuple = T match {
   case EmptyTuple              => EmptyTuple
   case TypedExpr[t, ?] *: tail => t *: ExprOutputs[tail]
+  case _                       => EmptyTuple
 }
 
 /**
@@ -1596,6 +1608,7 @@ type ExprOutputs[T <: Tuple] <: Tuple = T match {
 type CollectArgs[T <: Tuple] <: Tuple = T match {
   case EmptyTuple              => EmptyTuple
   case TypedExpr[?, a] *: tail => a *: CollectArgs[tail]
+  case _                       => EmptyTuple // dead-branch `<single-expr> & Tuple` intersections — see [[ExprOutputs]]
 }
 
 type ProjResult[X] = X match {

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.12.9
+sbt.version=1.12.11


### PR DESCRIPTION
## Summary

Bumps libraries flagged by `dependencyUpdates`, sbt, and the Scala compiler — with the 3.8.4 `-Werror` regressions fixed at the source, and otel4s resolved cleanly (no pin).

| Library | From | To |
|---|---|---|
| scala3 | 3.8.3 | 3.8.4 |
| munit | 1.2.4 | 1.3.2 |
| munit-cats-effect | 2.1.0 | 2.2.0 |
| iron | 3.0.2 | 3.3.1 |
| dumbo | 0.9.0 | 0.10.1 |
| tapir | 1.11.9 | 1.13.19 |
| http4s-ember-server | 0.23.30 | 0.23.34 |
| ciris | 3.6.0 | 3.15.0 |
| ducktape | 0.2.12 | 0.2.13 |
| sttp http4s-backend | 3.9.8 | 3.11.0 |
| sbt | 1.12.9 | 1.12.11 |

## Scala 3.8.4 fixes

3.8.4 turns two new lints fatal under `-Werror` for the projection DSL. Both are fixed in source, not suppressed:

1. **`[E184]` "match type reduction failed".** The `transparent inline` SELECT projection dispatch type-checks every `erasedValue` branch against the same `X`. For a single-`TypedExpr` projection, the dead plain-tuple/named branches form `ExprOutputs[<expr> & Tuple]` — an uninhabited intersection disjoint from both real cases, so it reduces to nothing and 3.8.4 warns. Fix: a `case _ => EmptyTuple` catch-all on `ExprOutputs` and its dual `CollectArgs`, reachable only for those dead-branch intersections (real projections are genuine tuples).
2. **"unused local definition" on `SelectBuilder.apply`.** As a pure forwarder to `select`, an `inline` `f` has its uses elaborated away at the abstract-`X` definition site. Fix: make `f` a plain parameter — a use the checker sees; `select` still inlines and the `transparent` result type is unchanged.

## otel4s

`otel4s-core` was declared directly in `tests`/`example` only for skunk's no-op `Tracer`/`Meter` givens — but skunk-core pulls the full otel4s module set transitively, so the direct dep (and its pin) was redundant. It was also the only thing blocking the otel4s 1.0.0 bump (skunk 1.0.0 pins 0.16.x; forcing 1.0.0 splits the modules). Dropped it entirely; otel4s now rides along transitively at skunk's version — nothing flagged, no conflict, imports unchanged.

## Verification

- `Test/compile` clean under `-Werror` and `SBT_TPOLECAT_CI=1`
- core 550 / iron 4 / circe 10 / refined 5 / tests 183 / example 36 — all pass
- `docs/mdoc`: 0 errors
- CompileBench: still **0 dynamic AFs per compile** across all 5 scenarios (invariant preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)